### PR TITLE
Fix FAB feature flag type-check

### DIFF
--- a/frontend/src/test/FloatingActionBar.feature-flag.test.tsx
+++ b/frontend/src/test/FloatingActionBar.feature-flag.test.tsx
@@ -52,6 +52,7 @@ const ensureTestAIMemoElementDefinition = () => {
 };
 
 beforeEach(() => {
+  ensureTestAIMemoElementDefinition();
   localStorage.clear();
   window.history.replaceState({}, '', '/projects');
 });


### PR DESCRIPTION
## Summary
- Register the test-only ai-memo-pad custom element stub in the FAB feature-flag test setup.
- Fix the TS6133 unused declaration error without changing production behavior.

## Testing
- npm --prefix frontend run type-check
- npm --prefix frontend run test:run -- FloatingActionBar.feature-flag.test.tsx

## Risks
- Low; change is limited to test setup.
- Targeted Vitest run still emits existing non-fatal warnings about React Router future flags, local API base fallback, project manifest fetch URL parsing, and act-wrapping.

## Follow-ups
- None.