### PR TITLE
feat(routes): centralize route mounting via registry pattern with data ownership headers

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto";
 import express from "express";
 import helmet from "helmet";
 import cors from "cors";
@@ -18,31 +17,13 @@ import {
   isPgConfigured,
 } from "./repositories/analytics.repository.js";
 import { closeRedis } from "./lib/redis-client.js";
-
-import aiRouter from "./routes/ai.js";
-import commentsRouter from "./routes/comments.js";
-import analyticsRouter from "./routes/analytics.js";
-import chatRouter, { initChatWebSocket } from "./routes/chat.js";
-import translateRouter from "./routes/translate.js";
-import userContentRouter from "./routes/userContent.js";
-import ogRouter from "./routes/og.js";
-import adminRouter from "./routes/admin.js";
-import postsRouter from "./routes/posts.js";
-import imagesRouter from "./routes/images.js";
-import authRouter from "./routes/auth.js";
-import ragRouter from "./routes/rag.js";
-import memoriesRouter from "./routes/memories.js";
-import memosRouter from "./routes/memos.js";
-import userRouter from "./routes/user.js";
-import searchRouter from "./routes/search.js";
-import configRouter from "./routes/config.js";
-import workersRouter from "./routes/workers.js";
-import agentRouter from "./routes/agent.js";
-import notificationsRouter from "./routes/notifications.js";
-import debateRouter from "./routes/debate.js";
 import metricsRouter from "./routes/metrics.js";
-import adminLogsRouter from "./routes/adminLogs.js";
-import executeRouter from "./routes/execute.js";
+import { initChatWebSocket } from "./routes/chat.js";
+import {
+  PUBLIC_ROUTE_REGISTRY,
+  PROTECTED_ROUTE_REGISTRY,
+  mountRouteRegistry,
+} from "./routes/registry.js";
 import { errorHandler, notFoundHandler } from "./middleware/errorHandler.js";
 
 async function startServer() {
@@ -96,6 +77,7 @@ async function startServer() {
   app.get("/api/v1/healthz", (req, res) => {
     res.json({ ok: true, env: config.appEnv, uptime: process.uptime() });
   });
+
   app.get(
     "/api/v1/public/config",
     httpCache({ ttl: 300, prefix: "config" }),
@@ -103,9 +85,11 @@ async function startServer() {
       res.json({ ok: true, data: publicRuntimeConfig() });
     },
   );
+
   app.use("/metrics", metricsRouter);
 
-  app.use("/api/v1/notifications", notificationsRouter);
+  mountRouteRegistry(app, PUBLIC_ROUTE_REGISTRY);
+
   app.use(requireBackendKey);
 
   app.use(express.json({ limit: "1mb" }));
@@ -119,32 +103,9 @@ async function startServer() {
   });
   app.use(limiter);
 
-  app.use("/api/v1/ai", aiRouter);
-  app.use("/api/v1/comments", commentsRouter);
-  app.use("/api/v1/analytics", analyticsRouter);
-  app.use("/api/v1/chat", chatRouter);
-  app.use("/api/v1", translateRouter);
-  app.use("/api/v1/memos", memosRouter);
-  app.use("/api/v1/user-content", userContentRouter);
-  app.use("/api/v1/og", ogRouter);
-  app.use("/api/v1/admin", adminRouter);
-  app.use("/api/v1/posts", postsRouter);
-  app.use("/api/v1/images", imagesRouter);
-  app.use("/api/v1/auth", authRouter);
-  app.use("/api/v1/rag", ragRouter);
-  app.use("/api/v1/memories", memoriesRouter);
-  app.use("/api/v1/user", userRouter);
-  app.use("/api/v1/search", searchRouter);
-  app.use("/api/v1/admin/config", configRouter);
-  app.use("/api/v1/admin/workers", workersRouter);
-  app.use("/api/v1/admin", adminLogsRouter);
-  app.use("/api/v1/agent", agentRouter);
-
-  app.use("/api/v1/debate", debateRouter);
-  app.use("/api/v1/execute", executeRouter);
+  mountRouteRegistry(app, PROTECTED_ROUTE_REGISTRY);
 
   app.use(notFoundHandler);
-
   app.use(errorHandler);
 
   const port = config.port;
@@ -157,11 +118,13 @@ async function startServer() {
           ai: config.features.aiEnabled,
           rag: config.features.ragEnabled,
           comments: config.features.commentsEnabled,
+          terminal: config.features.terminalEnabled,
         },
       },
       "features",
     );
   });
+
   initChatWebSocket(server);
 
   let shuttingDown = false;
@@ -193,6 +156,7 @@ async function startServer() {
   process.on("unhandledRejection", (reason) => {
     logger.error({ err: reason }, "Unhandled promise rejection");
   });
+
   process.on("uncaughtException", (err) => {
     logger.error({ err }, "Uncaught exception — shutting down");
     gracefulShutdown("uncaughtException");

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -10,9 +10,17 @@ import {
 } from '../repositories/analytics.repository.js';
 import { httpCache, invalidateCacheByPrefix } from '../middleware/httpCache.js';
 import { createLogger } from '../lib/logger.js';
+import { buildDataOwnershipHeaders } from '../../../shared/src/contracts/data-ownership.js';
 
 const router = Router();
 const logger = createLogger('analytics');
+
+function applyDataOwnership(res, ownershipId) {
+  const headers = buildDataOwnershipHeaders(ownershipId);
+  for (const [key, value] of Object.entries(headers)) {
+    res.setHeader(key, value);
+  }
+}
 
 const requirePg = (req, res, next) => {
   if (!isPgConfigured()) {
@@ -30,6 +38,7 @@ const requireD1 = (req, res, next) => {
 
 router.post('/view', requirePg, async (req, res, next) => {
   try {
+    applyDataOwnership(res, 'analytics.post_stats');
     const { year, slug } = req.body || {};
     if (!year || !slug) {
       return res.status(400).json({ ok: false, error: 'year and slug are required' });
@@ -54,6 +63,7 @@ router.post('/view', requirePg, async (req, res, next) => {
 
 router.get('/stats/:year/:slug', requirePg, async (req, res, next) => {
   try {
+    applyDataOwnership(res, 'analytics.post_stats');
     const { year, slug } = req.params;
     const stats = await getPostStats(slug, year);
     return res.json({
@@ -70,6 +80,7 @@ router.get('/all-stats', requirePg, getAllPostStatsHandler);
 
 export async function getAllPostStatsHandler(req, res, next) {
   try {
+    applyDataOwnership(res, 'analytics.post_stats');
     const limit = req.query.limit ? parseInt(req.query.limit) : undefined;
     const offset = parseInt(req.query.offset) || 0;
     const orderBy = req.query.orderBy || 'total_views';
@@ -82,6 +93,7 @@ export async function getAllPostStatsHandler(req, res, next) {
 
 router.get('/editor-picks', requireD1, httpCache({ ttl: 600, prefix: 'analytics' }), async (req, res, next) => {
   try {
+    applyDataOwnership(res, 'analytics.editor_picks');
     const limit = parseInt(req.query.limit) || 3;
     const picks = await queryAll(
       `SELECT * FROM editor_picks
@@ -100,6 +112,7 @@ router.get('/editor-picks', requireD1, httpCache({ ttl: 600, prefix: 'analytics'
 
 router.get('/trending', requirePg, httpCache({ ttl: 300, prefix: 'analytics' }), async (req, res, next) => {
   try {
+    applyDataOwnership(res, 'analytics.post_stats');
     const limit = parseInt(req.query.limit) || 10;
     const days = parseInt(req.query.days) || 7;
     const trending = await getTrendingPosts({ days, limit });
@@ -112,6 +125,7 @@ router.get('/trending', requirePg, httpCache({ ttl: 300, prefix: 'analytics' }),
 
 router.post('/refresh-stats', requirePg, async (req, res, next) => {
   try {
+    applyDataOwnership(res, 'analytics.post_stats');
     const refreshed = await refreshPeriodicStats();
     await invalidateCacheByPrefix('analytics');
     return res.json({ ok: true, data: { refreshed } });

--- a/backend/src/routes/registry.js
+++ b/backend/src/routes/registry.js
@@ -1,0 +1,76 @@
+import { buildRouteBoundaryHeaders } from '../../../shared/src/contracts/service-boundaries.js';
+
+import aiRouter from './ai.js';
+import commentsRouter from './comments.js';
+import analyticsRouter from './analytics.js';
+import chatRouter from './chat.js';
+import translateRouter from './translate.js';
+import userContentRouter from './userContent.js';
+import ogRouter from './og.js';
+import adminRouter from './admin.js';
+import postsRouter from './posts.js';
+import imagesRouter from './images.js';
+import authRouter from './auth.js';
+import ragRouter from './rag.js';
+import memoriesRouter from './memories.js';
+import memosRouter from './memos.js';
+import userRouter from './user.js';
+import searchRouter from './search.js';
+import configRouter from './config.js';
+import workersRouter from './workers.js';
+import agentRouter from './agent.js';
+import notificationsRouter from './notifications.js';
+import debateRouter from './debate.js';
+import adminLogsRouter from './adminLogs.js';
+import executeRouter from './execute.js';
+
+export const PUBLIC_ROUTE_REGISTRY = [
+  { boundaryId: 'notifications', basePath: '/api/v1/notifications', router: notificationsRouter },
+];
+
+export const PROTECTED_ROUTE_REGISTRY = [
+  { boundaryId: 'ai', basePath: '/api/v1/ai', router: aiRouter },
+  { boundaryId: 'comments', basePath: '/api/v1/comments', router: commentsRouter },
+  { boundaryId: 'analytics', basePath: '/api/v1/analytics', router: analyticsRouter },
+  { boundaryId: 'chat', basePath: '/api/v1/chat', router: chatRouter },
+  { boundaryId: 'translate', basePath: '/api/v1', router: translateRouter },
+  { boundaryId: 'memos', basePath: '/api/v1/memos', router: memosRouter },
+  { boundaryId: 'user-content', basePath: '/api/v1/user-content', router: userContentRouter },
+  { boundaryId: 'og', basePath: '/api/v1/og', router: ogRouter },
+  { boundaryId: 'admin', basePath: '/api/v1/admin', router: adminRouter },
+  { boundaryId: 'posts', basePath: '/api/v1/posts', router: postsRouter },
+  { boundaryId: 'images', basePath: '/api/v1/images', router: imagesRouter },
+  { boundaryId: 'auth', basePath: '/api/v1/auth', router: authRouter },
+  { boundaryId: 'rag', basePath: '/api/v1/rag', router: ragRouter },
+  { boundaryId: 'memories', basePath: '/api/v1/memories', router: memoriesRouter },
+  { boundaryId: 'user', basePath: '/api/v1/user', router: userRouter },
+  { boundaryId: 'search', basePath: '/api/v1/search', router: searchRouter },
+  { boundaryId: 'admin-config', basePath: '/api/v1/admin/config', router: configRouter },
+  { boundaryId: 'admin-workers', basePath: '/api/v1/admin/workers', router: workersRouter },
+  { boundaryId: 'admin', basePath: '/api/v1/admin', router: adminLogsRouter },
+  { boundaryId: 'agent', basePath: '/api/v1/agent', router: agentRouter },
+  { boundaryId: 'debate', basePath: '/api/v1/debate', router: debateRouter },
+  { boundaryId: 'execute', basePath: '/api/v1/execute', router: executeRouter },
+];
+
+export function attachBoundaryHeaders(boundaryId, responder = 'backend') {
+  return (req, res, next) => {
+    const headers = buildRouteBoundaryHeaders(boundaryId, {
+      responder,
+      edgeMode: 'origin-bypass',
+      originMode: 'native',
+    });
+
+    for (const [key, value] of Object.entries(headers)) {
+      res.setHeader(key, value);
+    }
+
+    next();
+  };
+}
+
+export function mountRouteRegistry(app, registry, responder = 'backend') {
+  for (const entry of registry) {
+    app.use(entry.basePath, attachBoundaryHeaders(entry.boundaryId, responder), entry.router);
+  }
+}

--- a/backend/src/routes/workers.js
+++ b/backend/src/routes/workers.js
@@ -4,37 +4,16 @@ import requireAdmin from '../middleware/adminAuth.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { WORKER_DEPLOYMENTS } from '../../../shared/src/contracts/workers.js';
 
 const router = Router();
 
 const WORKERS_ROOT = path.join(config.content.repoRoot, 'workers');
 
-const WORKERS_CONFIG = [
-  {
-    id: 'api-gateway',
-    name: 'Blog API Gateway',
-    description: '메인 블로그 API Worker (blog-api-gateway)',
-    path: 'api-gateway',
-    wranglerPath: 'api-gateway/wrangler.toml',
-    hasProduction: true,
-  },
-  {
-    id: 'r2-gateway',
-    name: 'R2 Gateway',
-    description: 'R2 스토리지 게이트웨이',
-    path: 'r2-gateway',
-    wranglerPath: 'r2-gateway/wrangler.toml',
-    hasProduction: true,
-  },
-  {
-    id: 'terminal-gateway',
-    name: 'Terminal Gateway',
-    description: '터미널 WebSocket 게이트웨이',
-    path: 'terminal-gateway',
-    wranglerPath: 'terminal-gateway/wrangler.toml',
-    hasProduction: true,
-  },
-];
+
+const WORKERS_CONFIG = WORKER_DEPLOYMENTS.map((worker) => ({
+  ...worker,
+}));
 
 const KNOWN_SECRETS = [
   { key: 'JWT_SECRET', description: 'JWT 서명 키', workers: ['api-gateway', 'terminal-gateway'] },
@@ -47,6 +26,7 @@ const KNOWN_SECRETS = [
   { key: 'BACKEND_KEY', description: 'Workers → Backend 인증 키 (X-Backend-Key)', workers: ['api-gateway', 'terminal-gateway'] },
   { key: 'RESEND_API_KEY', description: 'Resend.com API 키', workers: ['api-gateway'] },
   { key: 'INTERNAL_KEY', description: 'API GW → R2 GW 인증 키 (X-Internal-Key)', workers: ['api-gateway', 'r2-gateway'] },
+  { key: 'TERMINAL_SESSION_SECRET', description: 'Terminal connect token signing key', workers: ['terminal-gateway'] },
 ];
 
 router.get('/list', requireAdmin, async (req, res) => {

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -3,11 +3,8 @@
  *
  * 통합된 블로그 API Gateway:
  * - 모든 /api/v1/* 라우트 처리 (D1, R2, KV 기반)
- * - 백엔드 서버로 프록시 (fallback 또는 특정 경로)
+ * - backend-owned / proxy-only 경로만 origin 으로 프록시
  * - Cron 트리거 지원
- *
- * Architecture:
- *   Client → Cloudflare Workers (api.nodove.com) → Internal Routes OR → Backend Server
  */
 
 import { Hono } from 'hono';
@@ -19,51 +16,20 @@ import { errorHandler } from './middleware/error';
 import { success } from './lib/response';
 import { getCorsHeadersForRequest } from './lib/cors';
 import { getApiBaseUrl, getAiDefaultModel, getAiVisionModel } from './lib/config';
-
-// Import routes
-import auth from './routes/auth';
-import comments from './routes/comments';
-import ai from './routes/ai';
-import chat from './routes/chat';
-import images from './routes/images';
-import og from './routes/og';
-import analytics from './routes/analytics';
-import translate from './routes/translate';
-import config from './routes/config';
-import rag from './routes/rag';
-import gateway from './routes/gateway';
-import memos from './routes/memos';
-import memories from './routes/memories';
-import adminAi from './routes/admin-ai';
-import adminOutbox from './routes/admin-outbox';
-import secrets from './routes/secrets';
-import internal from './routes/internal';
-import personas from './routes/personas';
-import userContent from './routes/user-content';
-import search from './routes/search';
-import user from './routes/user';
-import debate from './routes/debate';
-import subscribe from './routes/subscribe';
-import contact from './routes/contact';
-import notifications from './routes/notifications';
-import adminLogs from './routes/admin-logs';
 import type { Env } from './types';
 import { flushAiArtifactOutbox } from './lib/ai-artifact-outbox';
+import {
+  buildProxyBoundaryHeaders,
+  canProxyPath,
+  registerWorkerRoutes,
+} from './routes/registry';
 
 const app = new Hono<HonoEnv>();
 
-// =============================================================================
-// Configuration
-// =============================================================================
-
-// NOTE: CORS helpers live in ./lib/cors.
-
-// =============================================================================
-// Backend Proxy (for routes not handled by Workers)
-// =============================================================================
-
 async function proxyToBackend(request: Request, env: Env): Promise<Response> {
   const backendOrigin = env.BACKEND_ORIGIN;
+  const url = new URL(request.url);
+
   if (!backendOrigin) {
     const corsHeaders = await getCorsHeadersForRequest(request, env);
     return new Response(
@@ -74,13 +40,29 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
       {
         status: 500,
         headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      }
+      },
     );
   }
 
-  const url = new URL(request.url);
-  const backendUrl = new URL(url.pathname + url.search, backendOrigin);
+  if (!canProxyPath(url.pathname)) {
+    const corsHeaders = await getCorsHeadersForRequest(request, env);
+    return new Response(
+      JSON.stringify({
+        error: 'Route ownership violation',
+        message: `${url.pathname} is not allowed to fall through to backend proxy`,
+      }),
+      {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json',
+          ...corsHeaders,
+          ...buildProxyBoundaryHeaders(url.pathname),
+        },
+      },
+    );
+  }
 
+  const backendUrl = new URL(url.pathname + url.search, backendOrigin);
   const headers = new Headers(request.headers);
   headers.delete('Host');
   headers.set('Host', 'blog-b.nodove.com');
@@ -128,16 +110,18 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
     const corsHeaders = await getCorsHeadersForRequest(request, env);
     const responseHeaders = new Headers(response.headers);
 
-    // Prevent upstream CORS headers from causing Origin mismatch issues
     responseHeaders.delete('Access-Control-Allow-Origin');
     responseHeaders.delete('Access-Control-Allow-Credentials');
     responseHeaders.delete('Access-Control-Allow-Methods');
     responseHeaders.delete('Access-Control-Allow-Headers');
     responseHeaders.delete('Access-Control-Max-Age');
 
-    Object.entries(corsHeaders).forEach(([key, value]) => {
+    for (const [key, value] of Object.entries(corsHeaders)) {
       responseHeaders.set(key, value);
-    });
+    }
+    for (const [key, value] of Object.entries(buildProxyBoundaryHeaders(url.pathname))) {
+      responseHeaders.set(key, value);
+    }
 
     if (response.status >= 502 && response.status <= 504) {
       console.error('Backend returned error status:', response.status);
@@ -155,7 +139,7 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
           status: response.status,
           statusText: response.statusText,
           headers: responseHeaders,
-        }
+        },
       );
     }
 
@@ -179,24 +163,17 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
           'Content-Type': 'application/json',
           'Retry-After': '30',
           ...corsHeaders,
+          ...buildProxyBoundaryHeaders(url.pathname),
         },
-      }
+      },
     );
   }
 }
-
-// =============================================================================
-// Global Middlewares
-// =============================================================================
 
 app.use('*', corsMiddleware);
 app.use('*', loggerMiddleware);
 app.use('/api/v1/ai/*', tracingMiddleware);
 app.use('/api/v1/chat/*', tracingMiddleware);
-
-// =============================================================================
-// Health & Status Endpoints
-// =============================================================================
 
 app.get('/_health', (c) => {
   return c.json({
@@ -255,51 +232,14 @@ app.get('/api/v1/public/config', async (c) => {
   return success(c, await buildPublicConfig(c.env));
 });
 
-// =============================================================================
-// Mount API Routes under /api/v1
-// =============================================================================
-
 const api = new Hono<HonoEnv>();
-api.route('/auth', auth);
-api.route('/comments', comments);
-api.route('/ai', ai);
-api.route('/chat', chat);
-api.route('/images', images);
-api.route('/og', og);
-api.route('/analytics', analytics);
-api.route('/', translate);
-api.route('/config', config);
-api.route('/rag', rag);
-api.route('/memos', memos);
-api.route('/memories', memories);
-api.route('/admin/ai', adminAi);
-api.route('/admin/outbox', adminOutbox);
-api.route('/admin/secrets', secrets);
-api.route('/internal', internal);
-api.route('/personas', personas);
-api.route('/user-content', userContent);
-api.route('/search', search);
-api.route('/user', user);
-api.route('/debate', debate);
-api.route('/subscribe', subscribe);
-api.route('/contact', contact);
-api.route('/notifications', notifications);
-api.route('/admin/logs', adminLogs);
-api.route('/gateway', gateway);
-// /posts is backend-owned. Requests fall through to the backend proxy below.
-
+registerWorkerRoutes(api);
 app.route('/api/v1', api);
 
-// =============================================================================
-// Fallback: Proxy to Backend for unhandled routes
-// =============================================================================
-
 app.all('*', async (c) => {
-  // If it's a route we don't handle, proxy to backend
   return proxyToBackend(c.req.raw, c.env);
 });
 
-// Error handler
 app.onError(errorHandler);
 
 // =============================================================================

--- a/workers/api-gateway/src/routes/analytics.ts
+++ b/workers/api-gateway/src/routes/analytics.ts
@@ -3,6 +3,7 @@ import type { HonoEnv, Env, PostStats, EditorPick } from '../types';
 import { queryOne, queryAll, execute } from '../lib/d1';
 import { success, error, badRequest, notFound } from '../lib/response';
 import { requireAdmin } from '../middleware/auth';
+import { buildDataOwnershipHeaders } from '../../../../shared/src/contracts/data-ownership.js';
 
 // ---------------------------------------------------------------------------
 // Backend proxy helper
@@ -43,6 +44,13 @@ async function proxyToBackend(
 
 const app = new Hono<HonoEnv>();
 
+function applyDataOwnership(c: any, ownershipId: string) {
+  const headers = buildDataOwnershipHeaders(ownershipId);
+  for (const [key, value] of Object.entries(headers)) {
+    c.header(key, value);
+  }
+}
+
 /**
  * POST /api/v1/analytics/view
  * Record a view for a post.
@@ -50,6 +58,7 @@ const app = new Hono<HonoEnv>();
  */
 app.post('/view', async (c) => {
   try {
+    applyDataOwnership(c, 'analytics.post_stats');
     const body = await c.req.json<{ year: string; slug: string }>().catch(() => ({}) as { year: string; slug: string });
     if (!body.year || !body.slug) {
       return error(c, 'year and slug are required', 400);
@@ -75,6 +84,7 @@ app.post('/view', async (c) => {
  */
 app.get('/stats/:year/:slug', async (c) => {
   try {
+    applyDataOwnership(c, 'analytics.post_stats');
     const { year, slug } = c.req.param();
 
     const result = await proxyToBackend(c.env, `/stats/${year}/${slug}`, 'GET');
@@ -102,6 +112,7 @@ app.get('/stats/:year/:slug', async (c) => {
  */
 app.get('/editor-picks', async (c) => {
   try {
+    applyDataOwnership(c, 'analytics.editor_picks');
     const db = c.env.DB;
     const limit = parseInt(c.req.query('limit') || '3');
 
@@ -129,6 +140,7 @@ app.get('/editor-picks', async (c) => {
  */
 app.get('/trending', async (c) => {
   try {
+    applyDataOwnership(c, 'analytics.post_stats');
     const limit = Math.min(parseInt(c.req.query('limit') || '10'), 50);
     const offset = Math.max(parseInt(c.req.query('offset') || '0'), 0);
     const days = parseInt(c.req.query('days') || '7');
@@ -160,6 +172,7 @@ app.get('/trending', async (c) => {
  */
 app.post('/refresh-stats', requireAdmin, async (c) => {
   try {
+    applyDataOwnership(c, 'analytics.post_stats');
     const result = await proxyToBackend(c.env, '/refresh-stats', 'POST');
     if (!result.ok) {
       return error(c, result.error || 'Failed to refresh stats', result.status as 500 | 503);
@@ -433,6 +446,7 @@ app.delete('/admin/editor-picks/:year/:slug', requireAdmin, async (c) => {
 
 app.post('/heartbeat', async (c) => {
   try {
+    applyDataOwnership(c, 'analytics.post_stats');
     const body = await c.req.json<{ visitorId?: string }>().catch(() => ({ visitorId: undefined }));
     const kv = c.env.KV;
     

--- a/workers/api-gateway/src/routes/registry.ts
+++ b/workers/api-gateway/src/routes/registry.ts
@@ -1,0 +1,111 @@
+import { Hono } from 'hono';
+import type { HonoEnv } from '../types';
+import {
+  buildRouteBoundaryHeaders,
+  matchServiceBoundary,
+  ROUTE_OWNERS,
+} from '../../../../shared/src/contracts/service-boundaries.js';
+
+import auth from './auth';
+import comments from './comments';
+import ai from './ai';
+import chat from './chat';
+import images from './images';
+import og from './og';
+import analytics from './analytics';
+import translate from './translate';
+import config from './config';
+import rag from './rag';
+import gateway from './gateway';
+import memos from './memos';
+import memories from './memories';
+import adminAi from './admin-ai';
+import adminOutbox from './admin-outbox';
+import secrets from './secrets';
+import internal from './internal';
+import personas from './personas';
+import userContent from './user-content';
+import search from './search';
+import user from './user';
+import debate from './debate';
+import subscribe from './subscribe';
+import contact from './contact';
+import notifications from './notifications';
+import adminLogs from './admin-logs';
+
+export type WorkerRouteRegistryEntry = {
+  boundaryId: string;
+  path: string;
+  router: Hono<HonoEnv>;
+};
+
+export const WORKER_ROUTE_REGISTRY: WorkerRouteRegistryEntry[] = [
+  { boundaryId: 'auth', path: '/auth', router: auth },
+  { boundaryId: 'comments', path: '/comments', router: comments },
+  { boundaryId: 'ai', path: '/ai', router: ai },
+  { boundaryId: 'chat', path: '/chat', router: chat },
+  { boundaryId: 'images', path: '/images', router: images },
+  { boundaryId: 'og', path: '/og', router: og },
+  { boundaryId: 'analytics', path: '/analytics', router: analytics },
+  { boundaryId: 'translate', path: '/', router: translate },
+  { boundaryId: 'config', path: '/config', router: config },
+  { boundaryId: 'rag', path: '/rag', router: rag },
+  { boundaryId: 'memos', path: '/memos', router: memos },
+  { boundaryId: 'memories', path: '/memories', router: memories },
+  { boundaryId: 'admin-ai', path: '/admin/ai', router: adminAi },
+  { boundaryId: 'admin-outbox', path: '/admin/outbox', router: adminOutbox },
+  { boundaryId: 'admin-secrets', path: '/admin/secrets', router: secrets },
+  { boundaryId: 'internal', path: '/internal', router: internal },
+  { boundaryId: 'personas', path: '/personas', router: personas },
+  { boundaryId: 'user-content', path: '/user-content', router: userContent },
+  { boundaryId: 'search', path: '/search', router: search },
+  { boundaryId: 'user', path: '/user', router: user },
+  { boundaryId: 'debate', path: '/debate', router: debate },
+  { boundaryId: 'subscribe', path: '/subscribe', router: subscribe },
+  { boundaryId: 'contact', path: '/contact', router: contact },
+  { boundaryId: 'notifications', path: '/notifications', router: notifications },
+  { boundaryId: 'admin-logs', path: '/admin/logs', router: adminLogs },
+  { boundaryId: 'gateway', path: '/gateway', router: gateway },
+];
+
+function applyBoundaryHeaderMiddleware(boundaryId: string) {
+  return async (c, next) => {
+    await next();
+    const headers = buildRouteBoundaryHeaders(boundaryId, {
+      responder: 'worker',
+      edgeMode: 'native',
+      originMode: 'worker',
+    });
+    for (const [key, value] of Object.entries(headers)) {
+      c.res.headers.set(key, value);
+    }
+  };
+}
+
+export function registerWorkerRoutes(api: Hono<HonoEnv>) {
+  for (const entry of WORKER_ROUTE_REGISTRY) {
+    if (entry.path !== '/') {
+      api.use(entry.path, applyBoundaryHeaderMiddleware(entry.boundaryId));
+      api.use(`${entry.path}/*`, applyBoundaryHeaderMiddleware(entry.boundaryId));
+    }
+    api.route(entry.path, entry.router);
+  }
+}
+
+export function canProxyPath(pathname: string) {
+  const boundary = matchServiceBoundary(pathname);
+  if (!boundary) return true;
+  return (
+    boundary.owner === ROUTE_OWNERS.BACKEND ||
+    boundary.owner === ROUTE_OWNERS.PROXY_ONLY ||
+    boundary.owner === ROUTE_OWNERS.COMPATIBILITY
+  );
+}
+
+export function buildProxyBoundaryHeaders(pathname: string) {
+  return buildRouteBoundaryHeaders(pathname, {
+    responder: 'worker-proxy',
+    edgeMode: 'proxy',
+    originMode: 'backend',
+  });
+}

--- a/workers/api-gateway/src/routes/translate.ts
+++ b/workers/api-gateway/src/routes/translate.ts
@@ -28,8 +28,21 @@ import {
 } from '../lib/translation-service';
 import { enqueueTranslationGeneration } from '../lib/ai-artifact-outbox';
 import { ERROR_MESSAGES } from '../config/defaults';
+import { buildRouteBoundaryHeaders } from '../../../../shared/src/contracts/service-boundaries.js';
 
 const app = new Hono<HonoEnv>();
+
+app.use('*', async (c, next) => {
+  await next();
+  const headers = buildRouteBoundaryHeaders('translate', {
+    responder: 'worker',
+    edgeMode: 'native',
+    originMode: 'worker',
+  });
+  for (const [key, value] of Object.entries(headers)) {
+    c.res.headers.set(key, value);
+  }
+});
 const LEGACY_TRANSLATE_SUNSET = 'Tue, 30 Jun 2026 00:00:00 GMT';
 
 type GenerateOptions = {


### PR DESCRIPTION
## Summary
- Backend: replace 20+ manual route imports/mounts with `PUBLIC_ROUTE_REGISTRY` and `PROTECTED_ROUTE_REGISTRY` + `mountRouteRegistry()` in `registry.js`
- API gateway: replace 25+ manual Hono route mounts with `registerWorkerRoutes()` + `canProxyPath()` proxy boundary enforcement in `registry.ts`
- Add data ownership headers (`X-Data-Owner`) to analytics routes on both backend and worker
- Add route boundary headers (`X-Route-Boundary`) to translate routes
- Workers admin config: use shared `WORKER_DEPLOYMENTS` contract from `shared/src/contracts/workers.js` instead of inline config

## Changed Files
- `backend/src/routes/registry.js` (NEW)
- `backend/src/index.js` - refactored to use route registry
- `backend/src/routes/{workers,analytics}.js`
- `workers/api-gateway/src/index.ts` - refactored to use route registry
- `workers/api-gateway/src/routes/{registry.ts NEW, analytics.ts, translate.ts}`