### PR TITLE
feat(ai-memo): Catalyst UX, history overlay, and markdown preview\n\n…

### DIFF
--- a/frontend/public/ai-memo/ai-memo.css
+++ b/frontend/public/ai-memo/ai-memo.css
@@ -25,13 +25,20 @@
   justify-content: center;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  opacity: 0.5;
+  transform: scale(0.98);
+  transition: opacity 0.2s ease, transform 0.15s ease, filter 0.15s ease;
 }
 /* Safe-area aware bottom (overrides if supported) */
 .launcher { bottom: 96px; }
 .launcher { bottom: calc(96px + env(safe-area-inset-bottom)); }
 .launcher:hover {
   filter: brightness(1.1);
+  opacity: 1;
+  transform: scale(1);
 }
+.launcher.history { bottom: 152px; }
+.launcher.history { bottom: calc(152px + env(safe-area-inset-bottom)); }
 
 /* Panel */
 .panel {
@@ -137,8 +144,17 @@
   .preview-md blockquote { margin: 8px 0; padding: 6px 10px; border-left: 3px solid #d1d5db; background: #f9fafb; border-radius: 6px; }
   .preview-md img { max-width: 100%; height: auto; display: block; margin: 8px 0; border-radius: 8px; border: 1px solid #e5e7eb; }
   .preview-md code { background: rgba(0,0,0,0.05); padding: 2px 4px; border-radius: 4px; }
-  .preview-md pre { background: #0b1020; color: #e5e7eb; padding: 10px; border-radius: 8px; overflow: auto; }
- 
+  .preview-md pre { background: #0b1020; color: #e5e7eb; padding: 10px; border-radius: 8px; overflow: auto; counter-reset: line; }
+  .preview-md pre code { display: grid; grid-auto-rows: min-content; gap: 0; }
+  .preview-md pre code .line { display: block; white-space: pre; }
+  .preview-md pre code .line::before { counter-increment: line; content: counter(line); display: inline-block; width: 2.5em; margin-right: 12px; color: rgba(255,255,255,0.4); text-align: right; }
+  .preview-md pre code .kw { color: #93c5fd; }
+  .preview-md pre code .str { color: #86efac; }
+  .preview-md pre code .num { color: #fca5a5; }
+  .preview-md pre code .cm { color: #9ca3af; font-style: italic; }
+  .preview-md pre code .fn { color: #fcd34d; }
+
+  :host(.dark) .preview-md pre { background: #050a1a; color: #d1d5db; }
   :host(.dark) .preview-md { background: #0f172a; border-color: rgba(255,255,255,0.12); }
   :host(.dark) .preview-md a { color: #93c5fd; }
   :host(.dark) .preview-md blockquote { background: rgba(255,255,255,0.05); border-left-color: rgba(255,255,255,0.2); }
@@ -244,18 +260,39 @@
   cursor: not-allowed;
 }
 
-.footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
-  border-top: 1px solid #e5e7eb;
-  background: rgba(249, 250, 251, 0.7);
-  backdrop-filter: blur(6px);
-  padding-bottom: calc(10px + env(safe-area-inset-bottom));
-}
-.small {
+ .footer {
+   display: flex;
+   justify-content: space-between;
+   align-items: center;
+   gap: 8px;
+   padding: 10px 12px;
+   border-top: 1px solid #e5e7eb;
+   background: rgba(249, 250, 251, 0.7);
+   backdrop-filter: blur(6px);
+   padding-bottom: calc(10px + env(safe-area-inset-bottom));
+ }
+ /* Catalyst inline bar uses row layout; ensure input flexes */
+ #catalystBox { align-items: stretch; }
+  #catalystBox .input { flex: 1; }
+  /* Busy state styles for Catalyst */
+  #catalystInput:disabled { cursor: progress; opacity: 0.7; }
+  #catalystRun:disabled { position: relative; cursor: progress; }
+  #catalystRun:disabled::after {
+    content: '';
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    width: 12px;
+    height: 12px;
+    margin-top: -6px;
+    border: 2px solid rgba(255,255,255,0.7);
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: ai-memo-spin 0.8s linear infinite;
+  }
+  @keyframes ai-memo-spin { to { transform: rotate(360deg); } }
+  :host(.dark) #catalystInput:disabled { opacity: 0.7; }
+  .small {
   font-size: 11px;
   color: #6b7280;
 }
@@ -315,4 +352,56 @@
   }
   .textarea { resize: vertical; }
   .split { grid-template-columns: 1fr; }
+}
+
+/* History overlay */
+.history-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  background: rgba(2, 6, 23, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+}
+.history-overlay .history-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(255,255,255,0.8);
+  border-bottom: 1px solid #e5e7eb;
+}
+:host(.dark) .history-overlay .history-toolbar {
+  background: rgba(2,6,23,0.8);
+  border-bottom-color: rgba(255,255,255,0.12);
+  color: #e5e7eb;
+}
+.history-overlay canvas {
+  flex: 1;
+  width: 100%;
+  height: calc(100% - 48px);
+  display: block;
+  cursor: grab;
+}
+.history-overlay canvas.grabbing { cursor: grabbing; }
+.history-tooltip {
+  position: fixed;
+  z-index: 2147483647;
+  background: #111827;
+  color: #fff;
+  font: 12px/1.3 ui-sans-serif, system-ui;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.12);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.25);
+  max-width: 260px;
+  pointer-events: none;
+}
+:host(.dark) .history-tooltip {
+  background: #0b1020;
+  color: #e5e7eb;
+  border-color: rgba(255,255,255,0.12);
 }


### PR DESCRIPTION
…- Catalyst: 160-char prompt cap, disable input/run during generation, status updates, result appended with headings + timestamp, inline bar closes on success, event logs for open/close/cancel/run\n- History: full-screen overlay with zoom/pan (wheel/drag), rAF-throttled redraw, center-on-click, double-click opens post, grouped event labels with counts, tooltip with Count and post info, export/import/reset, storage capped at 500 events\n- Markdown: markdownToHtml with basic sanitization; enhanceCodeBlocks with line numbers and simple highlighting for JS/TS, Python, JSON, Bash; debounced preview rendering\n- UX polish: fullscreen toggle, toolbar helpers, download menu, font size persistence, busy styles for Catalyst controls