### PR TITLE
feat(workers): decouple comments from posts; use provided postId as t…

### DIFF
--- a/workers/migrations/0003_comments_drop_fk.sql
+++ b/workers/migrations/0003_comments_drop_fk.sql
@@ -1,0 +1,30 @@
+-- Drop foreign key on comments.post_id by recreating table without FK
+-- This migration preserves data and indexes
+
+PRAGMA foreign_keys = OFF;
+
+-- Create new table without FK constraint
+CREATE TABLE IF NOT EXISTS comments_new (
+  id TEXT PRIMARY KEY,
+  post_id TEXT NOT NULL,
+  author TEXT NOT NULL,
+  email TEXT,
+  content TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'visible' CHECK(status IN ('visible', 'hidden', 'pending')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Copy data from old table
+INSERT INTO comments_new (id, post_id, author, email, content, status, created_at, updated_at)
+SELECT id, post_id, author, email, content, status, created_at, updated_at FROM comments;
+
+-- Replace old table
+DROP TABLE comments;
+ALTER TABLE comments_new RENAME TO comments;
+
+-- Recreate indexes
+CREATE INDEX IF NOT EXISTS idx_comments_post_id ON comments(post_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_comments_status ON comments(status);
+
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
…hread key\n\n- Remove posts existence check in API\n- Normalize and persist postId directly in comments\n- Add D1 migration to drop FK on comments.post_id while preserving data and indexes\n\nWhy: Frontend uses year/slug thread key for static posts not stored in D1; FK blocked comment creation.\nImpact: Enables comment creation and retrieval by postId without seeding posts.