### PR TITLE
fix(security): harden auth and upload flows

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -2,6 +2,8 @@ export {
   config,
   initConfig,
   loadAndApplyConsulConfig,
+  assertSecurityConfiguration,
+  getSecurityConfigurationErrors,
   publicRuntimeConfig,
   getServiceUrl,
   consulGet,

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -122,6 +122,7 @@ function createConfig(raw) {
 
     security: {
       protectedEnvironment: isProtectedEnvironment(raw.APP_ENV),
+      allowInsecureDevAuth: raw.ALLOW_INSECURE_DEV_AUTH === 'true',
     },
 
     backendKey: raw.BACKEND_KEY,
@@ -213,6 +214,51 @@ const syncConfig = configSchema.parse(process.env);
 
 export const config = createConfig(syncConfig);
 
+export function getSecurityConfigurationErrors(currentConfig = config) {
+  const errors = [];
+  const protectedEnvironment = currentConfig.security?.protectedEnvironment === true;
+  const allowInsecureDevAuth = currentConfig.security?.allowInsecureDevAuth === true;
+
+  if (!currentConfig.backendKey && (protectedEnvironment || !allowInsecureDevAuth)) {
+    errors.push(
+      protectedEnvironment
+        ? 'BACKEND_KEY is required in protected environments'
+        : 'BACKEND_KEY is required unless ALLOW_INSECURE_DEV_AUTH=true'
+    );
+  }
+
+  if (!currentConfig.auth?.jwtSecret && (protectedEnvironment || !allowInsecureDevAuth)) {
+    errors.push(
+      protectedEnvironment
+        ? 'JWT_SECRET is required in protected environments'
+        : 'JWT_SECRET is required unless ALLOW_INSECURE_DEV_AUTH=true'
+    );
+  }
+
+  if (
+    !currentConfig.admin?.bearerToken &&
+    !currentConfig.auth?.jwtSecret &&
+    (protectedEnvironment || !allowInsecureDevAuth)
+  ) {
+    errors.push(
+      protectedEnvironment
+        ? 'ADMIN_BEARER_TOKEN or JWT_SECRET is required for admin routes in protected environments'
+        : 'ADMIN_BEARER_TOKEN or JWT_SECRET is required for admin routes unless ALLOW_INSECURE_DEV_AUTH=true'
+    );
+  }
+
+  return errors;
+}
+
+export function assertSecurityConfiguration(currentConfig = config) {
+  const errors = getSecurityConfigurationErrors(currentConfig);
+  if (errors.length > 0) {
+    const err = new Error(`Security configuration is incomplete: ${errors.join('; ')}`);
+    err.code = 'SECURITY_CONFIG_INCOMPLETE';
+    throw err;
+  }
+}
+
 if (!config.services.workerApiUrl) {
   logger.warn({}, 'WORKER_API_URL is not set - AI dynamic config from Worker will be unavailable. Set WORKER_API_URL to the api-gateway Worker URL.');
 }
@@ -231,8 +277,10 @@ export async function loadAndApplyConsulConfig() {
       apiBaseUrl: asyncConfig.apiBaseUrl,
       allowedOrigins: asyncConfig.allowedOrigins,
       assetsBaseUrl: asyncConfig.assetsBaseUrl,
+      admin: asyncConfig.admin,
       ai: asyncConfig.ai,
       auth: asyncConfig.auth,
+      backendKey: asyncConfig.backendKey,
       content: asyncConfig.content,
       paths: asyncConfig.paths,
       rag: asyncConfig.rag,

--- a/backend/src/config/schema.js
+++ b/backend/src/config/schema.js
@@ -56,6 +56,7 @@ export const configSchema = z.object({
   REDIS_PASSWORD: z.string().optional(),
 
   BACKEND_KEY: z.string().optional(),
+  ALLOW_INSECURE_DEV_AUTH: z.enum(['true', 'false']).default('false'),
 
   OPEN_NOTEBOOK_URL: z.string().default('http://open-notebook:8501'),
   OPEN_NOTEBOOK_ENABLED: z.enum(['true', 'false']).default('false'),

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,7 @@ import {
   config,
   publicRuntimeConfig,
   loadAndApplyConsulConfig,
+  assertSecurityConfiguration,
 } from "./config.js";
 import { requireBackendKey } from "./middleware/backendAuth.js";
 import { httpCache } from "./middleware/httpCache.js";
@@ -33,6 +34,7 @@ import { errorHandler, notFoundHandler } from "./middleware/errorHandler.js";
 
 async function startServer() {
   await loadAndApplyConsulConfig();
+  assertSecurityConfiguration();
 
   if (isPgConfigured()) {
     try {

--- a/backend/src/middleware/adminAuth.js
+++ b/backend/src/middleware/adminAuth.js
@@ -4,32 +4,50 @@ import { verifyJwt, isAdminClaims } from '../lib/jwt.js';
 /**
  * Admin 보호 미들웨어.
  * - ADMIN_BEARER_TOKEN 또는 JWT_SECRET 둘 중 하나라도 설정되어 있으면 보호 활성화
- * - 둘 다 없으면(로컬 편의) 패스스루
+ * - 둘 다 없으면 명시적 ALLOW_INSECURE_DEV_AUTH=true 에서만 패스스루
  */
-export function requireAdmin(req, res, next) {
-  const protectionEnabled = !!(config.admin.bearerToken || config.auth?.jwtSecret);
-  if (!protectionEnabled) {
-    if (config.security?.protectedEnvironment) {
-      return res.status(503).json({ ok: false, error: 'Service unavailable' });
-    }
-    return next();
+function isInsecureDevAuthAllowed() {
+  return (
+    config.security?.protectedEnvironment !== true &&
+    config.security?.allowInsecureDevAuth === true
+  );
+}
+
+function isAdminProtectionConfigured() {
+  return !!(config.admin.bearerToken || config.auth?.jwtSecret);
+}
+
+export function isAdminRequest(req) {
+  if (!isAdminProtectionConfigured()) {
+    return isInsecureDevAuthAllowed();
   }
 
   const auth = req.headers['authorization'] || '';
   const token = auth.replace(/^Bearer\s+/i, '').trim();
-  if (!token) return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  if (!token) return false;
 
   // Static bearer token 우선
-  if (config.admin.bearerToken && token === config.admin.bearerToken) return next();
+  if (config.admin.bearerToken && token === config.admin.bearerToken) return true;
 
   // JWT 어드민 검사
   if (config.auth?.jwtSecret) {
     try {
       const claims = verifyJwt(token);
-      if (claims?.type === 'refresh') return res.status(401).json({ ok: false, error: 'Unauthorized' });
-      if (isAdminClaims(claims) && claims.emailVerified === true) return next();
+      if (claims?.type === 'refresh') return false;
+      if (isAdminClaims(claims) && claims.emailVerified === true) return true;
     } catch {}
   }
+
+  return false;
+}
+
+export function requireAdmin(req, res, next) {
+  if (!isAdminProtectionConfigured()) {
+    if (isInsecureDevAuthAllowed()) return next();
+    return res.status(503).json({ ok: false, error: 'Service unavailable' });
+  }
+
+  if (isAdminRequest(req)) return next();
 
   return res.status(401).json({ ok: false, error: 'Unauthorized' });
 }

--- a/backend/src/middleware/backendAuth.js
+++ b/backend/src/middleware/backendAuth.js
@@ -7,23 +7,31 @@ const logger = createLogger('backend-auth');
 /**
  * Backend key validation middleware.
  * Security: Prevents direct access to backend, bypassing Gateway's auth/rate-limiting.
- * If BACKEND_KEY not configured in protected environments: fail closed.
+ * If BACKEND_KEY is not configured, only explicit insecure local development may pass through.
  */
 export function requireBackendKey(req, res, next) {
   const backendKey = config.backendKey;
   const protectedEnvironment = config.security?.protectedEnvironment === true;
+  const allowInsecureDevAuth =
+    !protectedEnvironment && config.security?.allowInsecureDevAuth === true;
 
   if (!backendKey) {
-    if (protectedEnvironment) {
+    if (!allowInsecureDevAuth) {
       logger.error(
         { method: req.method, path: req.path },
-        'BACKEND_KEY missing in protected environment'
+        protectedEnvironment
+          ? 'BACKEND_KEY missing in protected environment'
+          : 'BACKEND_KEY missing and insecure dev auth is not allowed'
       );
       return res.status(503).json({
         ok: false,
         error: 'Service unavailable',
       });
     }
+    logger.warn(
+      { method: req.method, path: req.path },
+      'BACKEND_KEY missing; allowing request because ALLOW_INSECURE_DEV_AUTH=true'
+    );
     return next();
   }
 

--- a/backend/src/middleware/httpCache.js
+++ b/backend/src/middleware/httpCache.js
@@ -39,6 +39,7 @@ function buildCacheKey(req, { prefix, keyFromBody }) {
  * @param {string} [options.prefix='route']   - Cache key namespace
  * @param {string[]} [options.keyFromBody]    - POST body fields to include in cache key
  * @param {boolean} [options.allowPost=false] - Cache POST requests
+ * @param {(req: import('express').Request) => boolean} [options.skip] - Predicate to bypass cache
  * @returns {import('express').RequestHandler}
  */
 export function httpCache(options = {}) {
@@ -47,10 +48,16 @@ export function httpCache(options = {}) {
     prefix = 'route',
     keyFromBody = [],
     allowPost = false,
+    skip = null,
   } = options;
 
   return async (req, res, next) => {
     const method = req.method;
+
+    if (typeof skip === 'function' && skip(req)) {
+      res.set('X-Cache-Status', 'BYPASS');
+      return next();
+    }
 
     if (method !== 'GET' && !(method === 'POST' && allowPost)) {
       res.set('X-Cache-Status', 'BYPASS');

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -14,6 +14,13 @@ import { createLogger } from "../lib/logger.js";
 const logger = createLogger('images-route');
 
 const router = Router();
+const ALLOWED_IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "webp", "gif"]);
+const ALLOWED_IMAGE_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+]);
 
 function readHeaderValue(value) {
   if (Array.isArray(value)) return value[0];
@@ -81,9 +88,13 @@ function buildDir({ year, slug, subdir }) {
 async function saveWithVariants(destDirAbs, relDir, file) {
   const origName = sanitizeFilename(file.originalname || "image");
   const ext = (origName.split(".").pop() || "").toLowerCase();
-  const allowed = new Set(["jpg", "jpeg", "png", "webp", "gif", "svg"]);
-  if (!allowed.has(ext)) {
+  if (!ALLOWED_IMAGE_EXTENSIONS.has(ext)) {
     throw Object.assign(new Error(`Unsupported file type: .${ext}`), {
+      status: 400,
+    });
+  }
+  if (file.mimetype && !ALLOWED_IMAGE_MIME_TYPES.has(file.mimetype)) {
+    throw Object.assign(new Error(`Unsupported content type: ${file.mimetype}`), {
       status: 400,
     });
   }
@@ -116,7 +127,7 @@ async function saveWithVariants(destDirAbs, relDir, file) {
     await fse.writeFile(absWebp, webpBuffer);
     webpUrl = `/images/${relDir}/${webpName}`;
   } catch (_) {
-    // If sharp fails (e.g., SVG), silently skip variant
+    // If sharp cannot decode a supported image, keep the original and skip variants.
   }
 
   return {
@@ -248,6 +259,12 @@ router.post("/chat-upload", requireAdmin, upload.single("file"), async (req, res
     const file = req.file;
     if (!file) {
       return res.status(400).json({ ok: false, error: "file is required" });
+    }
+    if (file.mimetype && !ALLOWED_IMAGE_MIME_TYPES.has(file.mimetype)) {
+      return res.status(400).json({
+        ok: false,
+        error: `Unsupported content type: ${file.mimetype}`,
+      });
     }
 
     // Generate key

--- a/backend/src/routes/posts.js
+++ b/backend/src/routes/posts.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 import matter from 'gray-matter';
 import slugify from 'slugify';
 import { config } from '../config.js';
-import requireAdmin from '../middleware/adminAuth.js';
+import requireAdmin, { isAdminRequest } from '../middleware/adminAuth.js';
 import { buildFrontmatterMarkdown } from '../lib/markdown.js';
 import { httpCache, invalidateCacheByPrefix } from '../middleware/httpCache.js';
 import { createLogger } from '../lib/logger.js';
@@ -114,6 +114,18 @@ function computeItem(year, file, fm, body) {
   };
 }
 
+function isPublishedPost(fm) {
+  return fm?.published !== false;
+}
+
+function hasAuthorization(req) {
+  return typeof req.headers?.authorization === 'string' && req.headers.authorization.trim() !== '';
+}
+
+function shouldBypassPublicPostCache(req) {
+  return hasAuthorization(req) || String(req.query?.includeDrafts || 'false') === 'true';
+}
+
 async function listYears(postsDir) {
   const entries = await fs.promises.readdir(postsDir);
   const years = [];
@@ -199,13 +211,18 @@ async function generateUnifiedManifest() {
   return unified;
 }
 
-router.get('/', httpCache({ ttl: 300, prefix: 'posts' }), async (req, res, next) => {
+router.get('/', httpCache({ ttl: 300, prefix: 'posts', skip: shouldBypassPublicPostCache }), async (req, res, next) => {
   try {
     const q = req.query || {};
     const year = (q.year || '').toString();
     const includeDrafts = String(q.includeDrafts || 'false') === 'true';
     const limit = parseInt(q.limit) || 0;
     const offset = parseInt(q.offset) || 0;
+    const includeDraftsAllowed = includeDrafts && isAdminRequest(req);
+
+    if (includeDrafts && !includeDraftsAllowed) {
+      return res.status(403).json({ ok: false, error: 'Admin authorization required' });
+    }
 
     // Try filesystem first, fallback to remote manifest
     if (await isFilesystemAvailable()) {
@@ -223,7 +240,7 @@ router.get('/', httpCache({ ttl: 300, prefix: 'posts' }), async (req, res, next)
           const abs = path.join(dir, file);
           const raw = await fs.promises.readFile(abs, 'utf8');
           const { data: fm, content } = matter(raw);
-          if (fm.published === false && !includeDrafts) continue;
+          if (!isPublishedPost(fm) && !includeDraftsAllowed) continue;
           items.push(computeItem(y, file, fm, content));
         }
       }
@@ -248,7 +265,7 @@ router.get('/', httpCache({ ttl: 300, prefix: 'posts' }), async (req, res, next)
     }
 
     // Filter drafts
-    if (!includeDrafts) {
+    if (!includeDraftsAllowed) {
       items = items.filter(item => item.published !== false);
     }
 
@@ -268,7 +285,7 @@ router.get('/', httpCache({ ttl: 300, prefix: 'posts' }), async (req, res, next)
   }
 });
 
-router.get('/:year/:slug', httpCache({ ttl: 600, prefix: 'posts' }), async (req, res, next) => {
+router.get('/:year/:slug', httpCache({ ttl: 600, prefix: 'posts', skip: hasAuthorization }), async (req, res, next) => {
   try {
     const { year, slug } = req.params;
     if (!/^\d{4}$/.test(year))
@@ -282,6 +299,9 @@ router.get('/:year/:slug', httpCache({ ttl: 600, prefix: 'posts' }), async (req,
       if (await exists(abs)) {
         const raw = await fs.promises.readFile(abs, 'utf8');
         const { data: fm, content } = matter(raw);
+        if (!isPublishedPost(fm) && !isAdminRequest(req)) {
+          return res.status(404).json({ ok: false, error: 'Not found' });
+        }
         const item = computeItem(year, file, fm, content);
         return res.json({ ok: true, data: { item, markdown: raw }, source: 'filesystem' });
       }
@@ -294,6 +314,9 @@ router.get('/:year/:slug', httpCache({ ttl: 600, prefix: 'posts' }), async (req,
     }
 
     const { data: fm, content } = matter(markdown);
+    if (!isPublishedPost(fm) && !isAdminRequest(req)) {
+      return res.status(404).json({ ok: false, error: 'Not found' });
+    }
     const item = computeItem(year, file, fm, content);
     return res.json({ ok: true, data: { item, markdown }, source: 'remote' });
   } catch (err) {

--- a/backend/test/auth-guards.test.js
+++ b/backend/test/auth-guards.test.js
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || "auth-guards-test-secret";
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "15m";
+process.env.APP_ENV = process.env.APP_ENV || "test";
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || "gpt-4.1-mini";
+
+const [
+  { config, getSecurityConfigurationErrors },
+  { requireAdmin },
+  { requireBackendKey },
+] = await Promise.all([
+  import("../src/config/index.js"),
+  import("../src/middleware/adminAuth.js"),
+  import("../src/middleware/backendAuth.js"),
+]);
+
+function createResponseRecorder() {
+  return {
+    statusCode: 200,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    },
+  };
+}
+
+function cloneSecurityConfig() {
+  return {
+    backendKey: config.backendKey,
+    security: { ...config.security },
+    admin: { ...config.admin },
+    auth: { ...config.auth },
+  };
+}
+
+function restoreSecurityConfig(snapshot) {
+  config.backendKey = snapshot.backendKey;
+  config.security = snapshot.security;
+  config.admin = snapshot.admin;
+  config.auth = snapshot.auth;
+}
+
+async function withSecurityConfig(patch, callback) {
+  const snapshot = cloneSecurityConfig();
+  try {
+    Object.assign(config, patch);
+    if (patch.security) config.security = { ...snapshot.security, ...patch.security };
+    if (patch.admin) config.admin = { ...snapshot.admin, ...patch.admin };
+    if (patch.auth) config.auth = { ...snapshot.auth, ...patch.auth };
+    await callback();
+  } finally {
+    restoreSecurityConfig(snapshot);
+  }
+}
+
+test("backend key guard fails closed unless insecure development auth is explicitly allowed", async () => {
+  await withSecurityConfig(
+    {
+      backendKey: undefined,
+      security: { protectedEnvironment: false, allowInsecureDevAuth: false },
+    },
+    () => {
+      const req = { method: "GET", path: "/api/v1/posts", headers: {}, ip: "127.0.0.1" };
+      const res = createResponseRecorder();
+      let nextCalled = false;
+
+      requireBackendKey(req, res, () => {
+        nextCalled = true;
+      });
+
+      assert.equal(nextCalled, false);
+      assert.equal(res.statusCode, 503);
+      assert.deepEqual(res.payload, { ok: false, error: "Service unavailable" });
+    },
+  );
+});
+
+test("backend key guard allows explicit insecure development opt-in", async () => {
+  await withSecurityConfig(
+    {
+      backendKey: undefined,
+      security: { protectedEnvironment: false, allowInsecureDevAuth: true },
+    },
+    () => {
+      const req = { method: "GET", path: "/api/v1/posts", headers: {}, ip: "127.0.0.1" };
+      const res = createResponseRecorder();
+      let nextCalled = false;
+
+      requireBackendKey(req, res, () => {
+        nextCalled = true;
+      });
+
+      assert.equal(nextCalled, true);
+      assert.equal(res.statusCode, 200);
+    },
+  );
+});
+
+test("admin guard fails closed when no admin credential source is configured", async () => {
+  await withSecurityConfig(
+    {
+      security: { protectedEnvironment: false, allowInsecureDevAuth: false },
+      admin: { bearerToken: undefined },
+      auth: { jwtSecret: undefined },
+    },
+    () => {
+      const req = { headers: {} };
+      const res = createResponseRecorder();
+      let nextCalled = false;
+
+      requireAdmin(req, res, () => {
+        nextCalled = true;
+      });
+
+      assert.equal(nextCalled, false);
+      assert.equal(res.statusCode, 503);
+      assert.deepEqual(res.payload, { ok: false, error: "Service unavailable" });
+    },
+  );
+});
+
+test("protected security configuration requires backend and JWT secrets", () => {
+  const errors = getSecurityConfigurationErrors({
+    backendKey: undefined,
+    security: { protectedEnvironment: true, allowInsecureDevAuth: false },
+    admin: { bearerToken: undefined },
+    auth: { jwtSecret: undefined },
+  });
+
+  assert.ok(errors.includes("BACKEND_KEY is required in protected environments"));
+  assert.ok(errors.includes("JWT_SECRET is required in protected environments"));
+  assert.ok(
+    errors.includes(
+      "ADMIN_BEARER_TOKEN or JWT_SECRET is required for admin routes in protected environments",
+    ),
+  );
+});

--- a/backend/test/images-security.test.js
+++ b/backend/test/images-security.test.js
@@ -1,0 +1,107 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { File } from "node:buffer";
+
+import express from "express";
+
+const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "blog-images-security-"));
+const imagesDir = path.join(tempRoot, "images");
+
+process.env.ADMIN_BEARER_TOKEN = process.env.ADMIN_BEARER_TOKEN || "images-security-admin";
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "15m";
+process.env.APP_ENV = process.env.APP_ENV || "test";
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || "gpt-4.1-mini";
+process.env.CONTENT_IMAGES_DIR = imagesDir;
+
+const { default: imagesRouter } = await import("../src/routes/images.js");
+
+after(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+function createApp() {
+  const app = express();
+  app.use("/api/v1/images", imagesRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err?.status || 500).json({
+      ok: false,
+      error: err?.message || "Unhandled test error",
+    });
+  });
+  return app;
+}
+
+async function withServer(callback) {
+  const server = http.createServer(createApp());
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+test("backend image upload rejects SVG files", async () => {
+  await withServer(async (baseUrl) => {
+    const formData = new FormData();
+    formData.append(
+      "files",
+      new File(["<svg><script>alert(1)</script></svg>"], "bad.svg", {
+        type: "image/svg+xml",
+      }),
+    );
+
+    const response = await fetch(`${baseUrl}/api/v1/images/upload`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
+      },
+      body: formData,
+    });
+
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /Unsupported file type: \.svg/);
+  });
+});
+
+test("backend chat image upload rejects SVG content", async () => {
+  await withServer(async (baseUrl) => {
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new File(["<svg><script>alert(1)</script></svg>"], "bad.svg", {
+        type: "image/svg+xml",
+      }),
+    );
+
+    const response = await fetch(`${baseUrl}/api/v1/images/chat-upload`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
+      },
+      body: formData,
+    });
+
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.deepEqual(payload, {
+      ok: false,
+      error: "Unsupported content type: image/svg+xml",
+    });
+  });
+});

--- a/backend/test/posts-security.test.js
+++ b/backend/test/posts-security.test.js
@@ -1,0 +1,166 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import express from "express";
+
+const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "blog-posts-security-"));
+const postsDir = path.join(tempRoot, "posts");
+const publicDir = path.join(tempRoot, "public");
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || "posts-security-test-secret";
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "15m";
+process.env.APP_ENV = process.env.APP_ENV || "test";
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || "gpt-4.1-mini";
+process.env.CONTENT_POSTS_DIR = postsDir;
+process.env.CONTENT_PUBLIC_DIR = publicDir;
+
+await fs.mkdir(path.join(postsDir, "2026"), { recursive: true });
+await fs.mkdir(publicDir, { recursive: true });
+await fs.writeFile(
+  path.join(postsDir, "2026", "public-post.md"),
+  `---
+title: Public Post
+published: true
+date: 2026-01-01
+---
+
+Public body
+`,
+);
+await fs.writeFile(
+  path.join(postsDir, "2026", "draft-post.md"),
+  `---
+title: Draft Post
+published: false
+date: 2026-01-02
+---
+
+Draft body
+`,
+);
+
+const [{ default: postsRouter }, { signJwt }, { closeRedis }] = await Promise.all([
+  import("../src/routes/posts.js"),
+  import("../src/lib/jwt.js"),
+  import("../src/lib/redis-client.js"),
+]);
+
+after(async () => {
+  await closeRedis();
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/posts", postsRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err?.status || 500).json({
+      ok: false,
+      error: err?.message || "Unhandled test error",
+    });
+  });
+  return app;
+}
+
+async function withServer(callback) {
+  const server = http.createServer(createApp());
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+function createAdminToken() {
+  return signJwt({
+    sub: "admin-1",
+    role: "admin",
+    username: "Admin",
+    email: "admin@example.com",
+    emailVerified: true,
+    type: "access",
+  });
+}
+
+test("public post list never includes drafts by default", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/posts`);
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.deepEqual(
+      payload.data.items.map((item) => item.slug).sort(),
+      ["public-post"],
+    );
+  });
+});
+
+test("includeDrafts requires admin authorization", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/posts?includeDrafts=true`);
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      error: "Admin authorization required",
+    });
+  });
+});
+
+test("admin post list can include drafts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/posts?includeDrafts=true`, {
+      headers: {
+        Authorization: `Bearer ${createAdminToken()}`,
+      },
+    });
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.deepEqual(
+      payload.data.items.map((item) => item.slug).sort(),
+      ["draft-post", "public-post"],
+    );
+  });
+});
+
+test("public single-post lookup hides unpublished markdown", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/posts/2026/draft-post`);
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { ok: false, error: "Not found" });
+  });
+});
+
+test("admin single-post lookup can read unpublished markdown", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/posts/2026/draft-post`, {
+      headers: {
+        Authorization: `Bearer ${createAdminToken()}`,
+      },
+    });
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.equal(payload.data.item.slug, "draft-post");
+    assert.equal(payload.data.item.published, false);
+    assert.match(payload.data.markdown, /Draft body/);
+  });
+});

--- a/workers/api-gateway/src/routes/comments.ts
+++ b/workers/api-gateway/src/routes/comments.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import type { Context } from 'hono';
 import type { HonoEnv, Comment } from '../types';
 import { badRequest, notFound, success } from '../lib/response';
 import { execute, queryAll, queryOne } from '../lib/d1';
@@ -9,6 +10,7 @@ const comments = new Hono<HonoEnv>();
 
 const ALLOWED_EMOJIS = ['👍', '❤️', '😂', '😮', '😢', '🔥', '🎉', '💡'];
 const COMMENT_STREAM_POLL_INTERVAL_MS = 5000;
+const COMMENT_RATE_LIMIT_SECONDS = 60;
 
 function stripHtml(input: string): string {
   return input.replace(/<[^>]*>/g, '').trim();
@@ -44,6 +46,54 @@ function normalizeFingerprint(value: unknown): string {
   return String(value || '')
     .trim()
     .slice(0, 128);
+}
+
+function parseYearSlugPostId(postId: string): { year: string; slug: string } | null {
+  const match = postId.match(/^(\d{4})\/([a-zA-Z0-9][a-zA-Z0-9_-]{0,127})$/);
+  if (!match) return null;
+  return { year: match[1], slug: match[2] };
+}
+
+function getPublicSiteUrl(env: HonoEnv['Bindings']): string {
+  return String(env.PUBLIC_SITE_URL || 'https://noblog.nodove.com').replace(/\/$/, '');
+}
+
+async function publicPostExists(env: HonoEnv['Bindings'], postId: string): Promise<boolean> {
+  const parsed = parseYearSlugPostId(postId);
+  if (!parsed) return false;
+
+  const url = `${getPublicSiteUrl(env)}/posts/${encodeURIComponent(parsed.year)}/${encodeURIComponent(parsed.slug)}.md`;
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: 'text/markdown, text/plain, */*' },
+      signal: AbortSignal.timeout(5000),
+    });
+    return response.ok;
+  } catch (error) {
+    console.error('Failed to verify comment post existence:', error);
+    return false;
+  }
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', encoded);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function resolveCommentRateLimitIdentity(
+  c: Context<HonoEnv>,
+  fingerprint: string
+): Promise<string> {
+  if (fingerprint) return fingerprint;
+
+  const ip =
+    c.req.header('cf-connecting-ip') ||
+    c.req.header('x-forwarded-for') ||
+    'unknown-ip';
+  const userAgent = c.req.header('user-agent') || 'unknown-ua';
+  const digest = await sha256Hex(`${ip}:${userAgent}`);
+  return `ip:${digest}`;
 }
 
 export type CommentStreamCursor = {
@@ -169,6 +219,16 @@ comments.get('/:commentId/reactions', async (c) => {
   const commentId = normalizeCommentId(c.req.param('commentId'));
   if (!commentId) {
     return badRequest(c, 'commentId is required');
+  }
+
+  const comment = await queryOne<{ id: string }>(
+    c.env.DB,
+    'SELECT id FROM comments WHERE id = ? AND status = ?',
+    commentId,
+    'visible'
+  );
+  if (!comment) {
+    return notFound(c, 'Comment not found');
   }
 
   type ReactionRow = {
@@ -319,6 +379,10 @@ comments.post('/', async (c) => {
     return badRequest(c, 'postId, postSlug, or slug is required');
   }
 
+  if (!(await publicPostExists(c.env, postId))) {
+    return notFound(c, 'Post not found');
+  }
+
   if (typeof body.author !== 'string' || typeof body.content !== 'string') {
     return badRequest(c, 'author and content are required');
   }
@@ -333,34 +397,34 @@ comments.post('/', async (c) => {
   const fingerprint = normalizeFingerprint(
     c.req.header('X-Device-Fingerprint') || body.fingerprint
   );
+  const rateLimitIdentity = await resolveCommentRateLimitIdentity(c, fingerprint);
 
   if (!author || !content) {
     return badRequest(c, 'Author and content must not be empty after sanitization');
   }
 
-  if (fingerprint) {
-    const recent = await queryOne<{ id: string }>(
-      c.env.DB,
-      `SELECT id
-         FROM comments
-        WHERE device_fingerprint = ?
-          AND created_at > datetime('now', '-60 seconds')
-        LIMIT 1`,
-      fingerprint
-    );
+  const recent = await queryOne<{ id: string }>(
+    c.env.DB,
+    `SELECT id
+       FROM comments
+      WHERE device_fingerprint = ?
+        AND created_at > datetime('now', ?)
+      LIMIT 1`,
+    rateLimitIdentity,
+    `-${COMMENT_RATE_LIMIT_SECONDS} seconds`
+  );
 
-    if (recent) {
-      return c.json(
-        {
-          ok: false,
-          error: {
-            code: 'RATE_LIMITED',
-            message: 'Too many comments. Please wait a moment before posting again.',
-          },
+  if (recent) {
+    return c.json(
+      {
+        ok: false,
+        error: {
+          code: 'RATE_LIMITED',
+          message: 'Too many comments. Please wait a moment before posting again.',
         },
-        { status: 429 }
-      );
-    }
+      },
+      { status: 429 }
+    );
   }
 
   const commentId = `comment-${crypto.randomUUID()}`;
@@ -384,7 +448,7 @@ comments.post('/', async (c) => {
     author,
     email,
     content,
-    fingerprint || null,
+    rateLimitIdentity,
     'visible',
     now,
     now

--- a/workers/api-gateway/src/routes/images.ts
+++ b/workers/api-gateway/src/routes/images.ts
@@ -11,11 +11,61 @@ import { proxyToBackendWithPolicy } from '../lib/backend-proxy';
 
 const images = new Hono<HonoEnv>();
 
+const DIRECT_UPLOAD_MAX_SIZE = 20 * 1024 * 1024; // 20MB
+const DIRECT_UPLOAD_ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 const CHAT_UPLOAD_MAX_SIZE = 10 * 1024 * 1024; // 10MB
 const CHAT_UPLOAD_ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 const KV_RATE_LIMIT_PREFIX = 'ratelimit:chat-upload:';
 const CHAT_UPLOAD_RATE_LIMIT = 20;
 const CHAT_UPLOAD_RATE_WINDOW = 60;
+
+function sanitizeR2Filename(name: string): string {
+  const sanitized = String(name || '').replace(/[^a-zA-Z0-9._-]/g, '-').replace(/-+/g, '-');
+  if (!sanitized || sanitized.startsWith('.')) return `upload-${Date.now()}`;
+  return sanitized.slice(0, 160);
+}
+
+function sanitizeR2Segment(value: string): string {
+  return String(value || '')
+    .replace(/[^a-zA-Z0-9_-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 128);
+}
+
+function validateUploadFile(
+  file: File,
+  {
+    maxSize,
+    allowedTypes,
+  }: {
+    maxSize: number;
+    allowedTypes: string[];
+  }
+): string | null {
+  if (file.size > maxSize) {
+    return `File too large - maximum ${maxSize / 1024 / 1024}MB allowed`;
+  }
+
+  if (!allowedTypes.includes(file.type)) {
+    return `Invalid file type - allowed: ${allowedTypes.join(', ')}`;
+  }
+
+  return null;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = '';
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    const chunk = bytes.subarray(offset, offset + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+
+  return btoa(binary);
+}
 
 async function resolveAssetsBaseUrl(env: Env): Promise<string> {
   const secretValue = await getSecret(env, 'ASSETS_BASE_URL');
@@ -49,10 +99,11 @@ images.post('/presign', requireAdmin, async (c) => {
   }
 
   // Generate a unique key for R2
-  const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, '-');
+  const sanitized = sanitizeR2Filename(filename);
   const timestamp = Date.now();
-  const key = postId
-    ? `posts/${postId}/${timestamp}-${sanitized}`
+  const sanitizedPostId = postId ? sanitizeR2Segment(postId) : '';
+  const key = sanitizedPostId
+    ? `posts/${sanitizedPostId}/${timestamp}-${sanitized}`
     : `uploads/${new Date().getFullYear()}/${timestamp}-${sanitized}`;
 
   // For presigned URL approach, we'd use R2's presigned URL API
@@ -78,6 +129,14 @@ images.post('/upload-direct', requireAdmin, async (c) => {
     return badRequest(c, 'file is required');
   }
 
+  const validationError = validateUploadFile(file, {
+    maxSize: DIRECT_UPLOAD_MAX_SIZE,
+    allowedTypes: DIRECT_UPLOAD_ALLOWED_TYPES,
+  });
+  if (validationError) {
+    return badRequest(c, validationError);
+  }
+
   const r2 = c.env.R2;
   if (!r2) {
     return badRequest(c, 'R2 bucket is not configured');
@@ -85,10 +144,11 @@ images.post('/upload-direct', requireAdmin, async (c) => {
   const db = c.env.DB;
 
   // Generate R2 key
-  const sanitized = file.name.replace(/[^a-zA-Z0-9._-]/g, '-');
+  const sanitized = sanitizeR2Filename(file.name);
   const timestamp = Date.now();
-  const key = postId
-    ? `posts/${postId}/${timestamp}-${sanitized}`
+  const sanitizedPostId = postId ? sanitizeR2Segment(postId) : '';
+  const key = sanitizedPostId
+    ? `posts/${sanitizedPostId}/${timestamp}-${sanitized}`
     : `uploads/${new Date().getFullYear()}/${timestamp}-${sanitized}`;
 
   // Upload to R2
@@ -173,15 +233,12 @@ images.post('/chat-upload', requireAuth, async (c) => {
     return badRequest(c, 'file is required');
   }
 
-  if (file.size > CHAT_UPLOAD_MAX_SIZE) {
-    return badRequest(
-      c,
-      `File too large - maximum ${CHAT_UPLOAD_MAX_SIZE / 1024 / 1024}MB allowed`
-    );
-  }
-
-  if (!CHAT_UPLOAD_ALLOWED_TYPES.includes(file.type)) {
-    return badRequest(c, `Invalid file type - allowed: ${CHAT_UPLOAD_ALLOWED_TYPES.join(', ')}`);
+  const validationError = validateUploadFile(file, {
+    maxSize: CHAT_UPLOAD_MAX_SIZE,
+    allowedTypes: CHAT_UPLOAD_ALLOWED_TYPES,
+  });
+  if (validationError) {
+    return badRequest(c, validationError);
   }
 
   const r2 = c.env.R2;
@@ -189,7 +246,7 @@ images.post('/chat-upload', requireAuth, async (c) => {
     return badRequest(c, 'R2 bucket is not configured');
   }
 
-  const sanitized = file.name.replace(/[^a-zA-Z0-9._-]/g, '-');
+  const sanitized = sanitizeR2Filename(file.name);
   const timestamp = Date.now();
   const key = `ai-chat/${new Date().getFullYear()}/${timestamp}-${sanitized}`;
 
@@ -207,7 +264,7 @@ images.post('/chat-upload', requireAuth, async (c) => {
 
   if (file.type?.startsWith('image/')) {
     try {
-      const base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
+      const base64 = arrayBufferToBase64(buffer);
       const aiService = createAIService(c.env);
       imageAnalysis = await aiService.vision(base64, 'Describe this image briefly', {
         mimeType: file.type,

--- a/workers/api-gateway/test/comments-proxy.test.ts
+++ b/workers/api-gateway/test/comments-proxy.test.ts
@@ -1,17 +1,49 @@
 import { env, SELF } from 'cloudflare:test';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { execute, queryOne } from '../src/lib/d1';
 import { signJwt } from '../src/lib/jwt';
 import type { Env } from '../src/types';
 
 declare module 'cloudflare:test' {
-  interface ProvidedEnv extends Pick<Env, 'DB' | 'JWT_SECRET'> {}
+  interface ProvidedEnv extends Pick<Env, 'DB' | 'JWT_SECRET' | 'PUBLIC_SITE_URL'> {}
+}
+
+const validPostIds = new Set(['2026/test-post', '2026/alias-post', '2026/reactions-post']);
+
+function installPublishedPostFetchInterception() {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const parsedUrl = new URL(url);
+
+    if (url.startsWith(String(env.PUBLIC_SITE_URL))) {
+      const match = parsedUrl.pathname.match(/^\/posts\/(\d{4})\/([^/]+)\.md$/);
+      const postId = match ? `${match[1]}/${decodeURIComponent(match[2])}` : '';
+      if (validPostIds.has(postId)) {
+        return new Response(`---\ntitle: ${postId}\npublished: true\n---\n\nPost body`, {
+          status: 200,
+          headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+        });
+      }
+
+      return new Response('Not Found', { status: 404 });
+    }
+
+    return new Response('Unhandled fetch in comments test', { status: 500 });
+  });
 }
 
 beforeEach(async () => {
+  vi.restoreAllMocks();
+  env.PUBLIC_SITE_URL = 'https://public.example';
   await execute(env.DB, 'DELETE FROM comment_reactions');
   await execute(env.DB, 'DELETE FROM comments');
+  installPublishedPostFetchInterception();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('comments route ownership on worker D1', () => {
@@ -143,6 +175,69 @@ describe('comments route ownership on worker D1', () => {
     });
   });
 
+  it('rejects comments for unknown posts', async () => {
+    const response = await SELF.fetch('https://example.com/api/v1/comments', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Device-Fingerprint': 'fp-missing-post',
+      },
+      body: JSON.stringify({
+        postId: '2026/missing-post',
+        author: 'Mallory',
+        content: 'This post should not exist',
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: {
+        message: 'Post not found',
+      },
+    });
+  });
+
+  it('rate limits comments without a device fingerprint by IP and user agent', async () => {
+    const firstResponse = await SELF.fetch('https://example.com/api/v1/comments', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': '203.0.113.5',
+        'User-Agent': 'comments-test-agent',
+      },
+      body: JSON.stringify({
+        postId: '2026/test-post',
+        author: 'Dana',
+        content: 'First anonymous comment',
+      }),
+    });
+
+    expect(firstResponse.status).toBe(201);
+
+    const secondResponse = await SELF.fetch('https://example.com/api/v1/comments', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': '203.0.113.5',
+        'User-Agent': 'comments-test-agent',
+      },
+      body: JSON.stringify({
+        postId: '2026/test-post',
+        author: 'Dana',
+        content: 'Second anonymous comment',
+      }),
+    });
+
+    expect(secondResponse.status).toBe(429);
+    const rateLimited = (await secondResponse.json()) as {
+      ok: boolean;
+      error: { code: string; message: string };
+    };
+    expect(rateLimited.ok).toBe(false);
+    expect(rateLimited.error.code).toBe('RATE_LIMITED');
+  });
+
   it('stores reactions in D1 and hides comments through admin delete', async () => {
     const createResponse = await SELF.fetch('https://example.com/api/v1/comments', {
       method: 'POST',
@@ -236,6 +331,11 @@ describe('comments route ownership on worker D1', () => {
       created.data.id
     );
     expect(hidden?.status).toBe('hidden');
+
+    const hiddenReactionResponse = await SELF.fetch(
+      `https://example.com/api/v1/comments/${created.data.id}/reactions`
+    );
+    expect(hiddenReactionResponse.status).toBe(404);
 
     const listResponse = await SELF.fetch(
       'https://example.com/api/v1/comments?postId=2026%2Freactions-post'

--- a/workers/api-gateway/test/images-route.test.ts
+++ b/workers/api-gateway/test/images-route.test.ts
@@ -23,6 +23,20 @@ async function createUserToken() {
   );
 }
 
+async function createAdminToken() {
+  return signJwt(
+    {
+      sub: 'admin-1',
+      role: 'admin',
+      username: 'admin',
+      email: 'admin@example.com',
+      emailVerified: true,
+      type: 'access',
+    },
+    env
+  );
+}
+
 function createApp() {
   const app = new Hono();
   app.route('/api/v1/images', images);
@@ -78,6 +92,63 @@ describe('images chat-upload hardening', () => {
       ok: false,
       error: {
         message: 'Forbidden - Origin header required',
+      },
+    });
+  });
+
+  it('rejects SVG files on direct uploads', async () => {
+    const app = createApp();
+    const token = await createAdminToken();
+    const formData = new FormData();
+    formData.append('file', new File(['<svg></svg>'], 'bad.svg', { type: 'image/svg+xml' }));
+
+    const response = await app.request(
+      'https://example.com/api/v1/images/upload-direct',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        body: formData,
+      },
+      env
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: {
+        message: 'Invalid file type - allowed: image/jpeg, image/png, image/gif, image/webp',
+      },
+    });
+  });
+
+  it('rejects oversized files on direct uploads before writing to R2', async () => {
+    const app = createApp();
+    const token = await createAdminToken();
+    const formData = new FormData();
+    formData.append(
+      'file',
+      new File([new Uint8Array(20 * 1024 * 1024 + 1)], 'large.png', { type: 'image/png' })
+    );
+
+    const response = await app.request(
+      'https://example.com/api/v1/images/upload-direct',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        body: formData,
+      },
+      env
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: {
+        message: 'File too large - maximum 20MB allowed',
       },
     });
   });


### PR DESCRIPTION
## Summary
- fail closed when backend/admin auth secrets are missing unless insecure local auth is explicitly enabled
- restrict draft post reads to authorized admins and bypass public cache for authorized or draft-aware requests
- validate image uploads and comment targets more strictly in backend and worker routes, with targeted regression tests

## Testing
- `cd backend && node --test test/auth-guards.test.js test/images-security.test.js test/posts-security.test.js`
- `cd workers/api-gateway && npm test -- test/comments-proxy.test.ts test/images-route.test.ts`

## Risks
- comment post existence checks now depend on `PUBLIC_SITE_URL` serving the published markdown path
- no deployed-environment smoke test was run

## Follow-ups
- none