### PR TITLE
Fix launch readiness and chat turn safety

### DIFF
--- a/.gh_env.example
+++ b/.gh_env.example
@@ -32,7 +32,9 @@ VITE_FEATURE_FAB=true
 # -----------------------------------------------------------------------------
 BACKEND_ORIGIN=https://blog-b.nodove.com
 BACKEND_KEY=
+GATEWAY_SIGNING_SECRET=
 JWT_SECRET=
+SECRETS_ENCRYPTION_KEY=
 INTERNAL_KEY=
 TERMINAL_SESSION_SECRET=
 

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -67,6 +67,46 @@ jobs:
         working-directory: workers/${{ matrix.path }}
         run: npm run test
 
+      - name: Verify production worker secrets
+        if: ${{ matrix.hasSecrets }}
+        working-directory: workers/${{ matrix.path }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          REQUIRED_SECRETS_JSON: ${{ toJson(matrix.requiredSecrets) }}
+        run: |
+          npx wrangler secret list --env production --format json > /tmp/worker-secrets.json
+          node <<'NODE'
+          const fs = require('node:fs');
+          const required = JSON.parse(process.env.REQUIRED_SECRETS_JSON || '[]');
+          const listed = JSON.parse(fs.readFileSync('/tmp/worker-secrets.json', 'utf8'));
+          const names = new Set(listed.map((item) => item.name));
+          const missing = required.filter((name) => !names.has(name));
+          if (missing.length > 0) {
+            console.error(`Missing production Worker secrets: ${missing.join(', ')}`);
+            process.exit(1);
+          }
+          NODE
+
+      - name: Apply production D1 migrations
+        if: ${{ matrix.id == 'api-gateway' }}
+        working-directory: workers/${{ matrix.path }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npm run migrations:apply:prod
+
+      - name: Verify production D1 schema
+        if: ${{ matrix.id == 'api-gateway' }}
+        working-directory: workers/${{ matrix.path }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler d1 execute blog-db-prod --env production --remote --command "SELECT session_token_hash FROM user_sessions LIMIT 0"
+          npx wrangler d1 execute blog-db-prod --env production --remote --command "SELECT key, markdown FROM site_content_blocks LIMIT 0"
+          npx wrangler d1 execute blog-db-prod --env production --remote --command "SELECT scope, idempotency_key FROM idempotency_records LIMIT 0"
+
       - name: Deploy worker
         working-directory: workers/${{ matrix.path }}
         env:

--- a/.github/workflows/sync-workers-secrets.yml
+++ b/.github/workflows/sync-workers-secrets.yml
@@ -56,7 +56,9 @@ jobs:
           OPTIONAL_SECRETS_JSON: ${{ toJson(matrix.optionalSecrets) }}
           BACKEND_ORIGIN: ${{ secrets.BACKEND_ORIGIN }}
           BACKEND_KEY: ${{ secrets.BACKEND_KEY }}
+          GATEWAY_SIGNING_SECRET: ${{ secrets.GATEWAY_SIGNING_SECRET }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          SECRETS_ENCRYPTION_KEY: ${{ secrets.SECRETS_ENCRYPTION_KEY }}
           INTERNAL_KEY: ${{ secrets.INTERNAL_KEY }}
           TERMINAL_SESSION_SECRET: ${{ secrets.TERMINAL_SESSION_SECRET }}
           ADMIN_ALLOWED_EMAILS: ${{ secrets.ADMIN_ALLOWED_EMAILS }}

--- a/backend/src/lib/idempotency.js
+++ b/backend/src/lib/idempotency.js
@@ -194,6 +194,27 @@ async function releaseRecord(scope, key, requestHash) {
   );
 }
 
+export async function claimIdempotencyRecord(scope, key, requestPayload, options = {}) {
+  const requestHash = hashIdempotencyPayload(requestPayload);
+  const claim = await claimRecord(scope, key, requestHash, options);
+  return { ...claim, requestHash };
+}
+
+export async function storeIdempotencyRecord(
+  scope,
+  key,
+  requestHash,
+  statusCode,
+  response,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+) {
+  return storeRecord(scope, key, requestHash, statusCode, response, ttlSeconds);
+}
+
+export async function releaseIdempotencyRecord(scope, key, requestHash) {
+  return releaseRecord(scope, key, requestHash);
+}
+
 export async function runIdempotent(req, res, scope, requestPayload, handler, options = {}) {
   const key = getIdempotencyKey(req);
   if (!key) {

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -32,6 +32,7 @@ import {
   deriveUserQuery,
   getLiveContextForSession,
   setPerformRAGSearch,
+  claimSessionTurn,
 } from "../services/session.service.js";
 
 import {
@@ -76,6 +77,12 @@ import {
   streamWithFallback,
   finalizeChatTurn,
 } from "../lib/chat-streaming.js";
+import {
+  claimIdempotencyRecord,
+  getIdempotencyKey,
+  releaseIdempotencyRecord,
+  storeIdempotencyRecord,
+} from "../lib/idempotency.js";
 
 const router = Router();
 const {
@@ -103,6 +110,88 @@ const CHAT_RESPONSE_TIMEOUT_MS = Math.max(
   5_000,
   Number.parseInt(process.env.CHAT_RESPONSE_TIMEOUT_MS || "45000", 10),
 );
+const CHAT_IDEMPOTENCY_TTL_SECONDS = Math.max(
+  60,
+  Number.parseInt(process.env.CHAT_IDEMPOTENCY_TTL_SECONDS || `${24 * 60 * 60}`, 10),
+);
+const CHAT_TURN_LOCK_SECONDS = Math.max(
+  5,
+  Math.ceil(CHAT_RESPONSE_TIMEOUT_MS / 1000) + 15,
+);
+const CHAT_TURN_RETRY_AFTER_SECONDS = 3;
+
+function setIdempotencyHeaders(res, key, replayed = false) {
+  if (!key) return;
+  res.setHeader("Idempotency-Key", key);
+  if (replayed) {
+    res.setHeader("Idempotency-Replayed", "true");
+  }
+}
+
+function sendConflict(res, code, message, extraHeaders = {}) {
+  for (const [name, value] of Object.entries(extraHeaders)) {
+    res.setHeader(name, value);
+  }
+  return res.status(409).json({
+    ok: false,
+    error: { code, message },
+  });
+}
+
+function writeSseHeaders(res, extraHeaders = {}) {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    "X-Accel-Buffering": "no",
+    ...extraHeaders,
+  });
+}
+
+function writeSseEvent(res, data) {
+  const payload = typeof data === "string" ? data : JSON.stringify(data);
+  res.write(`data: ${payload}\n\n`);
+}
+
+async function replayCachedChatTurn(res, idempotencyKey, cachedResponse) {
+  writeSseHeaders(res, {
+    "Idempotency-Key": idempotencyKey,
+    "Idempotency-Replayed": "true",
+  });
+
+  let closed = false;
+  res.on("close", () => {
+    closed = true;
+  });
+
+  if (cachedResponse?.sessionId) {
+    writeSseEvent(res, { type: "session", sessionId: cachedResponse.sessionId });
+  }
+  if (Array.isArray(cachedResponse?.sources) && cachedResponse.sources.length > 0) {
+    writeSseEvent(res, { type: "sources", sources: cachedResponse.sources });
+  }
+  if (typeof cachedResponse?.text === "string" && cachedResponse.text) {
+    await emitTextChunks({
+      text: cachedResponse.text,
+      chunkSize: STREAMING.CHUNK_SIZE,
+      chunkDelayMs: 0,
+      isClosed: () => closed,
+      sendChunk: (piece) => writeSseEvent(res, { type: "text", text: piece }),
+    });
+  }
+
+  if (cachedResponse?.error) {
+    writeSseEvent(res, {
+      type: "error",
+      message: cachedResponse.error.message || "Chat failed",
+      code: cachedResponse.error.code,
+    });
+  } else {
+    writeSseEvent(res, { type: "done" });
+  }
+
+  res.end();
+}
 
 function timingSafeEqualString(a, b) {
   if (typeof a !== "string" || typeof b !== "string") return false;
@@ -378,25 +467,15 @@ router.post("/session", async (req, res, next) => {
  * Send chat message (SSE streaming)
  */
 router.post("/session/:sessionId/message", async (req, res, next) => {
+  let turnClaim = null;
+  let effectiveTurnClaim = null;
+  let idempotencyClaim = null;
+  let sideEffectStarted = false;
+
   try {
     const { sessionId } = req.params;
     const { parts, context, enableRag } = req.body || {};
     const forcedModel = resolveChatModel(req);
-    let effectiveSessionId = sessionId;
-
-    // Get or create session
-    let session = getSession(sessionId);
-    if (!session) {
-      effectiveSessionId = createSession();
-      session = getSession(effectiveSessionId);
-      if (openNotebook.isEnabled()) {
-        void ensureSessionNotebook(effectiveSessionId).catch((err) => {
-          logger.warn({}, "Session notebook bootstrap failed", {
-            error: err?.message,
-          });
-        });
-      }
-    }
 
     // Extract text from parts
     const partContext = extractPartContext(parts);
@@ -413,27 +492,134 @@ router.post("/session/:sessionId/message", async (req, res, next) => {
       userMessage = `${serializedPageContext}\n\n${userMessage}`;
     }
 
+    const idempotencyKey = getIdempotencyKey(req);
+    const idempotencyScope = `chat.message:${sessionId}`;
+    const idempotencyPayload = {
+      sessionId,
+      parts: parts ?? null,
+      context: context ?? null,
+      enableRag: enableRag === true,
+      model: forcedModel,
+    };
+
+    if (idempotencyKey) {
+      const claim = await claimIdempotencyRecord(
+        idempotencyScope,
+        idempotencyKey,
+        idempotencyPayload,
+        {
+          ttlSeconds: CHAT_IDEMPOTENCY_TTL_SECONDS,
+          lockSeconds: CHAT_TURN_LOCK_SECONDS,
+        },
+      );
+
+      if (claim.conflict) {
+        return sendConflict(
+          res,
+          "IDEMPOTENCY_KEY_REUSED",
+          "Idempotency-Key was reused with a different chat message payload",
+          { "Idempotency-Key": idempotencyKey },
+        );
+      }
+      if (claim.cached) {
+        return replayCachedChatTurn(res, idempotencyKey, claim.cached.response);
+      }
+      if (claim.inProgress) {
+        return sendConflict(
+          res,
+          "IDEMPOTENCY_IN_PROGRESS",
+          "A chat message with this Idempotency-Key is already in progress",
+          {
+            "Idempotency-Key": idempotencyKey,
+            "Retry-After": String(CHAT_TURN_RETRY_AFTER_SECONDS),
+          },
+        );
+      }
+
+      idempotencyClaim = {
+        key: idempotencyKey,
+        scope: idempotencyScope,
+        requestHash: claim.requestHash,
+      };
+      setIdempotencyHeaders(res, idempotencyKey);
+    }
+
+    turnClaim = claimSessionTurn(sessionId, {
+      idempotencyKey: idempotencyKey || null,
+      ttlMs: CHAT_TURN_LOCK_SECONDS * 1000,
+    });
+    if (!turnClaim.claimed) {
+      if (idempotencyClaim) {
+        await releaseIdempotencyRecord(
+          idempotencyClaim.scope,
+          idempotencyClaim.key,
+          idempotencyClaim.requestHash,
+        );
+        idempotencyClaim = null;
+      }
+      return sendConflict(
+        res,
+        "CHAT_TURN_IN_PROGRESS",
+        "Another chat turn is already in progress for this session",
+        { "Retry-After": String(CHAT_TURN_RETRY_AFTER_SECONDS) },
+      );
+    }
+
+    let effectiveSessionId = sessionId;
+
+    // Get or create session
+    let session = getSession(sessionId);
+    if (!session) {
+      effectiveSessionId = createSession();
+      session = getSession(effectiveSessionId);
+      effectiveTurnClaim = claimSessionTurn(effectiveSessionId, {
+        requestedSessionId: sessionId,
+        idempotencyKey: idempotencyKey || null,
+        ttlMs: CHAT_TURN_LOCK_SECONDS * 1000,
+      });
+      if (!effectiveTurnClaim.claimed) {
+        if (idempotencyClaim) {
+          await releaseIdempotencyRecord(
+            idempotencyClaim.scope,
+            idempotencyClaim.key,
+            idempotencyClaim.requestHash,
+          );
+          idempotencyClaim = null;
+        }
+        turnClaim?.release?.();
+        turnClaim = null;
+        return sendConflict(
+          res,
+          "CHAT_TURN_IN_PROGRESS",
+          "Another chat turn is already in progress for this session",
+          { "Retry-After": String(CHAT_TURN_RETRY_AFTER_SECONDS) },
+        );
+      }
+      if (openNotebook.isEnabled()) {
+        void ensureSessionNotebook(effectiveSessionId).catch((err) => {
+          logger.warn({}, "Session notebook bootstrap failed", {
+            error: err?.message,
+          });
+        });
+      }
+    }
+
     // Store message
     session.lastActivityAt = Date.now();
     session.messages.push({ role: "user", content: userMessage });
+    sideEffectStarted = true;
 
     // Set up SSE
-    res.writeHead(200, {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache, no-transform",
-      Connection: "keep-alive",
-      "X-Accel-Buffering": "no",
-    });
+    writeSseHeaders(res);
 
     const send = (data) => {
-      const payload = typeof data === "string" ? data : JSON.stringify(data);
-      res.write(`data: ${payload}\n\n`);
+      writeSseEvent(res, data);
     };
 
     send({ type: "session", sessionId: effectiveSessionId });
 
     let closed = false;
-    req.on("close", () => {
+    res.on("close", () => {
       closed = true;
     });
 
@@ -442,6 +628,10 @@ router.post("/session/:sessionId/message", async (req, res, next) => {
         send({ type: "heartbeat", ts: Date.now() });
       }
     }, 15000);
+
+    let emittedText = "";
+    let replaySources = [];
+    let idempotencyStored = false;
 
     try {
       const userQuery = deriveUserQuery(parts, userMessage);
@@ -457,6 +647,7 @@ router.post("/session/:sessionId/message", async (req, res, next) => {
         });
 
       if (ragSources.length > 0) {
+        replaySources = ragSources;
         send({ type: "sources", sources: ragSources });
       }
 
@@ -493,7 +684,10 @@ router.post("/session/:sessionId/message", async (req, res, next) => {
         chunkSize: STREAMING.CHUNK_SIZE,
         chunkDelayMs: STREAMING.CHUNK_DELAY,
         isClosed: () => closed,
-        sendChunk: (piece) => send({ type: "text", text: piece }),
+        sendChunk: (piece) => {
+          emittedText += piece;
+          send({ type: "text", text: piece });
+        },
       });
 
       if (!text.trim()) {
@@ -510,14 +704,79 @@ router.post("/session/:sessionId/message", async (req, res, next) => {
       });
 
       send({ type: "done" });
+      if (idempotencyClaim) {
+        try {
+          await storeIdempotencyRecord(
+            idempotencyClaim.scope,
+            idempotencyClaim.key,
+            idempotencyClaim.requestHash,
+            200,
+            {
+              type: "chat.sse",
+              sessionId: effectiveSessionId,
+              text,
+              sources: replaySources,
+            },
+            CHAT_IDEMPOTENCY_TTL_SECONDS,
+          );
+          idempotencyStored = true;
+        } catch (storeError) {
+          logger.error({}, "Failed to cache chat idempotency response", {
+            error: storeError?.message,
+          });
+        }
+      }
     } catch (err) {
       logger.error({}, "Chat streaming error", { error: err.message });
-      send({ type: "error", error: err.message || "Chat failed" });
+      const message = err.message || "Chat failed";
+      send({ type: "error", error: message, message });
+      if (idempotencyClaim) {
+        try {
+          await storeIdempotencyRecord(
+            idempotencyClaim.scope,
+            idempotencyClaim.key,
+            idempotencyClaim.requestHash,
+            200,
+            {
+              type: "chat.sse",
+              sessionId: effectiveSessionId,
+              text: emittedText,
+              sources: replaySources,
+              error: { code: "CHAT_STREAM_FAILED", message },
+            },
+            CHAT_IDEMPOTENCY_TTL_SECONDS,
+          );
+          idempotencyStored = true;
+        } catch (storeError) {
+          logger.error({}, "Failed to cache chat idempotency error response", {
+            error: storeError?.message,
+          });
+        }
+      }
+    } finally {
+      if (idempotencyClaim && !idempotencyStored && !sideEffectStarted) {
+        await releaseIdempotencyRecord(
+          idempotencyClaim.scope,
+          idempotencyClaim.key,
+          idempotencyClaim.requestHash,
+        );
+      }
+      effectiveTurnClaim?.release?.();
+      turnClaim?.release?.();
     }
 
     clearInterval(heartbeatInterval);
     res.end();
   } catch (err) {
+    if (idempotencyClaim && !sideEffectStarted) {
+      await releaseIdempotencyRecord(
+        idempotencyClaim.scope,
+        idempotencyClaim.key,
+        idempotencyClaim.requestHash,
+      );
+    }
+    effectiveTurnClaim?.release?.();
+    turnClaim?.release?.();
     return next(err);
   }
 });

--- a/backend/src/services/session.service.js
+++ b/backend/src/services/session.service.js
@@ -20,6 +20,7 @@ const logger = createLogger("session");
 
 const sessions = new Map();
 const notebookBootstrapJobs = new Map();
+const sessionTurnLocks = new Map();
 let postsCorpusCache = null;
 
 // ---------------------------------------------------------------------------
@@ -37,6 +38,12 @@ const sessionGcInterval = setInterval(() => {
     if (now - lastActivity > SESSION_TTL_MS) {
       sessions.delete(id);
       notebookBootstrapJobs.delete(id);
+      sessionTurnLocks.delete(id);
+    }
+  }
+  for (const [id, lock] of sessionTurnLocks) {
+    if (Number.isFinite(lock?.expiresAt) && lock.expiresAt <= now) {
+      sessionTurnLocks.delete(id);
     }
   }
 }, SESSION_GC_INTERVAL_MS);
@@ -102,6 +109,52 @@ export function createSession(title = "") {
 
 export function getSession(sessionId) {
   return sessions.get(sessionId);
+}
+
+export function claimSessionTurn(sessionId, metadata = {}) {
+  const key = String(sessionId || "").trim();
+  if (!key) {
+    return { claimed: false, reason: "missing_session_id" };
+  }
+
+  const now = Date.now();
+  const existing = sessionTurnLocks.get(key);
+  if (existing) {
+    if (Number.isFinite(existing.expiresAt) && existing.expiresAt <= now) {
+      sessionTurnLocks.delete(key);
+    } else {
+      return { claimed: false, lock: existing };
+    }
+  }
+
+  const ttlMs = Number.isFinite(metadata.ttlMs)
+    ? Math.max(1, Number(metadata.ttlMs))
+    : null;
+  const lockMetadata = { ...metadata };
+  delete lockMetadata.ttlMs;
+
+  const lock = {
+    id: `turn-${now}-${Math.random().toString(36).slice(2, 8)}`,
+    sessionId: key,
+    startedAt: now,
+    expiresAt: ttlMs ? now + ttlMs : null,
+    ...lockMetadata,
+  };
+  sessionTurnLocks.set(key, lock);
+
+  return {
+    claimed: true,
+    lock,
+    release() {
+      if (sessionTurnLocks.get(key) === lock) {
+        sessionTurnLocks.delete(key);
+      }
+    },
+  };
+}
+
+export function isSessionTurnInProgress(sessionId) {
+  return sessionTurnLocks.has(String(sessionId || "").trim());
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/test/chat-idempotency-concurrency.test.js
+++ b/backend/test/chat-idempotency-concurrency.test.js
@@ -1,0 +1,215 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import express from "express";
+
+const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "blog-chat-idem-"));
+const migrationsDir = path.join(tempRoot, "migrations");
+await fs.mkdir(migrationsDir, { recursive: true });
+
+process.env.APP_ENV = process.env.APP_ENV || "test";
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || "gpt-4.1-mini";
+process.env.OPEN_NOTEBOOK_ENABLED = "false";
+process.env.SQLITE_PATH = path.join(tempRoot, "idempotency.sqlite");
+process.env.SQLITE_MIGRATIONS_DIR = migrationsDir;
+process.env.CHAT_RESPONSE_TIMEOUT_MS = "5000";
+process.env.CHAT_IDEMPOTENCY_TTL_SECONDS = "3600";
+
+const [{ default: chatRouter }, { aiService }, sessionService] = await Promise.all([
+  import("../src/routes/chat.js"),
+  import("../src/lib/ai-service.js"),
+  import("../src/services/session.service.js"),
+]);
+
+after(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/chat", chatRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err?.status || 500).json({
+      ok: false,
+      error: err?.message || "Unhandled test error",
+    });
+  });
+  return app;
+}
+
+async function withServer(t, callback) {
+  const server = http.createServer(createApp());
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  t.after(async () => {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  return callback(`http://127.0.0.1:${address.port}`);
+}
+
+function installAiStub(t, implementation) {
+  const originalStreamChat = aiService.streamChat;
+  const originalChat = aiService.chat;
+  const calls = [];
+
+  aiService.streamChat = async function* streamChatStub(messages, options = {}) {
+    calls.push({ messages, options });
+    yield* implementation(messages, options);
+  };
+  aiService.chat = async () => ({ text: "fallback response" });
+
+  t.after(() => {
+    aiService.streamChat = originalStreamChat;
+    aiService.chat = originalChat;
+  });
+
+  return calls;
+}
+
+function buildBody(text) {
+  return {
+    parts: [{ type: "text", purpose: "user", text }],
+    context: { page: { title: "Chat test", url: "https://example.test/chat" } },
+    enableRag: false,
+  };
+}
+
+async function postChat(baseUrl, sessionId, body, headers = {}) {
+  return fetch(
+    `${baseUrl}/api/v1/chat/session/${encodeURIComponent(sessionId)}/message`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+        ...headers,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+async function readSseEvents(response) {
+  const body = await response.text();
+  return body
+    .split(/\r?\n\r?\n/)
+    .map((frame) => frame.trim())
+    .filter(Boolean)
+    .map((frame) => frame.replace(/^data:\s?/gm, ""))
+    .map((data) => JSON.parse(data));
+}
+
+test("chat message idempotency replays a completed SSE turn without a second AI call", async (t) => {
+  const calls = installAiStub(t, async function* () {
+    yield "cached answer";
+  });
+
+  await withServer(t, async (baseUrl) => {
+    const sessionId = sessionService.createSession("idempotency-test");
+    const body = buildBody("Explain idempotency");
+    const headers = { "Idempotency-Key": "chat-turn-idem-1" };
+
+    const first = await postChat(baseUrl, sessionId, body, headers);
+    assert.equal(first.status, 200);
+    const firstEvents = await readSseEvents(first);
+    assert.deepEqual(
+      firstEvents.filter((event) => event.type === "text").map((event) => event.text),
+      ["cached answer"],
+    );
+
+    const sessionAfterFirst = sessionService.getSession(sessionId);
+    assert.equal(sessionAfterFirst.messages.length, 2);
+    assert.equal(calls.length, 1);
+
+    const replay = await postChat(baseUrl, sessionId, body, headers);
+    assert.equal(replay.status, 200);
+    assert.equal(replay.headers.get("idempotency-replayed"), "true");
+    const replayEvents = await readSseEvents(replay);
+
+    assert.deepEqual(
+      replayEvents.filter((event) => event.type === "text").map((event) => event.text),
+      ["cached answer"],
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(sessionAfterFirst.messages.length, 2);
+  });
+});
+
+test("chat idempotency rejects reused keys with different payloads", async (t) => {
+  installAiStub(t, async function* () {
+    yield "first answer";
+  });
+
+  await withServer(t, async (baseUrl) => {
+    const sessionId = sessionService.createSession("idempotency-conflict-test");
+    const headers = { "Idempotency-Key": "chat-turn-idem-conflict" };
+
+    const first = await postChat(baseUrl, sessionId, buildBody("original"), headers);
+    assert.equal(first.status, 200);
+    await first.text();
+
+    const conflict = await postChat(baseUrl, sessionId, buildBody("changed"), headers);
+    assert.equal(conflict.status, 409);
+    assert.deepEqual(await conflict.json(), {
+      ok: false,
+      error: {
+        code: "IDEMPOTENCY_KEY_REUSED",
+        message: "Idempotency-Key was reused with a different chat message payload",
+      },
+    });
+  });
+});
+
+test("chat session turn lock rejects concurrent requests for the same session", async (t) => {
+  let releaseStream;
+  const streamGate = new Promise((resolve) => {
+    releaseStream = resolve;
+  });
+  const calls = installAiStub(t, async function* () {
+    await streamGate;
+    yield "serialized answer";
+  });
+
+  await withServer(t, async (baseUrl) => {
+    const sessionId = sessionService.createSession("concurrency-test");
+
+    const first = await postChat(baseUrl, sessionId, buildBody("first"));
+    assert.equal(first.status, 200);
+
+    const second = await postChat(baseUrl, sessionId, buildBody("second"));
+    assert.equal(second.status, 409);
+    assert.equal(second.headers.get("retry-after"), "3");
+    assert.deepEqual(await second.json(), {
+      ok: false,
+      error: {
+        code: "CHAT_TURN_IN_PROGRESS",
+        message: "Another chat turn is already in progress for this session",
+      },
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(sessionService.getSession(sessionId).messages.length, 1);
+
+    releaseStream();
+    const firstEvents = await readSseEvents(first);
+    assert.deepEqual(
+      firstEvents.filter((event) => event.type === "text").map((event) => event.text),
+      ["serialized answer"],
+    );
+    assert.equal(sessionService.getSession(sessionId).messages.length, 2);
+  });
+});

--- a/docs/generated/contracts/architecture-contracts.json
+++ b/docs/generated/contracts/architecture-contracts.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-14T17:56:51.307Z",
+  "generatedAt": "2026-05-01T12:17:04.135Z",
   "serviceBoundaries": [
     {
       "id": "auth",
@@ -152,6 +152,12 @@
       "description": "Edge-authenticated notification ingress with backend-origin streaming/history handlers"
     },
     {
+      "id": "site-content",
+      "prefix": "/api/v1/site-content",
+      "owner": "worker-owned",
+      "description": "D1-backed public and admin-managed site content blocks"
+    },
+    {
       "id": "gateway",
       "prefix": "/api/v1/gateway",
       "owner": "worker-owned",
@@ -204,6 +210,12 @@
       "prefix": "/api/v1/healthz",
       "owner": "proxy-only",
       "description": "Origin health check exposure through edge"
+    },
+    {
+      "id": "readiness",
+      "prefix": "/api/v1/readiness",
+      "owner": "proxy-only",
+      "description": "Origin readiness check exposure through edge"
     },
     {
       "id": "health",
@@ -362,7 +374,9 @@
       "requiredSecrets": [
         "BACKEND_ORIGIN",
         "BACKEND_KEY",
-        "JWT_SECRET"
+        "GATEWAY_SIGNING_SECRET",
+        "JWT_SECRET",
+        "SECRETS_ENCRYPTION_KEY"
       ]
     },
     {

--- a/docs/generated/route-governance.snapshot.json
+++ b/docs/generated/route-governance.snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-28T18:59:38.359Z",
+  "generatedAt": "2026-05-01T12:17:03.996Z",
   "counts": {
     "serviceBoundaries": {
       "worker-owned": 27,
@@ -493,7 +493,9 @@
       "requiredSecrets": [
         "BACKEND_ORIGIN",
         "BACKEND_KEY",
-        "JWT_SECRET"
+        "GATEWAY_SIGNING_SECRET",
+        "JWT_SECRET",
+        "SECRETS_ENCRYPTION_KEY"
       ]
     },
     {

--- a/docs/operations/release-rollback-runbook.md
+++ b/docs/operations/release-rollback-runbook.md
@@ -1,0 +1,120 @@
+# Release Rollback Runbook
+
+이 문서는 `Preflight -> Launchable -> Committed` 전환 중 고객 영향이 확인될 때
+`Committed -> Rollback`을 실행하기 위한 절차입니다. destructive DB rollback은 기본값이
+아니며, 먼저 이전 code target으로 되돌릴 수 있는지 확인합니다.
+
+## Release Record
+
+출시 전에 아래 값을 release ticket에 기록합니다.
+
+| Field                                              | Value |
+| -------------------------------------------------- | ----- |
+| Release commit SHA                                 |       |
+| Previous stable commit SHA                         |       |
+| `blog-api` previous image tag or digest            |       |
+| `ai-worker` previous image tag or digest           |       |
+| Cloudflare Worker current deployment or version ID |       |
+| Cloudflare Worker previous stable version ID       |       |
+| GitHub Pages previous deploy artifact or commit    |       |
+| D1 migration max version before deploy             |       |
+| D1 migration max version after deploy              |       |
+
+## Rollback Triggers
+
+하나라도 충족하면 신규 배포를 멈추고 rollback을 시작합니다.
+
+| Trigger           | Condition                                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------------------------- |
+| Backend readiness | `/api/v1/readiness`가 2회 연속 503이거나 5분 이상 degraded                                           |
+| Gateway auth      | `MISSING_GATEWAY_SIGNATURE` 또는 `INVALID_GATEWAY_SIGNATURE` 401이 backend-owned route에서 지속 증가 |
+| Worker proxy      | Worker proxy `502`, `503`, `504`가 5분 이상 지속                                                     |
+| D1 schema         | Worker log에 `no such column` 또는 `no such table` 발생                                              |
+| Auth/session      | login, session create, session recover 핵심 smoke 실패                                               |
+| Outbox            | `domain_outbox.deadLetter > 0` 또는 stuck event 지속 증가                                            |
+| AI queue          | `ai_task_dlq_length > 0` 또는 queue length가 drain되지 않음                                          |
+| Smoke             | public config, posts, auth/session, AI generate, analytics view 중 핵심 시나리오 실패                |
+
+## Freeze
+
+1. release owner 1명이 incident lead를 맡고, 추가 deploy를 중단합니다.
+2. Argo CD Application의 auto-sync와 Image Updater가 rollback target을 다시 덮어쓰지 않도록 일시 정지합니다.
+3. failing SHA, previous stable SHA, current Worker deployment/version ID, previous Worker version ID를 ticket에 기록합니다.
+4. 현재 증상에서 첫 신호를 고정합니다: gateway 401, D1 schema error, readiness 503, Worker 5xx, auth/session failure 중 하나입니다.
+
+## Worker Rollback
+
+Cloudflare Workers는 previous version으로 rollback하면 새 active deployment를 만듭니다. Cloudflare 문서 기준으로 Wrangler `rollback` 또는 dashboard의 Worker Deployments 화면을 사용합니다.
+
+```bash
+cd workers/api-gateway
+npx wrangler deployments list --env production
+npx wrangler rollback <previous-worker-version-id> --env production --message "rollback: <release-sha> to <previous-stable-sha>"
+```
+
+검증:
+
+```bash
+curl -fsS https://api.nodove.com/_health
+curl -fsS https://api.nodove.com/healthz
+curl -fsS https://api.nodove.com/api/v1/public/config
+```
+
+backend-owned route smoke를 1개 이상 실행하고 backend log에서 gateway signature 401이 멈췄는지 확인합니다.
+
+## Backend And k3s Rollback
+
+1. Argo CD auto-sync와 Image Updater가 정지되어 있는지 확인합니다.
+2. `api`와 `ai-worker` image를 previous stable SHA tag 또는 digest로 되돌립니다.
+3. `latest` tag를 rollback target으로 사용하지 않습니다.
+4. apply 후 rollout과 readiness를 확인합니다.
+
+```bash
+kubectl -n blog set image deploy/api api=ghcr.io/choisimo/blog-api:<previous-stable-sha>
+kubectl -n blog set image deploy/ai-worker ai-worker=ghcr.io/choisimo/blog-api:<previous-stable-sha>
+kubectl -n blog rollout status deploy/api
+kubectl -n blog rollout status deploy/ai-worker
+curl -fsS https://api.nodove.com/api/v1/readiness
+```
+
+Argo CD로 GitOps rollback을 수행하는 경우, k3s manifest가 previous stable image target을 가리키는 commit을 먼저 만들고 sync합니다.
+
+## Frontend Rollback
+
+1. previous GitHub Pages artifact 또는 previous stable commit을 redeploy합니다.
+2. `runtime-config.json`의 API base URL이 rollback target과 맞는지 확인합니다.
+3. browser smoke: home, posts list/detail, auth/session, AI entry를 확인합니다.
+
+## DB And Data Safety
+
+1. D1/Postgres migration은 즉시 destructive rollback하지 않습니다.
+2. 이전 code가 새 schema와 forward-compatible하면 schema는 유지합니다.
+3. 이전 code가 새 schema 때문에 실패하면 feature flag disable 또는 compatibility patch를 먼저 적용합니다.
+4. idempotency/outbox table은 삭제하지 않습니다. stuck/processing record만 별도 runbook 기준으로 release 또는 dead-letter 처리합니다.
+
+## Post-Rollback Verification
+
+| Area      | Check                                                   |
+| --------- | ------------------------------------------------------- |
+| Edge      | `/_health`, `/healthz`, `/api/v1/public/config` 200     |
+| Origin    | `/api/v1/readiness` 200 and `status=ready`              |
+| Auth      | login/session create/recover smoke pass                 |
+| Content   | posts list/detail smoke pass                            |
+| AI        | generate or queue smoke pass, depending on feature flag |
+| Analytics | view record and editor picks read smoke pass            |
+| Logs      | no gateway signature 401 spike, no D1 schema errors     |
+| Metrics   | 5xx rate and p95 latency return to baseline             |
+
+## Relaunch Gate
+
+재배포는 아래가 충족될 때만 허용합니다.
+
+1. rollback target이 stable 상태로 15분 이상 유지됩니다.
+2. root cause가 `must-fix-before-launch` 항목으로 문서화됩니다.
+3. affected secret, migration, image target, or feature flag contract가 CI 또는 deploy gate로 보강됩니다.
+4. smoke와 CI evidence가 release ticket에 링크됩니다.
+
+## References
+
+- Cloudflare Workers rollback docs: https://developers.cloudflare.com/workers/configuration/versions-and-deployments/rollbacks/
+- Wrangler Worker commands: https://developers.cloudflare.com/workers/wrangler/commands/workers/#rollback

--- a/frontend/src/components/features/chat/widget/hooks/useChatActions.ts
+++ b/frontend/src/components/features/chat/widget/hooks/useChatActions.ts
@@ -8,6 +8,7 @@ import type {
 import type { PageContext } from "@/services/chat/types";
 import type { SelectedBlockAttachment } from "@/services/chat";
 import {
+  createChatIdempotencyKey,
   streamChatEvents,
   uploadChatImage,
   invokeChatAggregate,
@@ -460,6 +461,7 @@ export function useChatActions({
         let acc = "";
         let finalSources: ChatMessage["sources"] | undefined;
         let finalFollowups: ChatMessage["followups"] | undefined;
+        const idempotencyKey = createChatIdempotencyKey();
 
         push({
           id: aiId,
@@ -471,6 +473,7 @@ export function useChatActions({
         for await (const ev of streamChatEvents({
           text: baseText,
           signal: controller.signal,
+          idempotencyKey,
           onFirstToken: (ms) => setFirstTokenMs(ms),
           useArticleContext: questionMode === "article",
           currentPost,

--- a/frontend/src/services/chat.ts
+++ b/frontend/src/services/chat.ts
@@ -51,6 +51,7 @@ export {
   invokeChatTask,
   invokeLensFeed,
   invokeThoughtFeed,
+  createChatIdempotencyKey,
   streamChatEvents,
   streamChatMessage,
   uploadChatImage,

--- a/frontend/src/services/chat/api.ts
+++ b/frontend/src/services/chat/api.ts
@@ -79,6 +79,14 @@ async function buildAuthenticatedChatHeaders(
   };
 }
 
+export function createChatIdempotencyKey(): string {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID === "function") {
+    return randomUUID.call(globalThis.crypto);
+  }
+  return `chat-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 function getAggregateText(data: ChatAggregateEnvelope["data"]): string | null {
   if (typeof data === "string") {
     return data;
@@ -234,7 +242,10 @@ export async function* streamChatEvents(
   const { page, parts, enableRag } = buildStreamPayload(input);
 
   const url = buildChatUrl("/message", sessionID);
-  const headers = await buildAuthenticatedChatHeaders("stream");
+  const idempotencyKey = input.idempotencyKey || createChatIdempotencyKey();
+  const headers = await buildAuthenticatedChatHeaders("stream", {
+    "Idempotency-Key": idempotencyKey,
+  });
 
   const res = await fetch(url, {
     method: "POST",

--- a/frontend/src/services/chat/index.ts
+++ b/frontend/src/services/chat/index.ts
@@ -95,6 +95,7 @@ export {
   invokeChatTask,
   invokeLensFeed,
   invokeThoughtFeed,
+  createChatIdempotencyKey,
   streamChatEvents,
   streamChatMessage,
   uploadChatImage,

--- a/frontend/src/services/chat/types.ts
+++ b/frontend/src/services/chat/types.ts
@@ -239,6 +239,7 @@ export type StreamChatInput = {
   page?: { url?: string; title?: string };
   currentPost?: PageContext["article"];
   signal?: AbortSignal;
+  idempotencyKey?: string;
   onFirstToken?: (ms: number) => void;
   useArticleContext?: boolean;
   imageUrl?: string;

--- a/frontend/src/test/chatUploadAuth.test.ts
+++ b/frontend/src/test/chatUploadAuth.test.ts
@@ -112,4 +112,35 @@ describe('chat upload authentication', () => {
       })
     );
   });
+
+  it('sends an Idempotency-Key with streamed chat messages', async () => {
+    localStorage.setItem('nodove_chat_session_id', 'session-1');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('data: {"type":"done"}\n\n', {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    );
+
+    const { streamChatEvents } = await import('@/services/chat/api');
+    const events: unknown[] = [];
+    for await (const event of streamChatEvents({
+      text: 'hello',
+      idempotencyKey: 'chat-turn-key-1',
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([{ type: 'done' }]);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.example.com/api/v1/chat/session/session-1/message',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer principal-token',
+          'Idempotency-Key': 'chat-turn-key-1',
+        }),
+      })
+    );
+  });
 });

--- a/shared/src/contracts/workers.js
+++ b/shared/src/contracts/workers.js
@@ -6,7 +6,13 @@ export const WORKER_DEPLOYMENTS = Object.freeze([
     path: 'api-gateway',
     wranglerPath: 'api-gateway/wrangler.toml',
     hasProduction: true,
-    requiredSecrets: ['BACKEND_ORIGIN', 'BACKEND_KEY', 'JWT_SECRET'],
+    requiredSecrets: [
+      'BACKEND_ORIGIN',
+      'BACKEND_KEY',
+      'GATEWAY_SIGNING_SECRET',
+      'JWT_SECRET',
+      'SECRETS_ENCRYPTION_KEY',
+    ],
   },
   {
     id: 'r2-gateway',

--- a/workers/api-gateway/README.md
+++ b/workers/api-gateway/README.md
@@ -64,7 +64,8 @@
 
 - `BACKEND_ORIGIN`이 없으면 `500` JSON 오류 반환
 - `BACKEND_KEY`가 있으면 `X-Backend-Key` 주입
-- `GATEWAY_SIGNING_SECRET`이 있으면 `X-Gateway-*` HMAC origin signature 주입
+- protected env(`production`, `staging`)에서는 `GATEWAY_SIGNING_SECRET`이 필수이며, 없으면 backend로 unsigned 요청을 보내지 않고 `500`으로 실패
+- `GATEWAY_SIGNING_SECRET`으로 `X-Gateway-*` HMAC origin signature 주입
 - 추가 전달 가능 헤더:
   - `X-Forwarded-For`
   - `X-Forwarded-Proto`
@@ -110,9 +111,10 @@ public config 응답에는 다음 필드가 포함됩니다.
 
 - cron: `0 6 * * *`
 - 확인된 동작:
-  - `post_stats`의 `views_7d`, `views_30d` 갱신
-  - `editor_picks` 재선정
-  - `post_views`의 90일 초과 데이터 삭제
+- `post_stats`의 `views_7d`, `views_30d` 갱신
+- `editor_picks` 재선정
+- `post_views`의 90일 초과 데이터 삭제
+- backend 호출은 `X-Backend-Key`와 `X-Gateway-*` HMAC signature를 함께 전송
 
 이 job은 D1 binding `DB`를 전제로 합니다.
 
@@ -171,4 +173,5 @@ GitHub Actions 파일: `.github/workflows/deploy-workers.yml`
 
 - `workers/**` 변경 또는 수동 실행 시 동작
 - 현재 자동 배포 대상은 `api-gateway`
+- api-gateway deploy 전 production D1 migration을 apply하고 schema smoke query를 실행
 - 일부 runtime config를 production secret으로 주입한 뒤 deploy 실행

--- a/workers/api-gateway/package-lock.json
+++ b/workers/api-gateway/package-lock.json
@@ -2655,9 +2655,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/hono": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
-      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -18,7 +18,11 @@ import { validateIapJwt } from './middleware/iap';
 import { success } from './lib/response';
 import { getCorsHeadersForRequest } from './lib/cors';
 import { getApiBaseUrl, getAiDefaultModel, getAiVisionModel } from './lib/config';
-import { attachOriginSignatureHeaders, stripOriginSignatureHeaders } from './lib/origin-signature';
+import {
+  OriginSignatureConfigurationError,
+  attachOriginSignatureHeaders,
+  stripOriginSignatureHeaders,
+} from './lib/origin-signature';
 import type { Env } from './types';
 import { flushAiArtifactOutbox } from './lib/ai-artifact-outbox';
 import { flushNotificationOutbox } from './lib/notification-outbox';
@@ -27,11 +31,7 @@ import {
   selectTopEditorPicks,
   type EditorPickStatRow,
 } from './lib/editor-picks';
-import {
-  buildProxyBoundaryHeaders,
-  canProxyPath,
-  registerWorkerRoutes,
-} from './routes/registry';
+import { buildProxyBoundaryHeaders, canProxyPath, registerWorkerRoutes } from './routes/registry';
 
 const app = new Hono<HonoEnv>();
 
@@ -39,7 +39,7 @@ const PUBLIC_EDGE_BLOCKED_BACKEND_PREFIXES = ['/api/v1/agent', '/api/v1/execute'
 
 function isPublicEdgeBlockedBackendPath(pathname: string): boolean {
   return PUBLIC_EDGE_BLOCKED_BACKEND_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
   );
 }
 
@@ -57,7 +57,7 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
       {
         status: 500,
         headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      },
+      }
     );
   }
 
@@ -75,7 +75,7 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
           ...corsHeaders,
           ...buildProxyBoundaryHeaders(url.pathname, request.method),
         },
-      },
+      }
     );
   }
 
@@ -93,7 +93,7 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
           ...corsHeaders,
           ...buildProxyBoundaryHeaders(url.pathname, request.method),
         },
-      },
+      }
     );
   }
 
@@ -139,15 +139,15 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
     }
   }
 
-  await attachOriginSignatureHeaders({
-    env,
-    headers,
-    method: request.method,
-    pathAndQuery: `${backendUrl.pathname}${backendUrl.search}`,
-    requestId: headers.get('X-Request-ID') || undefined,
-  });
-
   try {
+    await attachOriginSignatureHeaders({
+      env,
+      headers,
+      method: request.method,
+      pathAndQuery: `${backendUrl.pathname}${backendUrl.search}`,
+      requestId: headers.get('X-Request-ID') || undefined,
+    });
+
     const response = await fetch(backendUrl.toString(), {
       method: request.method,
       headers,
@@ -190,7 +190,7 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
           status: response.status,
           statusText: response.statusText,
           headers: responseHeaders,
-        },
+        }
       );
     }
 
@@ -200,6 +200,25 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
       headers: responseHeaders,
     });
   } catch (error) {
+    if (error instanceof OriginSignatureConfigurationError) {
+      console.error('Backend origin signing configuration error:', error.message);
+      const corsHeaders = await getCorsHeadersForRequest(request, env);
+      return new Response(
+        JSON.stringify({
+          error: 'Configuration error',
+          message: error.message,
+        }),
+        {
+          status: 500,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders,
+            ...buildProxyBoundaryHeaders(url.pathname, request.method),
+          },
+        }
+      );
+    }
+
     console.error('Backend request failed:', error);
 
     const corsHeaders = await getCorsHeadersForRequest(request, env);
@@ -216,9 +235,32 @@ async function proxyToBackend(request: Request, env: Env): Promise<Response> {
           ...corsHeaders,
           ...buildProxyBoundaryHeaders(url.pathname, request.method),
         },
-      },
+      }
     );
   }
+}
+
+async function buildScheduledBackendHeaders(
+  env: Env,
+  method: string,
+  url: string,
+  init?: HeadersInit
+): Promise<Headers> {
+  const headers = new Headers(init);
+  if (env.BACKEND_KEY) {
+    headers.set('X-Backend-Key', env.BACKEND_KEY);
+  }
+  const requestId = crypto.randomUUID();
+  headers.set('X-Request-ID', requestId);
+  const parsed = new URL(url);
+  await attachOriginSignatureHeaders({
+    env,
+    headers,
+    method,
+    pathAndQuery: `${parsed.pathname}${parsed.search}`,
+    requestId,
+  });
+  return headers;
 }
 
 app.use('*', corsMiddleware);
@@ -268,7 +310,7 @@ app.all('/metrics', async (c) => {
         'Content-Type': 'application/json',
         ...corsHeaders,
       },
-    },
+    }
   );
 });
 
@@ -335,15 +377,21 @@ async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext)
     if (env.BACKEND_ORIGIN && env.BACKEND_KEY) {
       try {
         const refreshUrl = `${env.BACKEND_ORIGIN}/api/v1/analytics/refresh-stats`;
+        const headers = await buildScheduledBackendHeaders(env, 'POST', refreshUrl, {
+          'Content-Type': 'application/json',
+        });
         const refreshResp = await fetch(refreshUrl, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Backend-Key': env.BACKEND_KEY,
-          },
+          headers,
         });
-        const refreshData = await refreshResp.json<{ ok?: boolean; data?: { refreshed?: number } }>().catch(() => null);
-        console.log(`Stats refresh: ${refreshResp.status}`, refreshData?.data?.refreshed ?? 0, 'rows');
+        const refreshData = await refreshResp
+          .json<{ ok?: boolean; data?: { refreshed?: number } }>()
+          .catch(() => null);
+        console.log(
+          `Stats refresh: ${refreshResp.status}`,
+          refreshData?.data?.refreshed ?? 0,
+          'rows'
+        );
       } catch (refreshErr) {
         console.error('Stats refresh failed (non-fatal):', refreshErr);
       }
@@ -356,13 +404,16 @@ async function scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext)
     if (env.BACKEND_ORIGIN && env.BACKEND_KEY) {
       try {
         const statsUrl = `${env.BACKEND_ORIGIN}/api/v1/analytics/all-stats?limit=10&orderBy=total_views`;
+        const headers = await buildScheduledBackendHeaders(env, 'GET', statsUrl);
         const statsResp = await fetch(statsUrl, {
-          headers: { 'X-Backend-Key': env.BACKEND_KEY },
+          headers,
         });
-        const statsData = await statsResp.json<{
-          ok?: boolean;
-          data?: { stats?: EditorPickStatRow[] };
-        }>().catch(() => null);
+        const statsData = await statsResp
+          .json<{
+            ok?: boolean;
+            data?: { stats?: EditorPickStatRow[] };
+          }>()
+          .catch(() => null);
 
         const allStats = statsData?.data?.stats || [];
         const topPicks = selectTopEditorPicks(allStats);

--- a/workers/api-gateway/src/lib/ai-service.ts
+++ b/workers/api-gateway/src/lib/ai-service.ts
@@ -16,6 +16,7 @@
 
 import type { Env } from '../types';
 import { getAiServeUrl, getAiServeApiKey, getAiDefaultModel, getAiVisionModel } from './config';
+import { attachOriginSignatureHeadersForUrl } from './origin-signature';
 import { buildTaskPrompt, getFallbackData, type TaskMode, type TaskPayload } from './prompts';
 
 export const TRACE_ID_HEADER = 'X-Trace-ID';
@@ -108,15 +109,15 @@ export class AIService {
   /**
    * Build request headers with authentication
    */
-  private async buildHeaders(): Promise<Record<string, string>> {
-    const headers: Record<string, string> = {
+  private async buildHeaders(): Promise<Headers> {
+    const headers = new Headers({
       'Content-Type': 'application/json',
       'User-Agent': 'Blog-Workers/1.0',
       Accept: 'application/json',
-    };
+    });
 
     if (this.traceId) {
-      headers[TRACE_ID_HEADER] = this.traceId;
+      headers.set(TRACE_ID_HEADER, this.traceId);
     }
 
     const [apiKey, forcedModel, forcedVisionModel] = await Promise.all([
@@ -125,17 +126,17 @@ export class AIService {
       getAiVisionModel(this.env),
     ]);
     if (apiKey) {
-      headers['X-API-KEY'] = apiKey;
+      headers.set('X-API-KEY', apiKey);
     }
     if (forcedModel) {
-      headers['X-AI-Model'] = forcedModel;
+      headers.set('X-AI-Model', forcedModel);
     }
     if (forcedVisionModel) {
-      headers['X-AI-Vision-Model'] = forcedVisionModel;
+      headers.set('X-AI-Vision-Model', forcedVisionModel);
     }
 
     if (this.env.BACKEND_KEY) {
-      headers['X-Backend-Key'] = this.env.BACKEND_KEY;
+      headers.set('X-Backend-Key', this.env.BACKEND_KEY);
     }
 
     return headers;
@@ -152,6 +153,12 @@ export class AIService {
     const baseUrl = await this.getBaseUrl();
     const url = `${baseUrl.replace(/\/$/, '')}/api/v1/ai${endpoint}`;
     const headers = await this.buildHeaders();
+    await attachOriginSignatureHeadersForUrl({
+      env: this.env,
+      headers,
+      method: 'POST',
+      url,
+    });
 
     const controller = new AbortController();
     const timeoutId = options.timeout
@@ -300,14 +307,20 @@ export class AIService {
 
       const url = `${backendOrigin.replace(/\/$/, '')}/api/v1/ai/health`;
 
-      const headers: Record<string, string> = {
+      const headers = new Headers({
         Accept: 'application/json',
         'User-Agent': 'Blog-Workers/1.0',
-      };
+      });
 
       if (this.env.BACKEND_KEY) {
-        headers['X-Backend-Key'] = this.env.BACKEND_KEY;
+        headers.set('X-Backend-Key', this.env.BACKEND_KEY);
       }
+      await attachOriginSignatureHeadersForUrl({
+        env: this.env,
+        headers,
+        method: 'GET',
+        url,
+      });
 
       const res = await fetch(url, {
         method: 'GET',

--- a/workers/api-gateway/src/lib/backend-proxy.ts
+++ b/workers/api-gateway/src/lib/backend-proxy.ts
@@ -2,7 +2,11 @@ import type { Context } from 'hono';
 import type { HonoEnv } from '../types';
 import { getCorsHeadersForRequest } from './cors';
 import { getAiDefaultModel, getAiVisionModel } from './config';
-import { attachOriginSignatureHeaders, stripOriginSignatureHeaders } from './origin-signature';
+import {
+  OriginSignatureConfigurationError,
+  attachOriginSignatureHeaders,
+  stripOriginSignatureHeaders,
+} from './origin-signature';
 
 export type BackendProxyOptions = {
   upstreamPath: string;
@@ -112,7 +116,7 @@ async function buildProxyHeaders(
 
 async function buildProxyBody(
   c: Context<HonoEnv>,
-  options: BackendProxyOptions,
+  options: BackendProxyOptions
 ): Promise<BodyInit | null | undefined> {
   const method = (options.method || c.req.method).toUpperCase();
   if (method === 'GET' || method === 'HEAD') {
@@ -148,12 +152,13 @@ async function buildProxyBody(
 
 export async function proxyToBackendWithPolicy(
   c: Context<HonoEnv>,
-  options: BackendProxyOptions,
+  options: BackendProxyOptions
 ): Promise<Response> {
   const corsHeaders = await getCorsHeadersForRequest(c.req.raw, c.env);
   const backendUrl = buildBackendUrl(c, options);
   const method = options.method || c.req.method;
-  const unavailableMessage = options.backendUnavailableMessage || 'Could not connect to backend service';
+  const unavailableMessage =
+    options.backendUnavailableMessage || 'Could not connect to backend service';
 
   if (!backendUrl) {
     return new Response(
@@ -170,16 +175,16 @@ export async function proxyToBackendWithPolicy(
           'Content-Type': 'application/json',
           ...corsHeaders,
         },
-      },
+      }
     );
   }
 
-  const [headers, body] = await Promise.all([
-    buildProxyHeaders(c, options, backendUrl),
-    buildProxyBody(c, options),
-  ]);
-
   try {
+    const [headers, body] = await Promise.all([
+      buildProxyHeaders(c, options, backendUrl),
+      buildProxyBody(c, options),
+    ]);
+
     const requestInit: RequestInit & { duplex?: 'half' } = {
       method,
       headers,
@@ -225,7 +230,7 @@ export async function proxyToBackendWithPolicy(
             'Retry-After': '30',
             ...corsHeaders,
           },
-        },
+        }
       );
     }
 
@@ -235,6 +240,26 @@ export async function proxyToBackendWithPolicy(
       headers: responseHeaders,
     });
   } catch (error) {
+    if (error instanceof OriginSignatureConfigurationError) {
+      console.error('[backend-proxy] origin signing configuration error', error);
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: {
+            code: 'CONFIG_ERROR',
+            message: error.message,
+          },
+        }),
+        {
+          status: 500,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders,
+          },
+        }
+      );
+    }
+
     console.error('[backend-proxy] upstream request failed', error);
     return new Response(
       JSON.stringify({
@@ -251,7 +276,7 @@ export async function proxyToBackendWithPolicy(
           'Retry-After': '30',
           ...corsHeaders,
         },
-      },
+      }
     );
   }
 }

--- a/workers/api-gateway/src/lib/gemini.ts
+++ b/workers/api-gateway/src/lib/gemini.ts
@@ -13,6 +13,7 @@
 
 import type { Env } from '../types';
 import { getAiServeUrl, getAiServeApiKey } from './config';
+import { attachOriginSignatureHeadersForUrl } from './origin-signature';
 
 export type GenerateOptions = {
   temperature?: number;
@@ -23,7 +24,7 @@ export type GenerateOptions = {
  * 백엔드 AI 서버를 통해 콘텐츠를 생성합니다.
  *
  * @deprecated Use createAIService(env).generate() from ai-service.ts instead
- * 
+ *
  * @param prompt - 생성할 프롬프트
  * @param env - Worker 환경 변수
  * @param options - 생성 옵션 (temperature, maxTokens)
@@ -39,21 +40,27 @@ export async function generateContent(
   const maxTokens = options?.maxTokens ?? 2048;
 
   // Use BACKEND_ORIGIN to avoid circular calls (api.nodove.com -> api.nodove.com)
-  const base = env.BACKEND_ORIGIN || await getAiServeUrl(env);
+  const base = env.BACKEND_ORIGIN || (await getAiServeUrl(env));
   const url = `${base.replace(/\/$/, '')}/api/v1/ai/generate`;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Content-Type': 'application/json',
     'User-Agent': 'Blog-Workers/1.0',
-    'Accept': 'application/json',
-  };
+    Accept: 'application/json',
+  });
   const apiKey = await getAiServeApiKey(env);
   if (apiKey) {
-    headers['X-API-KEY'] = apiKey;
+    headers.set('X-API-KEY', apiKey);
   }
   if (env.BACKEND_KEY) {
-    headers['X-Backend-Key'] = env.BACKEND_KEY;
+    headers.set('X-Backend-Key', env.BACKEND_KEY);
   }
+  await attachOriginSignatureHeadersForUrl({
+    env,
+    headers,
+    method: 'POST',
+    url,
+  });
 
   const res = await fetch(url, {
     method: 'POST',

--- a/workers/api-gateway/src/lib/memory-embedding-outbox.ts
+++ b/workers/api-gateway/src/lib/memory-embedding-outbox.ts
@@ -6,6 +6,7 @@ import {
   markDomainOutboxProcessed,
   prepareAppendDomainOutboxStatement,
 } from './domain-outbox';
+import { attachOriginSignatureHeadersForUrl } from './origin-signature';
 
 const MEMORY_EMBEDDING_STREAM = 'memory.embedding';
 const MEMORY_EMBEDDING_MAX_RETRIES = 5;
@@ -36,12 +37,21 @@ async function requireBackend(env: Env) {
 
 async function upsertMemoryEmbedding(env: Env, payload: MemoryEmbeddingUpsertPayload) {
   const { backendOrigin, backendKey } = await requireBackend(env);
-  const response = await fetch(`${backendOrigin}/api/v1/rag/memories/upsert/internal`, {
+  const url = `${backendOrigin}/api/v1/rag/memories/upsert/internal`;
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    ...(backendKey ? { 'X-Backend-Key': backendKey } : {}),
+  });
+  await attachOriginSignatureHeadersForUrl({
+    env,
+    headers,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(backendKey ? { 'X-Backend-Key': backendKey } : {}),
-    },
+    url,
+  });
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
     body: JSON.stringify({
       userId: payload.userId,
       memories: [
@@ -62,13 +72,18 @@ async function upsertMemoryEmbedding(env: Env, payload: MemoryEmbeddingUpsertPay
 
 async function deleteMemoryEmbedding(env: Env, payload: MemoryEmbeddingDeletePayload) {
   const { backendOrigin, backendKey } = await requireBackend(env);
-  const response = await fetch(
-    `${backendOrigin}/api/v1/rag/memories/${payload.userId}/${payload.memoryId}/internal`,
-    {
-      method: 'DELETE',
-      headers: backendKey ? { 'X-Backend-Key': backendKey } : undefined,
-    }
-  );
+  const url = `${backendOrigin}/api/v1/rag/memories/${payload.userId}/${payload.memoryId}/internal`;
+  const headers = new Headers(backendKey ? { 'X-Backend-Key': backendKey } : undefined);
+  await attachOriginSignatureHeadersForUrl({
+    env,
+    headers,
+    method: 'DELETE',
+    url,
+  });
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers,
+  });
 
   if (!response.ok && response.status !== 404) {
     throw new Error(`Memory embedding delete failed: ${response.status}`);

--- a/workers/api-gateway/src/lib/notification-outbox.ts
+++ b/workers/api-gateway/src/lib/notification-outbox.ts
@@ -7,6 +7,7 @@ import {
   markDomainOutboxProcessed,
   reviveDomainOutboxEvent,
 } from './domain-outbox';
+import { attachOriginSignatureHeadersForUrl } from './origin-signature';
 
 export const NOTIFICATION_DELIVERY_STREAM = 'notification.delivery';
 const NOTIFICATION_MAX_RETRIES = 8;
@@ -21,12 +22,15 @@ export type NotificationDeliveryPayload = {
   payload?: Record<string, unknown>;
 };
 
-async function appendOrReuseNotification(env: Env, input: {
-  aggregateId: string;
-  eventType: string;
-  payload: NotificationDeliveryPayload;
-  idempotencyKey: string;
-}) {
+async function appendOrReuseNotification(
+  env: Env,
+  input: {
+    aggregateId: string;
+    eventType: string;
+    payload: NotificationDeliveryPayload;
+    idempotencyKey: string;
+  }
+) {
   try {
     return await appendDomainOutboxEvent(env.DB, {
       stream: NOTIFICATION_DELIVERY_STREAM,
@@ -66,8 +70,7 @@ export async function enqueueNotificationDelivery(
     aggregateId: payload.sourceId,
     eventType: 'notification.deliver',
     payload,
-    idempotencyKey:
-      options.idempotencyKey || `notification:${payload.sourceId}:${payload.type}`,
+    idempotencyKey: options.idempotencyKey || `notification:${payload.sourceId}:${payload.type}`,
   });
 }
 
@@ -84,13 +87,22 @@ async function deliverNotification(
   }
 
   const backendOrigin = env.BACKEND_ORIGIN.replace(/\/$/, '');
-  const response = await fetch(`${backendOrigin}/api/v1/notifications/outbox/internal`, {
+  const url = `${backendOrigin}/api/v1/notifications/outbox/internal`;
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    'X-Backend-Key': env.BACKEND_KEY,
+    ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
+  });
+  await attachOriginSignatureHeadersForUrl({
+    env,
+    headers,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Backend-Key': env.BACKEND_KEY,
-      ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {}),
-    },
+    url,
+  });
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
     body: JSON.stringify(payload),
   });
 

--- a/workers/api-gateway/src/lib/origin-signature.ts
+++ b/workers/api-gateway/src/lib/origin-signature.ts
@@ -1,11 +1,19 @@
 import type { Env } from '../types';
 
 const SIGNATURE_VERSION = 'v1';
+const PROTECTED_ENVS = new Set(['production', 'staging']);
+
+export class OriginSignatureConfigurationError extends Error {
+  code = 'ORIGIN_SIGNATURE_CONFIG_MISSING';
+
+  constructor() {
+    super('GATEWAY_SIGNING_SECRET is required for backend origin signing');
+    this.name = 'OriginSignatureConfigurationError';
+  }
+}
 
 function toHex(bytes: ArrayBuffer): string {
-  return [...new Uint8Array(bytes)]
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
+  return [...new Uint8Array(bytes)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
 async function hmacSha256(secret: string, value: string): Promise<string> {
@@ -23,6 +31,10 @@ async function hmacSha256(secret: string, value: string): Promise<string> {
 function gatewaySigningSecret(env: Env): string | null {
   const secret = env.GATEWAY_SIGNING_SECRET || env.BACKEND_GATEWAY_SIGNING_SECRET;
   return typeof secret === 'string' && secret.trim() ? secret.trim() : null;
+}
+
+function isProtectedEnv(env: Env): boolean {
+  return PROTECTED_ENVS.has(env.ENV);
 }
 
 function buildPayload(input: {
@@ -59,7 +71,12 @@ export async function attachOriginSignatureHeaders(input: {
   now?: Date;
 }): Promise<string | null> {
   const secret = gatewaySigningSecret(input.env);
-  if (!secret) return null;
+  if (!secret) {
+    if (isProtectedEnv(input.env)) {
+      throw new OriginSignatureConfigurationError();
+    }
+    return null;
+  }
 
   const requestId = input.requestId || crypto.randomUUID();
   const timestamp = Math.floor((input.now || new Date()).getTime() / 1000).toString();
@@ -79,4 +96,23 @@ export async function attachOriginSignatureHeaders(input: {
   input.headers.set('X-Gateway-Signature', signature);
   input.headers.set('X-Origin-Verified-By', 'api-gateway');
   return requestId;
+}
+
+export async function attachOriginSignatureHeadersForUrl(input: {
+  env: Env;
+  headers: Headers;
+  method: string;
+  url: string;
+  requestId?: string;
+  now?: Date;
+}): Promise<string | null> {
+  const parsed = new URL(input.url);
+  return attachOriginSignatureHeaders({
+    env: input.env,
+    headers: input.headers,
+    method: input.method,
+    pathAndQuery: `${parsed.pathname}${parsed.search}`,
+    requestId: input.requestId,
+    now: input.now,
+  });
 }

--- a/workers/api-gateway/src/routes/admin-ai/models.ts
+++ b/workers/api-gateway/src/routes/admin-ai/models.ts
@@ -50,6 +50,7 @@ models.get('/', requireAdmin, async (c) => {
 
 models.get('/:id', requireAdmin, async (c) => {
   const id = c.req.param('id');
+  if (!id) return badRequest(c, 'Model id is required');
 
   try {
     const model = await queryOne(
@@ -147,11 +148,7 @@ models.post('/', requireAdmin, async (c) => {
       priority || 0
     );
 
-    const model = await queryOne<AIModel>(
-      c.env.DB,
-      `SELECT * FROM ai_models WHERE id = ?`,
-      id
-    );
+    const model = await queryOne<AIModel>(c.env.DB, `SELECT * FROM ai_models WHERE id = ?`, id);
 
     return success(c, { model }, 201);
   } catch (err) {
@@ -165,14 +162,11 @@ models.post('/', requireAdmin, async (c) => {
 
 models.put('/:id', requireAdmin, async (c) => {
   const id = c.req.param('id');
+  if (!id) return badRequest(c, 'Model id is required');
   const body = await c.req.json().catch(() => ({}));
 
   try {
-    const existing = await queryOne<AIModel>(
-      c.env.DB,
-      `SELECT * FROM ai_models WHERE id = ?`,
-      id
-    );
+    const existing = await queryOne<AIModel>(c.env.DB, `SELECT * FROM ai_models WHERE id = ?`, id);
 
     if (!existing) {
       return notFound(c, `Model not found: ${id}`);
@@ -265,17 +259,9 @@ models.put('/:id', requireAdmin, async (c) => {
     updates.push('updated_at = CURRENT_TIMESTAMP');
     values.push(id);
 
-    await execute(
-      c.env.DB,
-      `UPDATE ai_models SET ${updates.join(', ')} WHERE id = ?`,
-      ...values
-    );
+    await execute(c.env.DB, `UPDATE ai_models SET ${updates.join(', ')} WHERE id = ?`, ...values);
 
-    const model = await queryOne<AIModel>(
-      c.env.DB,
-      `SELECT * FROM ai_models WHERE id = ?`,
-      id
-    );
+    const model = await queryOne<AIModel>(c.env.DB, `SELECT * FROM ai_models WHERE id = ?`, id);
 
     return success(c, { model });
   } catch (err) {
@@ -286,13 +272,10 @@ models.put('/:id', requireAdmin, async (c) => {
 
 models.delete('/:id', requireAdmin, async (c) => {
   const id = c.req.param('id');
+  if (!id) return badRequest(c, 'Model id is required');
 
   try {
-    const existing = await queryOne<AIModel>(
-      c.env.DB,
-      `SELECT * FROM ai_models WHERE id = ?`,
-      id
-    );
+    const existing = await queryOne<AIModel>(c.env.DB, `SELECT * FROM ai_models WHERE id = ?`, id);
 
     if (!existing) {
       return notFound(c, `Model not found: ${id}`);

--- a/workers/api-gateway/src/routes/admin-ai/routes.ts
+++ b/workers/api-gateway/src/routes/admin-ai/routes.ts
@@ -30,6 +30,7 @@ routes.get('/', requireAdmin, async (c) => {
 
 routes.get('/:id', requireAdmin, async (c) => {
   const id = c.req.param('id');
+  if (!id) return badRequest(c, 'Route id is required');
 
   try {
     const route = await queryOne(
@@ -108,11 +109,7 @@ routes.post('/', requireAdmin, async (c) => {
       is_default ? 1 : 0
     );
 
-    const route = await queryOne<AIRoute>(
-      c.env.DB,
-      `SELECT * FROM ai_routes WHERE id = ?`,
-      id
-    );
+    const route = await queryOne<AIRoute>(c.env.DB, `SELECT * FROM ai_routes WHERE id = ?`, id);
 
     return success(c, { route }, 201);
   } catch (err) {
@@ -126,14 +123,11 @@ routes.post('/', requireAdmin, async (c) => {
 
 routes.put('/:id', requireAdmin, async (c) => {
   const id = c.req.param('id');
+  if (!id) return badRequest(c, 'Route id is required');
   const body = await c.req.json().catch(() => ({}));
 
   try {
-    const existing = await queryOne<AIRoute>(
-      c.env.DB,
-      `SELECT * FROM ai_routes WHERE id = ?`,
-      id
-    );
+    const existing = await queryOne<AIRoute>(c.env.DB, `SELECT * FROM ai_routes WHERE id = ?`, id);
 
     if (!existing) {
       return notFound(c, `Route not found: ${id}`);
@@ -222,17 +216,9 @@ routes.put('/:id', requireAdmin, async (c) => {
     updates.push('updated_at = CURRENT_TIMESTAMP');
     values.push(id);
 
-    await execute(
-      c.env.DB,
-      `UPDATE ai_routes SET ${updates.join(', ')} WHERE id = ?`,
-      ...values
-    );
+    await execute(c.env.DB, `UPDATE ai_routes SET ${updates.join(', ')} WHERE id = ?`, ...values);
 
-    const route = await queryOne<AIRoute>(
-      c.env.DB,
-      `SELECT * FROM ai_routes WHERE id = ?`,
-      id
-    );
+    const route = await queryOne<AIRoute>(c.env.DB, `SELECT * FROM ai_routes WHERE id = ?`, id);
 
     return success(c, { route });
   } catch (err) {
@@ -243,13 +229,10 @@ routes.put('/:id', requireAdmin, async (c) => {
 
 routes.delete('/:id', requireAdmin, async (c) => {
   const id = c.req.param('id');
+  if (!id) return badRequest(c, 'Route id is required');
 
   try {
-    const existing = await queryOne<AIRoute>(
-      c.env.DB,
-      `SELECT * FROM ai_routes WHERE id = ?`,
-      id
-    );
+    const existing = await queryOne<AIRoute>(c.env.DB, `SELECT * FROM ai_routes WHERE id = ?`, id);
 
     if (!existing) {
       return notFound(c, `Route not found: ${id}`);

--- a/workers/api-gateway/src/routes/admin-ai/templates.ts
+++ b/workers/api-gateway/src/routes/admin-ai/templates.ts
@@ -104,6 +104,7 @@ templates.post('/', requireAdmin, async (c) => {
 
 templates.put('/:id', requireAdmin, async (c) => {
   const id = c.req.param('id');
+  if (!id) return badRequest(c, 'Template id is required');
   const body = await c.req.json().catch(() => ({}));
 
   try {
@@ -213,6 +214,7 @@ templates.put('/:id', requireAdmin, async (c) => {
 
 templates.delete('/:id', requireAdmin, async (c) => {
   const id = c.req.param('id');
+  if (!id) return badRequest(c, 'Template id is required');
 
   try {
     const existing = await queryOne(
@@ -236,6 +238,7 @@ templates.delete('/:id', requireAdmin, async (c) => {
 
 templates.post('/:id/use', requireAdmin, async (c) => {
   const id = c.req.param('id');
+  if (!id) return badRequest(c, 'Template id is required');
 
   try {
     const template = await queryOne<PromptTemplate>(

--- a/workers/api-gateway/src/routes/gateway.ts
+++ b/workers/api-gateway/src/routes/gateway.ts
@@ -21,6 +21,10 @@ import {
   getAiDefaultModel,
   getAiVisionModel,
 } from '../lib/config';
+import {
+  attachOriginSignatureHeadersForUrl,
+  stripOriginSignatureHeaders,
+} from '../lib/origin-signature';
 import { requireAdmin, requireAuth } from '../middleware/auth';
 
 const gateway = new Hono<HonoEnv>();
@@ -61,6 +65,7 @@ async function proxyToBackendAi(request: Request, env: Env, path: string): Promi
 
   const headers = new Headers(request.headers);
   headers.set('Host', new URL(backendUrl).host);
+  stripOriginSignatureHeaders(headers);
 
   // Add internal key if configured
   const apiKey = await getAiServeApiKey(env);
@@ -74,6 +79,13 @@ async function proxyToBackendAi(request: Request, env: Env, path: string): Promi
 
   // Remove sensitive headers
   headers.delete('X-Gateway-Caller-Key');
+  await attachOriginSignatureHeadersForUrl({
+    env,
+    headers,
+    method: request.method,
+    url: url.toString(),
+    requestId: headers.get('X-Request-ID') || undefined,
+  });
 
   const body = ['GET', 'HEAD'].includes(request.method) ? undefined : await request.blob();
 
@@ -119,14 +131,21 @@ gateway.get('/call/status', async (c) => {
     const backendUrl = await getAiAgentBackendUrl(c.env);
     const apiKey = await getAiServeApiKey(c.env);
 
-    const headers: Record<string, string> = {
+    const url = `${backendUrl}/api/v1/ai/status`;
+    const headers = new Headers({
       'Content-Type': 'application/json',
-    };
+    });
     if (apiKey) {
-      headers['X-Internal-Gateway-Key'] = apiKey;
+      headers.set('X-Internal-Gateway-Key', apiKey);
     }
+    await attachOriginSignatureHeadersForUrl({
+      env: c.env,
+      headers,
+      method: 'GET',
+      url,
+    });
 
-    const response = await fetch(`${backendUrl}/api/v1/ai/status`, {
+    const response = await fetch(url, {
       method: 'GET',
       headers,
     });
@@ -180,23 +199,29 @@ async function analyzeWithBackend(
   const backendUrl = await getAiAgentBackendUrl(env);
   const url = `${backendUrl}/api/v1/ai/vision/analyze`;
 
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     'Content-Type': 'application/json',
-  };
+  });
   const apiKey = await getAiServeApiKey(env);
   if (apiKey) {
-    headers['X-Internal-Gateway-Key'] = apiKey;
+    headers.set('X-Internal-Gateway-Key', apiKey);
   }
   const [forcedModel, forcedVisionModel] = await Promise.all([
     getAiDefaultModel(env),
     getAiVisionModel(env),
   ]);
   if (forcedModel) {
-    headers['X-AI-Model'] = forcedModel;
+    headers.set('X-AI-Model', forcedModel);
   }
   if (forcedVisionModel) {
-    headers['X-AI-Vision-Model'] = forcedVisionModel;
+    headers.set('X-AI-Vision-Model', forcedVisionModel);
   }
+  await attachOriginSignatureHeadersForUrl({
+    env,
+    headers,
+    method: 'POST',
+    url,
+  });
 
   const response = await fetch(url, {
     method: 'POST',

--- a/workers/api-gateway/src/routes/images.ts
+++ b/workers/api-gateway/src/routes/images.ts
@@ -20,7 +20,9 @@ const CHAT_UPLOAD_RATE_LIMIT = 20;
 const CHAT_UPLOAD_RATE_WINDOW = 60;
 
 function sanitizeR2Filename(name: string): string {
-  const sanitized = String(name || '').replace(/[^a-zA-Z0-9._-]/g, '-').replace(/-+/g, '-');
+  const sanitized = String(name || '')
+    .replace(/[^a-zA-Z0-9._-]/g, '-')
+    .replace(/-+/g, '-');
   if (!sanitized || sanitized.startsWith('.')) return `upload-${Date.now()}`;
   return sanitized.slice(0, 160);
 }
@@ -332,6 +334,7 @@ images.get('/chat-object', requireAuth, async (c) => {
 // DELETE /images/:key - Delete image from R2 (admin only)
 images.delete('/:key', requireAdmin, async (c) => {
   const key = c.req.param('key');
+  if (!key) return badRequest(c, 'Image key is required');
   const r2 = c.env.R2;
   if (!r2) {
     return badRequest(c, 'R2 bucket is not configured');

--- a/workers/api-gateway/src/routes/notifications.ts
+++ b/workers/api-gateway/src/routes/notifications.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { HonoEnv } from '../types';
 import { requireAuth } from '../middleware/auth';
 import { proxyToBackendWithPolicy } from '../lib/backend-proxy';
+import { badRequest } from '../lib/response';
 
 const notifications = new Hono<HonoEnv>();
 
@@ -28,8 +29,11 @@ notifications.get('/history', requireAuth, async (c) => {
 });
 
 notifications.patch('/:notificationId/read', requireAuth, async (c) => {
+  const notificationId = c.req.param('notificationId');
+  if (!notificationId) return badRequest(c, 'Notification id is required');
+
   return proxyToBackendWithPolicy(c, {
-    upstreamPath: `/api/v1/notifications/${encodeURIComponent(c.req.param('notificationId'))}/read`,
+    upstreamPath: `/api/v1/notifications/${encodeURIComponent(notificationId)}/read`,
     backendUnavailableMessage: 'Could not connect to notifications backend',
   });
 });

--- a/workers/api-gateway/src/routes/rag.ts
+++ b/workers/api-gateway/src/routes/rag.ts
@@ -16,7 +16,7 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import type { HonoEnv } from '../types';
-import { forbidden } from '../lib/response';
+import { badRequest, forbidden } from '../lib/response';
 import { requireAdmin, requireAuth } from '../middleware/auth';
 import { proxyToBackendWithPolicy } from '../lib/backend-proxy';
 
@@ -130,11 +130,9 @@ rag.post('/index', requireAdmin, async (c) => {
  * DELETE /index/:documentId - 인덱스에서 문서 삭제
  */
 rag.delete('/index/:documentId', requireAdmin, async (c) => {
-  return proxyToBackend(
-    c,
-    `/index/${encodeURIComponent(c.req.param('documentId'))}`,
-    'DELETE'
-  );
+  const documentId = c.req.param('documentId');
+  if (!documentId) return badRequest(c, 'Document id is required');
+  return proxyToBackend(c, `/index/${encodeURIComponent(documentId)}`, 'DELETE');
 });
 
 rag.post('/memories/search', requireAuth, async (c) => {

--- a/workers/api-gateway/src/routes/search.ts
+++ b/workers/api-gateway/src/routes/search.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { HonoEnv, Env } from '../types';
 import { success, badRequest, serverError } from '../lib/response';
 import { getPerplexityModel } from '../lib/config';
+import { attachOriginSignatureHeadersForUrl } from '../lib/origin-signature';
 
 const search = new Hono<HonoEnv>();
 
@@ -179,13 +180,19 @@ async function proxyToBackendWebSearch(
 
   const upstreamUrl = `${backendOrigin.replace(/\/$/, '')}/api/v1/search/web`;
 
-  const headers: HeadersInit = {
+  const headers = new Headers({
     'Content-Type': 'application/json',
-  };
+  });
 
   if (env.BACKEND_KEY) {
-    headers['X-Backend-Key'] = env.BACKEND_KEY;
+    headers.set('X-Backend-Key', env.BACKEND_KEY);
   }
+  await attachOriginSignatureHeadersForUrl({
+    env,
+    headers,
+    method: 'POST',
+    url: upstreamUrl,
+  });
 
   const response = await fetch(upstreamUrl, {
     method: 'POST',

--- a/workers/api-gateway/src/routes/site-content/index.ts
+++ b/workers/api-gateway/src/routes/site-content/index.ts
@@ -13,7 +13,8 @@ import {
 const siteContent = new Hono<HonoEnv>();
 
 siteContent.get('/admin/:key', requireAdmin, async (c) => {
-  const key = parseSiteContentBlockKey(c.req.param('key'));
+  const rawKey = c.req.param('key');
+  const key = rawKey ? parseSiteContentBlockKey(rawKey) : null;
   if (!key) return badRequest(c, 'Invalid site content block key');
 
   try {
@@ -30,7 +31,8 @@ siteContent.get('/admin/:key', requireAdmin, async (c) => {
 });
 
 siteContent.put('/admin/:key', requireAdmin, async (c) => {
-  const key = parseSiteContentBlockKey(c.req.param('key'));
+  const rawKey = c.req.param('key');
+  const key = rawKey ? parseSiteContentBlockKey(rawKey) : null;
   if (!key) return badRequest(c, 'Invalid site content block key');
 
   const body = await c.req.json().catch(() => null);
@@ -68,7 +70,8 @@ siteContent.put('/admin/:key', requireAdmin, async (c) => {
 });
 
 siteContent.get('/:key', async (c) => {
-  const key = parseSiteContentBlockKey(c.req.param('key'));
+  const rawKey = c.req.param('key');
+  const key = rawKey ? parseSiteContentBlockKey(rawKey) : null;
   if (!key) return badRequest(c, 'Invalid site content block key');
 
   try {

--- a/workers/api-gateway/test/origin-signature.test.ts
+++ b/workers/api-gateway/test/origin-signature.test.ts
@@ -1,0 +1,141 @@
+import { env } from 'cloudflare:test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import worker from '../src/index';
+import type { Env } from '../src/types';
+import {
+  attachOriginSignatureHeaders,
+  attachOriginSignatureHeadersForUrl,
+} from '../src/lib/origin-signature';
+
+declare module 'cloudflare:test' {
+  interface ProvidedEnv extends Pick<
+    Env,
+    'ENV' | 'BACKEND_ORIGIN' | 'BACKEND_KEY' | 'GATEWAY_SIGNING_SECRET' | 'JWT_SECRET'
+  > {}
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  env.ENV = 'development';
+  env.BACKEND_ORIGIN = 'https://backend.example';
+  env.BACKEND_KEY = 'comments-backend-key';
+  env.GATEWAY_SIGNING_SECRET = undefined;
+});
+
+describe('origin signature configuration', () => {
+  it('fails closed in protected environments when the signing secret is missing', async () => {
+    const headers = new Headers();
+
+    await expect(
+      attachOriginSignatureHeaders({
+        env: {
+          ENV: 'production',
+        } as Env,
+        headers,
+        method: 'GET',
+        pathAndQuery: '/api/v1/posts',
+      })
+    ).rejects.toMatchObject({
+      code: 'ORIGIN_SIGNATURE_CONFIG_MISSING',
+    });
+
+    expect(headers.get('X-Gateway-Signature')).toBeNull();
+  });
+
+  it('keeps unsigned development requests opt-in when no signing secret is configured', async () => {
+    const headers = new Headers();
+
+    await expect(
+      attachOriginSignatureHeaders({
+        env: {
+          ENV: 'development',
+        } as Env,
+        headers,
+        method: 'GET',
+        pathAndQuery: '/api/v1/posts',
+      })
+    ).resolves.toBeNull();
+
+    expect(headers.get('X-Gateway-Signature')).toBeNull();
+  });
+
+  it('derives the signed payload path and query from a backend URL', async () => {
+    const headers = new Headers();
+
+    await attachOriginSignatureHeadersForUrl({
+      env: {
+        ENV: 'production',
+        GATEWAY_SIGNING_SECRET: 'test-signing-secret',
+      } as Env,
+      headers,
+      method: 'GET',
+      url: 'https://backend.example/api/v1/analytics/all-stats?limit=10',
+      now: new Date('2026-05-01T00:00:00.000Z'),
+    });
+
+    expect(headers.get('X-Origin-Verified-By')).toBe('api-gateway');
+    expect(headers.get('X-Gateway-Signature')).toMatch(/^v1:[0-9a-f]{64}$/);
+  });
+});
+
+describe('scheduled backend calls', () => {
+  it('signs cron refresh and editor-picks backend requests', async () => {
+    env.ENV = 'production';
+    env.BACKEND_ORIGIN = 'https://backend.example';
+    env.BACKEND_KEY = 'cron-backend-key';
+    env.GATEWAY_SIGNING_SECRET = 'test-signing-secret';
+
+    const upstreamFetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/v1/analytics/refresh-stats')) {
+        return new Response(JSON.stringify({ ok: true, data: { refreshed: 1 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/v1/analytics/all-stats')) {
+        return new Response(JSON.stringify({ ok: true, data: { stats: [] } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/v1/ai/queue-stats')) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: { enabled: false, asyncMode: false, queueLength: 0, dlqLength: 0 },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    await worker.scheduled({} as ScheduledEvent, env as Env, {} as ExecutionContext);
+
+    const analyticsCalls = upstreamFetch.mock.calls.filter(([input]) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      return url.includes('/api/v1/analytics/');
+    });
+
+    expect(analyticsCalls).toHaveLength(2);
+    for (const [, init] of analyticsCalls) {
+      const headers = new Headers(init?.headers);
+      expect(headers.get('X-Backend-Key')).toBe('cron-backend-key');
+      expect(headers.get('X-Origin-Verified-By')).toBe('api-gateway');
+      expect(headers.get('X-Gateway-Signature-Version')).toBe('v1');
+      expect(headers.get('X-Gateway-Timestamp')).toBeTruthy();
+      expect(headers.get('X-Gateway-Request-ID')).toBeTruthy();
+      expect(headers.get('X-Gateway-Signature')).toMatch(/^v1:[0-9a-f]{64}$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce Worker release gates for required signing/encryption secrets, production D1 migration apply/verify, and signed backend-origin requests, including scheduled and direct Worker backend calls.
- Add a rollback runbook and refresh generated route/architecture contract snapshots.
- Add chat SSE `Idempotency-Key` support with cached replay/conflict handling and a per-session turn guard that returns `409 CHAT_TURN_IN_PROGRESS` for concurrent turns.
- Generate and send chat idempotency keys from the frontend stream client.

## Testing
- `workers/api-gateway`: `npm run typecheck`
- `workers/api-gateway`: `npm run test`
- `workers/api-gateway`: `npm audit --omit=dev`
- repo root: `node scripts/check-route-governance.mjs`
- repo root: `npm run contracts:check`
- `backend`: `node --test test/chat-idempotency-concurrency.test.js`
- `backend`: `npm test` (44 passed, 1 skipped)
- `frontend`: `npx vitest run src/test/chatUploadAuth.test.ts --config config/vite.config.ts`
- `frontend`: `npm run type-check`
- repo root: `git diff --check`

## Risks
- Branch was created from the local `fix/minor-bugs` base; `origin/main` has advanced. A read-only `git merge-tree` check did not show conflict markers before push.
- Full non-omit audits for backend/frontend were not used as release gates here; `npm ci` reports existing dependency advisories in those packages.

## Follow-ups
- Rehearse the rollback runbook against staging with a recorded previous stable Worker version and image SHA.
- Capture latest GitHub Actions run URLs after CI completes on this PR.
