### PR TITLE
fix(ai): restore deployed Sentio auth flow

### DIFF
--- a/frontend/src/components/features/sentio/hooks/useAsyncArtifact.ts
+++ b/frontend/src/components/features/sentio/hooks/useAsyncArtifact.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export type AsyncArtifactSource = "feed" | "warming" | "fallback";
 
@@ -53,6 +53,7 @@ export function useWarmingRetry({
 }: UseWarmingRetryOptions) {
   const attemptRef = useRef(0);
   const onRetryRef = useRef(onRetry);
+  const [retryTick, setRetryTick] = useState(0);
 
   useEffect(() => {
     onRetryRef.current = onRetry;
@@ -60,6 +61,7 @@ export function useWarmingRetry({
 
   const reset = useCallback(() => {
     attemptRef.current = 0;
+    setRetryTick(tick => tick + 1);
   }, []);
 
   const onExhaustedRef = useRef(onExhausted);
@@ -81,15 +83,21 @@ export function useWarmingRetry({
 
     const delay = delays[attemptRef.current] ?? delays[delays.length - 1] ?? 3000;
 
+    let cancelled = false;
     const timer = window.setTimeout(() => {
       attemptRef.current += 1;
-      void onRetryRef.current();
+      void Promise.resolve(onRetryRef.current()).finally(() => {
+        if (!cancelled) {
+          setRetryTick(tick => tick + 1);
+        }
+      });
     }, delay);
 
     return () => {
+      cancelled = true;
       clearTimeout(timer);
     };
-  }, [delays, enabled, status]);
+  }, [delays, enabled, retryTick, status]);
 
   return { reset };
 }

--- a/frontend/src/components/features/sentio/hooks/useLensDeck.ts
+++ b/frontend/src/components/features/sentio/hooks/useLensDeck.ts
@@ -291,6 +291,21 @@ export function useLensDeck({
     persistCache();
   }, [cards, currentIndex, exhausted, persistCache, source]);
 
+  const applyFallbackCards = useCallback(() => {
+    const mapped = mapPrismFacetsToCards(
+      paragraph,
+      postTitle,
+      FALLBACK_DATA.PRISM.FACETS,
+      'fallback'
+    );
+    setCards(mapped);
+    setCurrentIndex(0);
+    setExhausted(true);
+    setSource('fallback');
+    nextCursorRef.current = null;
+    notifyReady(mapped, 'fallback');
+  }, [notifyReady, paragraph, postTitle]);
+
   const loadInitial = useCallback(
     async (warmingRetry = false) => {
       if (!paragraph.trim()) return;
@@ -385,18 +400,7 @@ export function useLensDeck({
           );
         }
 
-        const mapped = mapPrismFacetsToCards(
-          paragraph,
-          postTitle,
-          FALLBACK_DATA.PRISM.FACETS,
-          'fallback'
-        );
-        setCards(mapped);
-        setCurrentIndex(0);
-        setExhausted(true);
-        setSource('fallback');
-        nextCursorRef.current = null;
-        notifyReady(mapped, 'fallback');
+        applyFallbackCards();
       } finally {
         if (requestId === requestIdRef.current) {
           setLoading(false);
@@ -406,8 +410,58 @@ export function useLensDeck({
         }
       }
     },
-    [notifyReady, paragraph, postTitle]
+    [applyFallbackCards, notifyReady, paragraph, postTitle]
   );
+
+  const recoverAfterWarmingExhausted = useCallback(async () => {
+    if (!paragraph.trim()) {
+      applyFallbackCards();
+      return;
+    }
+
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+    initialAbortRef.current?.abort();
+    const controller = new AbortController();
+    initialAbortRef.current = controller;
+    setLoading(cardsRef.current.length === 0);
+
+    try {
+      const mapped = await loadLensCardsViaTask({
+        paragraph,
+        postTitle,
+        signal: controller.signal,
+      });
+      if (requestId !== requestIdRef.current || controller.signal.aborted) {
+        return;
+      }
+
+      setCards(mapped);
+      setCurrentIndex(0);
+      setExhausted(true);
+      setSource('feed');
+      nextCursorRef.current = null;
+      notifyReady(mapped, 'feed');
+    } catch (error) {
+      if (isAbortError(error) || controller.signal.aborted) {
+        return;
+      }
+      console.warn(
+        '[PrismDeck] warming exhausted; task recovery failed, using local fallback cards',
+        error
+      );
+      if (requestId === requestIdRef.current) {
+        applyFallbackCards();
+      }
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+      if (initialAbortRef.current === controller) {
+        initialAbortRef.current = null;
+      }
+    }
+  }, [applyFallbackCards, notifyReady, paragraph, postTitle]);
 
   const { reset: resetWarmingRetry } = useWarmingRetry({
     enabled:
@@ -421,7 +475,7 @@ export function useLensDeck({
       void loadInitial(true);
     },
     onExhausted: () => {
-      setSource('fallback');
+      void recoverAfterWarmingExhausted();
     },
   });
 

--- a/frontend/src/components/features/sentio/hooks/useThoughtFeed.ts
+++ b/frontend/src/components/features/sentio/hooks/useThoughtFeed.ts
@@ -255,6 +255,18 @@ export function useThoughtFeed({
     persistCache();
   }, [cards, exhausted, persistCache, source]);
 
+  const applyFallbackCards = useCallback(() => {
+    const mapped = mapChainQuestionsToThoughts(
+      FALLBACK_DATA.CHAIN.QUESTIONS,
+      'fallback'
+    );
+    setCards(mapped);
+    setExhausted(true);
+    setSource('fallback');
+    nextCursorRef.current = null;
+    notifyReady(mapped, 'fallback');
+  }, [notifyReady]);
+
   const loadInitial = useCallback(
     async (warmingRetry = false) => {
       if (!paragraph.trim()) return;
@@ -345,15 +357,7 @@ export function useThoughtFeed({
           );
         }
 
-        const mapped = mapChainQuestionsToThoughts(
-          FALLBACK_DATA.CHAIN.QUESTIONS,
-          'fallback'
-        );
-        setCards(mapped);
-        setExhausted(true);
-        setSource('fallback');
-        nextCursorRef.current = null;
-        notifyReady(mapped, 'fallback');
+        applyFallbackCards();
       } finally {
         if (requestId === requestIdRef.current) {
           setLoading(false);
@@ -363,8 +367,57 @@ export function useThoughtFeed({
         }
       }
     },
-    [notifyReady, paragraph, postTitle]
+    [applyFallbackCards, notifyReady, paragraph, postTitle]
   );
+
+  const recoverAfterWarmingExhausted = useCallback(async () => {
+    if (!paragraph.trim()) {
+      applyFallbackCards();
+      return;
+    }
+
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+    initialAbortRef.current?.abort();
+    const controller = new AbortController();
+    initialAbortRef.current = controller;
+    setLoading(cardsRef.current.length === 0);
+
+    try {
+      const mapped = await loadThoughtCardsViaTask({
+        paragraph,
+        postTitle,
+        signal: controller.signal,
+      });
+      if (requestId !== requestIdRef.current || controller.signal.aborted) {
+        return;
+      }
+
+      setCards(mapped);
+      setExhausted(true);
+      setSource('feed');
+      nextCursorRef.current = null;
+      notifyReady(mapped, 'feed');
+    } catch (error) {
+      if (isAbortError(error) || controller.signal.aborted) {
+        return;
+      }
+      console.warn(
+        '[ThoughtFeed] warming exhausted; task recovery failed, using local fallback cards',
+        error
+      );
+      if (requestId === requestIdRef.current) {
+        applyFallbackCards();
+      }
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+      if (initialAbortRef.current === controller) {
+        initialAbortRef.current = null;
+      }
+    }
+  }, [applyFallbackCards, notifyReady, paragraph, postTitle]);
 
   const { reset: resetWarmingRetry } = useWarmingRetry({
     enabled:
@@ -378,7 +431,7 @@ export function useThoughtFeed({
       void loadInitial(true);
     },
     onExhausted: () => {
-      setSource('fallback');
+      void recoverAfterWarmingExhausted();
     },
   });
 

--- a/frontend/src/services/chat/api.ts
+++ b/frontend/src/services/chat/api.ts
@@ -67,6 +67,18 @@ type ChatJsonResponse<T> = {
   raw: unknown;
 };
 
+async function buildAuthenticatedChatHeaders(
+  contentType: "json" | "stream",
+  extraHeaders?: Record<string, string>,
+): Promise<Record<string, string>> {
+  const token = await getPrincipalToken();
+  return {
+    ...buildChatHeaders(contentType),
+    ...bearerAuth(token),
+    ...(extraHeaders ?? {}),
+  };
+}
+
 function getAggregateText(data: ChatAggregateEnvelope["data"]): string | null {
   if (typeof data === "string") {
     return data;
@@ -102,9 +114,7 @@ async function postSessionJson<T>(
   options?: ChatJsonRequestOptions,
 ): Promise<ChatJsonResponse<T>> {
   const url = buildChatUrl(path, sessionId);
-  const headers = buildChatHeaders("json");
-
-  if (options?.headers) Object.assign(headers, options.headers);
+  const headers = await buildAuthenticatedChatHeaders("json", options?.headers);
 
   const res = await fetch(url, {
     method: "POST",
@@ -224,7 +234,7 @@ export async function* streamChatEvents(
   const { page, parts, enableRag } = buildStreamPayload(input);
 
   const url = buildChatUrl("/message", sessionID);
-  const headers = buildChatHeaders("stream");
+  const headers = await buildAuthenticatedChatHeaders("stream");
 
   const res = await fetch(url, {
     method: "POST",
@@ -436,10 +446,11 @@ export async function invokeChatAggregate(input: {
 }): Promise<string> {
   const base = getApiBaseUrl();
   const url = `${base.replace(/\/$/, "")}/api/v1/chat/aggregate`;
+  const headers = await buildAuthenticatedChatHeaders("json");
 
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({ prompt: input.prompt }),
     signal: input.signal,
   });

--- a/frontend/src/services/chat/session.ts
+++ b/frontend/src/services/chat/session.ts
@@ -6,6 +6,8 @@
  * - 모든 세션 관련 상수와 함수를 여기서 관리
  */
 
+import { bearerAuth } from '@/lib/auth';
+import { getPrincipalToken } from '@/services/session/userContentAuth';
 import { buildChatUrl, buildChatHeaders } from './config';
 
 // ============================================================================
@@ -269,10 +271,14 @@ export function setPersistEnabled(enabled: boolean): void {
 export async function createBackendSession(title?: string): Promise<string> {
   const url = buildChatUrl('/session');
   const headers = buildChatHeaders('json');
+  const token = await getPrincipalToken();
 
   const res = await fetch(url, {
     method: 'POST',
-    headers,
+    headers: {
+      ...headers,
+      ...bearerAuth(token),
+    },
     body: JSON.stringify({ title: title || 'Nodove Blog Visitor Session' }),
   });
 

--- a/frontend/src/test/Sentio.feed-cache.warming-baseline.test.tsx
+++ b/frontend/src/test/Sentio.feed-cache.warming-baseline.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FALLBACK_DATA } from '@/config/defaults';
 import { useLensDeck } from '@/components/features/sentio/hooks/useLensDeck';
@@ -188,6 +188,96 @@ describe('sentio feed warming baseline', () => {
     });
     expect(screen.getByTestId('thought-status')).toHaveTextContent('warming');
     expect(screen.getByTestId('thought-cards')).toHaveTextContent('');
+  });
+
+  it('recovers a lens feed that stays warming by using the prism task', async () => {
+    vi.useFakeTimers();
+    vi.mocked(invokeLensFeed).mockResolvedValue({
+      items: [],
+      nextCursor: null,
+      exhausted: false,
+      warming: true,
+      source: 'warming',
+    } satisfies LensFeedResponse);
+    vi.mocked(invokeChatTask).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: {
+        facets: [
+          {
+            title: 'Recovered lens',
+            points: ['Recovered point'],
+          },
+        ],
+      },
+      raw: {},
+    });
+
+    render(<LensStateHarness cacheKey='lens:warming-task' enabled={true} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('lens-source')).toHaveTextContent('warming');
+
+    for (const delay of [1500, 3000, 5000, 8000]) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(delay);
+      });
+    }
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(invokeChatTask).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'prism' })
+    );
+    expect(screen.getByTestId('lens-source')).toHaveTextContent('feed');
+    expect(screen.getByTestId('lens-status')).toHaveTextContent('ready');
+    expect(screen.getByTestId('lens-cards')).toHaveTextContent(
+      'Recovered lens'
+    );
+  });
+
+  it('recovers a thought feed that stays warming by using local fallback when the chain task fails', async () => {
+    vi.useFakeTimers();
+    vi.mocked(invokeThoughtFeed).mockResolvedValue({
+      items: [],
+      nextCursor: null,
+      exhausted: false,
+      warming: true,
+      source: 'warming',
+    } satisfies ThoughtFeedResponse);
+    vi.mocked(invokeChatTask).mockRejectedValueOnce(new Error('chain failed'));
+
+    render(
+      <ThoughtStateHarness cacheKey='thought:warming-fallback' enabled={true} />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('thought-source')).toHaveTextContent('warming');
+
+    for (const delay of [1500, 3000, 5000, 8000]) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(delay);
+      });
+    }
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(invokeChatTask).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'chain' })
+    );
+    expect(screen.getByTestId('thought-source')).toHaveTextContent('fallback');
+    expect(screen.getByTestId('thought-status')).toHaveTextContent(
+      'fallback-hard'
+    );
+    expect(screen.getByTestId('thought-cards')).toHaveTextContent(
+      FALLBACK_DATA.CHAIN.QUESTIONS[0].q
+    );
   });
 
   it('uses locally generated prism fallback cards when the lens request fails', async () => {

--- a/frontend/src/test/chatUploadAuth.test.ts
+++ b/frontend/src/test/chatUploadAuth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/utils/network/apiBase', () => ({
   getApiBaseUrl: () => 'https://api.example.com',
@@ -9,7 +9,12 @@ vi.mock('@/services/session/userContentAuth', () => ({
 }));
 
 describe('chat upload authentication', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   afterEach(() => {
+    localStorage.clear();
     vi.restoreAllMocks();
   });
 
@@ -44,6 +49,66 @@ describe('chat upload authentication', () => {
         headers: {
           Authorization: 'Bearer principal-token',
         },
+      })
+    );
+  });
+
+  it('sends the principal bearer token when creating chat sessions', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, data: { id: 'session-1' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const { createBackendSession } = await import('@/services/chat/session');
+
+    await expect(createBackendSession('Visitor session')).resolves.toBe(
+      'session-1'
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.example.com/api/v1/chat/session',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer principal-token',
+        }),
+      })
+    );
+  });
+
+  it('sends the principal bearer token with chat feed requests', async () => {
+    localStorage.setItem('nodove_chat_session_id', 'session-1');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          data: {
+            items: [],
+            nextCursor: null,
+            exhausted: true,
+            source: 'snapshot',
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const { invokeLensFeed } = await import('@/services/chat/api');
+
+    await invokeLensFeed({ paragraph: 'hello', postTitle: 'debug' });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.example.com/api/v1/chat/session/session-1/lens-feed',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer principal-token',
+        }),
       })
     );
   });

--- a/workers/api-gateway/src/lib/ai-artifact-outbox.ts
+++ b/workers/api-gateway/src/lib/ai-artifact-outbox.ts
@@ -46,6 +46,7 @@ import {
   translateAndCachePost,
   type SupportedTranslationLang,
 } from './translation-service';
+import { attachOriginSignatureHeaders } from './origin-signature';
 
 export const AI_ARTIFACT_STREAM = 'ai.artifact.generate';
 const FEED_SCHEMA_VERSION = '2';
@@ -168,8 +169,19 @@ async function fetchQueueStats(env: Env): Promise<QueueStatsSnapshot> {
   }
 
   try {
-    const response = await fetch(`${env.BACKEND_ORIGIN.replace(/\/$/, '')}/api/v1/ai/queue-stats`, {
-      headers: env.BACKEND_KEY ? { 'X-Backend-Key': env.BACKEND_KEY } : undefined,
+    const url = `${env.BACKEND_ORIGIN.replace(/\/$/, '')}/api/v1/ai/queue-stats`;
+    const headers = new Headers();
+    if (env.BACKEND_KEY) {
+      headers.set('X-Backend-Key', env.BACKEND_KEY);
+    }
+    await attachOriginSignatureHeaders({
+      env,
+      headers,
+      method: 'GET',
+      pathAndQuery: new URL(url).pathname,
+    });
+    const response = await fetch(url, {
+      headers,
     });
     if (!response.ok) {
       throw new Error(`queue stats failed: ${response.status}`);

--- a/workers/api-gateway/src/lib/llm.ts
+++ b/workers/api-gateway/src/lib/llm.ts
@@ -9,6 +9,7 @@ import type { Env } from '../types';
 import type { PromptConfig, TaskMode } from './prompts';
 import { getFallbackData } from './prompts';
 import { getApiBaseUrl, getAiServeApiKey, getAiDefaultModel, getAiVisionModel } from './config';
+import { attachOriginSignatureHeaders } from './origin-signature';
 
 export type LLMRequest = {
   system?: string;
@@ -78,6 +79,21 @@ function toText(value: unknown): string {
     return String(value);
   }
   return '';
+}
+
+async function attachBackendSignature(
+  env: Env,
+  headers: Headers,
+  method: string,
+  url: string
+): Promise<void> {
+  const parsed = new URL(url);
+  await attachOriginSignatureHeaders({
+    env,
+    headers,
+    method,
+    pathAndQuery: `${parsed.pathname}${parsed.search}`,
+  });
 }
 
 function normalizeQuizType(value: unknown): QuizQuestionType {
@@ -445,25 +461,26 @@ async function callBackendAutoChat(
 
   const message = request.system ? `${request.system}\n\n${request.user}` : request.user;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Content-Type': 'application/json',
     Accept: 'application/json',
     'User-Agent': 'Blog-Workers/1.0',
-  };
+  });
 
   // Backend authentication - required for all AI requests
   if (env.BACKEND_KEY) {
-    headers['X-Backend-Key'] = env.BACKEND_KEY;
+    headers.set('X-Backend-Key', env.BACKEND_KEY);
   }
 
   const apiKey = await getAiServeApiKey(env);
   if (apiKey) {
-    headers['X-API-KEY'] = apiKey;
+    headers.set('X-API-KEY', apiKey);
   }
   const forcedModel = await getAiDefaultModel(env);
   if (forcedModel) {
-    headers['X-AI-Model'] = forcedModel;
+    headers.set('X-AI-Model', forcedModel);
   }
+  await attachBackendSignature(env, headers, 'POST', url);
 
   try {
     const res = await fetch(url, {
@@ -527,29 +544,30 @@ async function callBackendGenerate(
 
   const fullPrompt = request.system ? `${request.system}\n\n${request.user}` : request.user;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Content-Type': 'application/json',
     'User-Agent': 'Blog-Workers/1.0',
-  };
+  });
 
   if (env.BACKEND_KEY) {
-    headers['X-Backend-Key'] = env.BACKEND_KEY;
+    headers.set('X-Backend-Key', env.BACKEND_KEY);
   }
 
   const apiKey = await getAiServeApiKey(env);
   if (apiKey) {
-    headers['X-API-KEY'] = apiKey;
+    headers.set('X-API-KEY', apiKey);
   }
   const [forcedModel, forcedVisionModel] = await Promise.all([
     getAiDefaultModel(env),
     getAiVisionModel(env),
   ]);
   if (forcedModel) {
-    headers['X-AI-Model'] = forcedModel;
+    headers.set('X-AI-Model', forcedModel);
   }
   if (forcedVisionModel) {
-    headers['X-AI-Vision-Model'] = forcedVisionModel;
+    headers.set('X-AI-Vision-Model', forcedVisionModel);
   }
+  await attachBackendSignature(env, headers, 'POST', url);
 
   try {
     const res = await fetch(url, {

--- a/workers/api-gateway/test/auth-state-repository.test.ts
+++ b/workers/api-gateway/test/auth-state-repository.test.ts
@@ -20,8 +20,14 @@ declare module 'cloudflare:test' {
   }
 }
 
+const TEST_EPOCH = new Date(Date.now() + 60_000);
+
+function testIso(minutesFromEpoch: number): string {
+  return new Date(TEST_EPOCH.getTime() + minutesFromEpoch * 60_000).toISOString();
+}
+
 function buildRefreshRecord(overrides: Partial<RefreshTokenRecord> = {}): RefreshTokenRecord {
-  const now = overrides.createdAt ? new Date(overrides.createdAt) : new Date('2026-04-23T00:00:00.000Z');
+  const now = overrides.createdAt ? new Date(overrides.createdAt) : TEST_EPOCH;
   return {
     jti: overrides.jti ?? `refresh-${crypto.randomUUID()}`,
     familyId: overrides.familyId ?? `family-${crypto.randomUUID()}`,
@@ -47,12 +53,12 @@ describe('auth-state-repository', () => {
     const current = buildRefreshRecord({
       jti: 'refresh-current',
       familyId: 'family-cas',
-      createdAt: '2026-04-23T00:00:00.000Z',
+      createdAt: testIso(0),
     });
     const replacement = buildRefreshRecord({
       jti: 'refresh-next',
       familyId: current.familyId,
-      createdAt: '2026-04-23T00:01:00.000Z',
+      createdAt: testIso(1),
     });
 
     await createRefreshTokenRecord(env.DB, current);
@@ -61,7 +67,7 @@ describe('auth-state-repository', () => {
       currentJti: current.jti,
       familyId: current.familyId,
       replacement,
-      rotatedAt: '2026-04-23T00:01:00.000Z',
+      rotatedAt: testIso(1),
     });
     expect(first.ok).toBe(true);
 
@@ -71,9 +77,9 @@ describe('auth-state-repository', () => {
       replacement: buildRefreshRecord({
         jti: 'refresh-replay',
         familyId: current.familyId,
-        createdAt: '2026-04-23T00:02:00.000Z',
+        createdAt: testIso(2),
       }),
-      rotatedAt: '2026-04-23T00:02:00.000Z',
+      rotatedAt: testIso(2),
     });
     expect(replay.ok).toBe(false);
     if (!replay.ok) {
@@ -95,14 +101,14 @@ describe('auth-state-repository', () => {
       reason: 'reuse-detected',
       lastJti: current.jti,
       expiresAt: current.expiresAt,
-      revokedAt: '2026-04-23T00:03:00.000Z',
+      revokedAt: testIso(3),
     });
 
     const rotation = await rotateRefreshTokenCas(env.DB, {
       currentJti: current.jti,
       familyId: current.familyId,
       replacement: buildRefreshRecord({ jti: 'refresh-after-revoke', familyId: current.familyId }),
-      rotatedAt: '2026-04-23T00:04:00.000Z',
+      rotatedAt: testIso(4),
     });
 
     expect(rotation.ok).toBe(false);

--- a/workers/api-gateway/test/llm-backend-signature.test.ts
+++ b/workers/api-gateway/test/llm-backend-signature.test.ts
@@ -1,0 +1,58 @@
+import { env } from 'cloudflare:test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Env } from '../src/types';
+import { callTaskLLM } from '../src/lib/llm';
+
+declare module 'cloudflare:test' {
+  interface ProvidedEnv
+    extends Pick<
+      Env,
+      'BACKEND_ORIGIN' | 'BACKEND_KEY' | 'GATEWAY_SIGNING_SECRET' | 'AI_DEFAULT_MODEL'
+    > {}
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  env.BACKEND_ORIGIN = 'https://backend.example';
+  env.BACKEND_KEY = 'test-backend-key';
+  env.GATEWAY_SIGNING_SECRET = 'test-signing-secret';
+  env.AI_DEFAULT_MODEL = undefined;
+});
+
+describe('backend LLM origin signature', () => {
+  it('signs direct backend generate calls from worker-native AI tasks', async () => {
+    env.BACKEND_ORIGIN = 'https://backend.example';
+    env.BACKEND_KEY = 'test-backend-key';
+    env.GATEWAY_SIGNING_SECRET = 'test-signing-secret';
+
+    const upstreamFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ text: '{"items":[]}' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await callTaskLLM(
+      {
+        system: 'system prompt',
+        user: 'user prompt',
+        temperature: 0.2,
+        maxTokens: 64,
+      },
+      env
+    );
+
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+    const [upstreamUrl, requestInit] = upstreamFetch.mock.calls[0] ?? [];
+    const headers = new Headers(requestInit?.headers);
+
+    expect(upstreamUrl).toBe('https://backend.example/api/v1/ai/generate');
+    expect(headers.get('X-Backend-Key')).toBe('test-backend-key');
+    expect(headers.get('X-Origin-Verified-By')).toBe('api-gateway');
+    expect(headers.get('X-Gateway-Signature-Version')).toBe('v1');
+    expect(headers.get('X-Gateway-Timestamp')).toBeTruthy();
+    expect(headers.get('X-Gateway-Request-ID')).toBeTruthy();
+    expect(headers.get('X-Gateway-Signature')).toMatch(/^v1:[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
## Summary
- Restore deployed Sentio AI calls by attaching the principal bearer token to chat/session JSON, streaming, aggregate, lens-feed, and thought-feed requests.
- Add backend origin signatures to direct Worker -> backend AI paths and queue-stats calls so protected backend routes accept Cloudflare Worker traffic.
- Improve warming recovery for lens/thought feeds with chained retries, task recovery, and local fallback cards when async artifacts stay warming.
- Stabilize the refresh auth-state Worker test by using non-expired test timestamps.

## Testing
- `frontend`: targeted Sentio/chat auth tests passed.
- `frontend`: `npm run type-check`, focused ESLint, and production build passed.
- `workers/api-gateway`: targeted signature/warming/proxy tests passed.
- `workers/api-gateway`: full `npm run test` passed after test timestamp stabilization.
- `workers/api-gateway`: `npm run typecheck` passed.
- GitHub Actions: Deploy to GitHub Pages succeeded in run `25182244867`.
- GitHub Actions: Deploy Cloudflare Workers succeeded in run `25182408709`.
- Live smoke: authenticated `/task`, `/lens-feed`, and `/thought-feed` returned `200`; lens/thought returned snapshot items.

## Risks
- Production correctness depends on Cloudflare Worker `GATEWAY_SIGNING_SECRET` staying synchronized with the backend k3s secret.
- Initial feed calls can still briefly return warming while artifacts are generated; frontend now retries and falls back instead of staying broken.

## Follow-ups
- Add `GATEWAY_SIGNING_SECRET` to the durable GitHub Actions secret inventory so future Worker secret syncs do not require a one-off operation.
