### PR TITLE
refactor(ai-memo): unify catalyst action panel

### DIFF
--- a/frontend/public/ai-memo/ai-memo.css
+++ b/frontend/public/ai-memo/ai-memo.css
@@ -1301,255 +1301,208 @@
 }
 
 /* ========================================
-   CATALYST PANEL - Improved UX
+   CATALYST PANEL - Unified assistant panel
    ======================================== */
 .catalyst-panel {
-  padding: 18px;
-  background: radial-gradient(circle at top, rgba(124, 58, 237, 0.08), rgba(15, 23, 42, 0))
-      rgba(247, 248, 252, 0.9);
-  border-top: 1px solid rgba(124, 58, 237, 0.15);
-  animation: catalyst-slide-in 0.2s ease-out;
+  padding: 14px 18px 18px;
+  border-top: 1px solid var(--memo-border);
+  background: var(--memo-surface-subtle);
+  animation: catalyst-slide-in 180ms var(--memo-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+
+.catalyst-panel[hidden] {
+  display: none !important;
 }
 
 @keyframes catalyst-slide-in {
   from {
     opacity: 0;
-    transform: translateY(-8px);
+    transform: translateY(-6px) scale(0.995);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
   }
 }
 
-:host(.dark) .catalyst-panel {
-  background: radial-gradient(circle at top, rgba(124, 58, 237, 0.25), rgba(7, 11, 22, 0.85))
-      rgba(6, 9, 18, 0.92);
-  border-top-color: rgba(124, 58, 237, 0.35);
-}
-
 .catalyst-card {
-  border-radius: 24px;
-  padding: 20px 24px;
-  background: #fff;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
-  border: 1px solid rgba(124, 58, 237, 0.1);
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 14px;
+  padding: 16px;
+  border: 1px solid var(--memo-border);
+  border-radius: 8px;
+  background: var(--memo-surface);
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.08);
 }
 
-:host(.dark) .catalyst-card {
-  background: rgba(15, 23, 42, 0.9);
-  border-color: rgba(124, 58, 237, 0.25);
-  box-shadow: 0 25px 50px rgba(4, 6, 12, 0.6);
+.catalyst-header,
+.catalyst-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
 }
 
 .catalyst-header {
-  display: flex;
-  align-items: center;
   justify-content: space-between;
-  gap: 12px;
-}
-
-.catalyst-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(124, 58, 237, 0.1);
-  border: 1px solid rgba(124, 58, 237, 0.2);
 }
 
 .catalyst-icon {
-  font-size: 14px;
-  color: #7c3aed;
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 36px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: rgba(109, 93, 252, 0.1);
+  color: var(--memo-ai);
+  font-size: 17px;
 }
 
 .catalyst-title {
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  font-size: 11px;
-  color: #4c1d95;
-}
-
-:host(.dark) .catalyst-icon {
-  color: #c4b5fd;
-}
-
-:host(.dark) .catalyst-title {
-  color: #d8b4fe;
+  color: var(--memo-text);
+  font: 850 15px/1.2 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Pretendard", sans-serif;
+  letter-spacing: 0;
 }
 
 .catalyst-status {
-  font-size: 12px;
-  font-weight: 500;
-  color: rgba(15, 23, 42, 0.6);
-}
-
-:host(.dark) .catalyst-status {
-  color: rgba(248, 250, 252, 0.6);
+  display: inline-flex;
+  min-height: 26px;
+  align-items: center;
+  padding: 0 10px;
+  border: 1px solid rgba(109, 93, 252, 0.18);
+  border-radius: 999px;
+  background: rgba(109, 93, 252, 0.08);
+  color: var(--memo-ai);
+  font: 800 11px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
 .catalyst-subtext {
-  font-size: 13px;
-  line-height: 1.5;
-  color: rgba(15, 23, 42, 0.75);
-  margin: 0;
-}
-
-:host(.dark) .catalyst-subtext {
-  color: rgba(226, 232, 240, 0.78);
+  margin: 3px 0 0;
+  color: var(--memo-text-muted);
+  font: 600 12px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
 .catalyst-input-label {
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.7);
-}
-
-:host(.dark) .catalyst-input-label {
-  color: rgba(226, 232, 240, 0.7);
+  color: var(--memo-text);
+  font: 800 12px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
 .catalyst-input-shell {
   position: relative;
-  margin-top: 4px;
+  margin-top: 8px;
 }
 
 .catalyst-input {
   width: 100%;
-  padding: 14px 44px 14px 38px;
-  font: 500 14px/1.4 'Pretendard', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    sans-serif;
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: 16px;
+  min-height: 48px;
+  padding: 12px 72px 12px 14px;
+  border: 1px solid var(--memo-border);
+  border-radius: 8px;
+  background: var(--memo-surface);
+  color: var(--memo-text);
+  font: 700 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Pretendard", sans-serif;
   outline: none;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color 140ms var(--memo-ease), box-shadow 140ms var(--memo-ease), background 140ms var(--memo-ease);
   box-sizing: border-box;
-  color: #0f172a;
 }
 
 .catalyst-input::placeholder {
-  color: rgba(15, 23, 42, 0.4);
+  color: var(--memo-text-subtle);
 }
 
 .catalyst-input:hover {
-  border-color: rgba(124, 58, 237, 0.45);
+  border-color: var(--memo-border-strong);
 }
 
 .catalyst-input:focus {
-  border-color: rgba(124, 58, 237, 0.65);
-  box-shadow: 0 10px 30px rgba(124, 58, 237, 0.18), 0 0 0 3px rgba(124, 58, 237, 0.15);
-  background: #fff;
+  border-color: var(--memo-ai);
+  box-shadow: 0 0 0 3px rgba(109, 93, 252, 0.14);
 }
 
-:host(.dark) .catalyst-input {
-  background: rgba(10, 12, 25, 0.9);
-  border-color: rgba(124, 58, 237, 0.25);
-  color: #e2e8f0;
-}
-
-:host(.dark) .catalyst-input::placeholder {
-  color: rgba(226, 232, 240, 0.45);
-}
-
-:host(.dark) .catalyst-input:hover {
-  border-color: rgba(168, 85, 247, 0.5);
-}
-
-:host(.dark) .catalyst-input:focus {
-  border-color: rgba(190, 161, 255, 0.9);
-  box-shadow: 0 18px 45px rgba(7, 10, 20, 0.9), 0 0 0 3px rgba(124, 58, 237, 0.2);
-  background: rgba(7, 10, 20, 0.95);
-}
-
-.catalyst-input-indicator {
-  position: absolute;
-  left: 14px;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 13px;
-  font-weight: 600;
-  color: rgba(124, 58, 237, 0.9);
+.catalyst-input:disabled {
+  opacity: 0.62;
 }
 
 .catalyst-input-hint {
   position: absolute;
-  right: 16px;
+  right: 14px;
   top: 50%;
+  color: var(--memo-text-subtle);
+  font: 750 11px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   transform: translateY(-50%);
-  font-size: 11px;
-  color: rgba(15, 23, 42, 0.4);
 }
 
-:host(.dark) .catalyst-input-hint {
-  color: rgba(226, 232, 240, 0.45);
-}
-
-.catalyst-suggestions {
-  display: flex;
-  flex-wrap: wrap;
+.catalyst-quick-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 8px;
-  margin-top: 4px;
 }
 
 .catalyst-suggestion {
-  border: none;
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+  border: 1px solid var(--memo-border);
+  border-radius: 8px;
+  background: var(--memo-surface);
+  color: var(--memo-text-muted);
   cursor: pointer;
-  font: inherit;
-  font-size: 11px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(124, 58, 237, 0.08);
-  border: 1px solid rgba(124, 58, 237, 0.2);
-  color: #5b21b6;
-  cursor: pointer;
-  transition: background 0.2s, color 0.2s, transform 0.2s;
+  font: 800 12px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  transition: transform 140ms var(--memo-spring), border-color 140ms var(--memo-ease), background 140ms var(--memo-ease), color 140ms var(--memo-ease);
 }
 
 .catalyst-suggestion:hover {
-  background: rgba(124, 58, 237, 0.2);
   transform: translateY(-1px);
+  border-color: rgba(109, 93, 252, 0.28);
+  background: rgba(109, 93, 252, 0.08);
+  color: var(--memo-ai);
 }
 
-:host(.dark) .catalyst-suggestion {
-  background: rgba(124, 58, 237, 0.2);
-  border-color: rgba(124, 58, 237, 0.35);
-  color: #d8b4fe;
+.catalyst-suggestion:active {
+  transform: scale(0.97);
+}
+
+.catalyst-suggestion:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(109, 93, 252, 0.16);
 }
 
 .catalyst-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 10px;
-  margin-top: 6px;
+  gap: 8px;
+  padding-top: 2px;
 }
 
 .catalyst-run {
   display: inline-flex;
+  min-height: 44px;
   align-items: center;
   gap: 8px;
-  padding-inline: 18px;
-  background: linear-gradient(135deg, #7c3aed 0%, #a855f7 45%, #ec4899 100%);
-  color: #fff;
   border-color: transparent;
-  border-radius: 999px;
-  box-shadow: 0 15px 35px rgba(124, 58, 237, 0.35);
+  border-radius: 8px;
+  background: var(--memo-ai);
+  color: #fff;
+  box-shadow: 0 12px 28px rgba(109, 93, 252, 0.24);
 }
 
-.catalyst-run:hover {
-  transform: translateY(-1px) scale(1.01);
-  box-shadow: 0 20px 45px rgba(124, 58, 237, 0.45);
+.catalyst-run:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 34px rgba(109, 93, 252, 0.32);
 }
 
-.catalyst-run:active {
-  transform: translateY(0);
+.catalyst-run:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.catalyst-run:disabled {
+  cursor: not-allowed;
+  opacity: 0.54;
+  box-shadow: none;
 }
 
 .catalyst-run-icon {
@@ -2360,6 +2313,19 @@
   /* Catalyst panel mobile */
   .catalyst-panel {
     padding: 12px;
+  }
+
+  .catalyst-header,
+  .catalyst-heading {
+    align-items: flex-start;
+  }
+
+  .catalyst-header {
+    flex-direction: column;
+  }
+
+  .catalyst-quick-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .catalyst-actions {
@@ -3509,6 +3475,18 @@ body.ai-memo-block-select-active {
   background: var(--memo-primary);
 }
 
+.status-bar[data-state="busy"] .status-dot {
+  background: var(--memo-ai);
+}
+
+.status-bar[data-state="saved"] .status-dot {
+  background: #16a34a;
+}
+
+.status-bar[data-state="error"] .status-dot {
+  background: var(--memo-danger);
+}
+
 .footer-actions {
   gap: 6px;
 }
@@ -3959,6 +3937,10 @@ body.ai-memo-block-select-active {
   .tab,
   .footer-btn,
   .save-btn,
+  .catalyst-panel,
+  .catalyst-input,
+  .catalyst-suggestion,
+  .catalyst-run,
   .window-control,
   .header .close,
   .status-dot {
@@ -4832,14 +4814,20 @@ body.ai-memo-block-select-active {
   .history-info,
   .code-mode,
   .code-mode-button,
-  .code-mode-select {
+  .code-mode-select,
+  .catalyst-panel,
+  .catalyst-input,
+  .catalyst-suggestion,
+  .catalyst-run {
     animation: none !important;
     transition: none !important;
   }
 
   .code-mode,
   .code-mode.is-visible,
-  .code-mode-button:active:not(:disabled) {
+  .code-mode-button:active:not(:disabled),
+  .catalyst-suggestion,
+  .catalyst-run {
     transform: none !important;
   }
 

--- a/frontend/public/ai-memo/ai-memo.js
+++ b/frontend/public/ai-memo/ai-memo.js
@@ -61,6 +61,7 @@
   const DEFAULT_API_URL = 'https://api.nodove.com';
   const DEFAULT_REPO_URL = 'https://github.com/choisimo/blog';
   const AI_MEMO_ASSET_VERSION = '20260501-memo-editor-redesign';
+  const CATALYST_PROMPT_MAX_LENGTH = 160;
   const BLOCK_SELECTORS = 'p, pre, code, blockquote, ul, ol, li, table, thead, tbody, tr, th, td, figure, figcaption, h1, h2, h3, h4, h5, h6, section, article, main';
   const MAX_BLOCK_PAYLOAD_CHARS = 6000;
   const WINDOW_MIN_WIDTH = 360;
@@ -90,6 +91,12 @@
     { label: 'C', value: 'c', aliases: [], pistonLang: 'c', pistonVersion: '10.2.0' },
     { label: 'Shell', value: 'bash', aliases: ['sh', 'shell', 'zsh'], pistonLang: 'bash', pistonVersion: '5.2.0' },
   ];
+  const CATALYST_QUICK_ACTIONS = [
+    { id: 'summary', label: '요약', prompt: '현재 문서를 핵심 요약과 다음 행동으로 정리해줘' },
+    { id: 'format', label: '포맷 변환', prompt: '현재 메모를 블로그 글 구조로 변환해줘' },
+    { id: 'visualize', label: '시각화', prompt: '문서의 개념과 데이터를 표와 차트 아이디어로 정리해줘' },
+    { id: 'learning', label: '학습 문제', prompt: '현재 문서 기반의 퀴즈와 플래시카드를 만들어줘' },
+  ];
 
   function normalizeBaseUrl(url) {
     let normalized = String(url || '').trim();
@@ -110,6 +117,14 @@
       normalized = normalized.slice(0, -4);
     }
     return normalized;
+  }
+
+  function escapeAttribute(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
   }
 
   function getFabPositionSetting() {
@@ -723,11 +738,10 @@
 
       const btn = this.$aiSummary;
       const prevStatus = this.out.getStatus();
-      const statusDot = this.shadowRoot?.querySelector('.status-dot');
       
       try {
         btn.disabled = true;
-        if (statusDot) statusDot.style.background = '#7c3aed';
+        this.setStatusState('busy');
         this.out.setStatus('AI 요약 중…');
         
         const backend = window.__APP_CONFIG?.apiBaseUrl || window.APP_CONFIG?.apiBaseUrl || DEFAULT_API_URL;
@@ -758,19 +772,19 @@
         const block = `\n\n[AI 요약 @ ${stamp}]\n${out.trim()}\n`;
         this.out.append(block);
         this.out.toast('AI 요약이 메모에 추가되었습니다.');
-        if (statusDot) statusDot.style.background = 'var(--memo-accent)';
+        this.setStatusState('saved');
         this.out.setStatus('완료');
         this.logEvent({ type: 'ai_summary_done', label: 'ok' });
       } catch (err) {
         console.error('Gemini summarize error:', err);
-        if (statusDot) statusDot.style.background = '#dc2626';
+        this.setStatusState('error');
         this.out.setStatus('오류');
         this.out.toast(err?.message || '요약 중 오류가 발생했습니다.');
         this.logEvent({ type: 'ai_summary_error', label: err?.message || 'error' });
       } finally {
         btn.disabled = false;
         setTimeout(() => {
-          if (statusDot) statusDot.style.background = 'var(--memo-accent)';
+          this.setStatusState('idle');
           this.out.setStatus(prevStatus || 'Ready');
         }, 1400);
       }
@@ -796,14 +810,10 @@
       const prev = this.out.getStatus();
       
       try {
-        // Set loading state
         if (btn) btn.disabled = true;
         if (inputEl) inputEl.disabled = true;
         if (catalystPanel) catalystPanel.classList.add('loading');
-        
-        // Update status with loading indicator
-        const statusDot = this.shadowRoot?.querySelector('.status-dot');
-        if (statusDot) statusDot.style.background = '#7c3aed';
+        this.setStatusState('busy');
         this.out.setStatus('Catalyst 생성 중…');
         
         const backend = window.__APP_CONFIG?.apiBaseUrl || window.APP_CONFIG?.apiBaseUrl || DEFAULT_API_URL;
@@ -836,25 +846,23 @@
         this.out.toast('Catalyst 결과가 메모에 추가되었습니다.');
         this.logEvent({ type: 'catalyst_run', label: prompt });
         if (this.$catalystInput) this.$catalystInput.value = '';
-        if (this.$catalystBox) this.$catalystBox.style.display = 'none';
+        this.syncCatalystInputState();
+        this.setCatalystOpen(false);
         if (this.$catalystInput) this.$catalystInput.disabled = false;
-        
-        // Success status
-        if (statusDot) statusDot.style.background = 'var(--memo-accent)';
+        this.setStatusState('saved');
         this.out.setStatus('완료');
       } catch (err) {
         console.error('Catalyst error:', err);
-        const statusDot = this.shadowRoot?.querySelector('.status-dot');
-        if (statusDot) statusDot.style.background = '#dc2626';
+        this.setStatusState('error');
         this.out.setStatus('오류');
         this.out.toast(err?.message || 'Catalyst 생성 중 오류가 발생했습니다.');
       } finally {
         if (btn) btn.disabled = false;
         if (inputEl) inputEl.disabled = false;
         if (catalystPanel) catalystPanel.classList.remove('loading');
+        this.syncCatalystInputState();
         setTimeout(() => { 
-          const statusDot = this.shadowRoot?.querySelector('.status-dot');
-          if (statusDot) statusDot.style.background = 'var(--memo-accent)';
+          this.setStatusState('idle');
           this.out.setStatus(prev || 'Ready'); 
         }, 1400);
       }
@@ -1348,7 +1356,41 @@
 
     setMemoAutoSaveText(text) {
       if (!this.$memoAutoSave) return;
-      this.$memoAutoSave.textContent = String(text || '자동 저장됨');
+      this.$memoAutoSave.textContent = String(text || '저장됨');
+    }
+
+    setStatusState(state = 'idle') {
+      if (!this.$status) return;
+      const next = ['idle', 'busy', 'saved', 'error'].includes(state) ? state : 'idle';
+      this.$status.dataset.state = next;
+    }
+
+    setCatalystOpen(open) {
+      if (!this.$catalystBox) return;
+      const visible = Boolean(open);
+      this.$catalystBox.hidden = !visible;
+      this.$catalystBox.setAttribute('aria-hidden', visible ? 'false' : 'true');
+      this.$catalystBtn?.setAttribute('aria-expanded', visible ? 'true' : 'false');
+      if (visible) {
+        this.syncCatalystInputState();
+        setTimeout(() => this.$catalystInput?.focus(), 0);
+      }
+    }
+
+    syncCatalystInputState() {
+      if (!this.$catalystInput) return;
+      const raw = this.$catalystInput.value || '';
+      if (raw.length > CATALYST_PROMPT_MAX_LENGTH) {
+        this.$catalystInput.value = raw.slice(0, CATALYST_PROMPT_MAX_LENGTH);
+      }
+      const value = this.$catalystInput.value || '';
+      if (this.$catalystCharCount) {
+        this.$catalystCharCount.textContent = `${value.length}/${CATALYST_PROMPT_MAX_LENGTH}`;
+      }
+      if (this.$catalystRun) {
+        const loading = this.$catalystBox?.classList.contains('loading');
+        this.$catalystRun.disabled = Boolean(loading || !value.trim());
+      }
     }
 
     setMemoTitle(title, options = {}) {
@@ -1852,7 +1894,7 @@
           <div id="drag" class="header">
             <div class="title-stack">
               <div id="memoTitleDisplay" class="title">새 메모</div>
-              <div id="memoAutoSave" class="auto-save">자동 저장됨</div>
+              <div id="memoAutoSave" class="auto-save" aria-live="polite">저장됨</div>
             </div>
             <div class="spacer"></div>
             <button id="memoHelp" class="header-help" type="button" aria-label="도움말">도움말</button>
@@ -1894,7 +1936,7 @@
             <div class="toolbar-divider"></div>
             <div class="toolbar-group ai-group" role="toolbar" aria-label="AI 기능">
               <button id="aiSummary" class="toolbar-btn ai" type="button" title="AI로 요약 생성" aria-label="AI 요약"><span class="icon">✦</span><span class="label">요약</span></button>
-              <button id="catalyst" class="toolbar-btn ai primary" type="button" title="Catalyst 프롬프트" aria-label="Catalyst"><span class="icon">⚡</span><span class="label">Catalyst</span></button>
+              <button id="catalyst" class="toolbar-btn ai primary" type="button" title="Catalyst 프롬프트" aria-label="Catalyst" aria-expanded="false" aria-controls="catalystBox"><span class="icon">⚡</span><span class="label">Catalyst</span></button>
             </div>
           </div>
           <div class="tabs" role="tablist" aria-label="메모 패널">
@@ -2050,43 +2092,44 @@
             </div>
           </div>
 
-          <div id="catalystBox" class="catalyst-panel" style="display:none;">
+          <div id="catalystBox" class="catalyst-panel" hidden aria-hidden="true" aria-label="Catalyst AI 작업 패널">
             <div class="catalyst-card">
               <div class="catalyst-header">
-                <span class="catalyst-pill">
-                  <span class="catalyst-icon">⚡</span>
-                  <span class="catalyst-title">Catalyst</span>
-                </span>
-                <span class="catalyst-status">실험 기능</span>
+                <div class="catalyst-heading">
+                  <span class="catalyst-icon" aria-hidden="true">⚡</span>
+                  <div>
+                    <div class="catalyst-title">Catalyst</div>
+                    <p class="catalyst-subtext">문서 내용과 현재 메모를 기준으로 작업합니다.</p>
+                  </div>
+                </div>
+                <span class="catalyst-status">Beta</span>
               </div>
-              <p class="catalyst-subtext">
-                AI에게 확장 프롬프트를 전달해 요약, 인사이트, 액션 아이템 등을 빠르게 받아보세요.
-              </p>
-              <label class="catalyst-input-label" for="catalystInput">프롬프트</label>
+              <label class="catalyst-input-label" for="catalystInput">문서 작업</label>
               <div class="catalyst-input-shell">
-                <span class="catalyst-input-indicator">/</span>
                 <input
                   id="catalystInput"
                   class="input catalyst-input"
-                  placeholder="어떻게 확장해볼까요? 예: 사용 사례 관점에서 다시 보기"
-                  maxlength="160"
+                  placeholder="문서에서 어떤 작업을 할까요?"
+                  maxlength="${CATALYST_PROMPT_MAX_LENGTH}"
                 />
-                <span class="catalyst-input-hint">최대 160자</span>
+                <span class="catalyst-input-hint" id="catalystCharCount">0/${CATALYST_PROMPT_MAX_LENGTH}</span>
               </div>
-              <div class="catalyst-suggestions" aria-label="추천 프롬프트">
-                <button type="button" class="catalyst-suggestion">사용 사례 정리</button>
-                <button type="button" class="catalyst-suggestion">톤 조정</button>
-                <button type="button" class="catalyst-suggestion">액션 아이템</button>
+              <div class="catalyst-quick-grid" aria-label="자주 쓰는 작업">
+                ${CATALYST_QUICK_ACTIONS.map(action => `
+                  <button type="button" class="catalyst-suggestion" data-action="${escapeAttribute(action.id)}" data-prompt="${escapeAttribute(action.prompt)}">
+                    <span>${escapeAttribute(action.label)}</span>
+                  </button>
+                `).join('')}
               </div>
-              <div class="catalyst-actions">
+              <div id="catalystActionBar" class="catalyst-actions">
                 <button id="catalystCancel" class="btn secondary">취소</button>
-                <button id="catalystRun" class="btn catalyst-run"><span class="catalyst-run-icon">▶</span> 생성</button>
+                <button id="catalystRun" class="btn catalyst-run" disabled><span class="catalyst-run-icon">▶</span> 생성 후 삽입</button>
               </div>
             </div>
           </div>
           <div class="footer">
             <div class="footer-utility">
-              <div id="status" class="status-bar">
+              <div id="status" class="status-bar" data-state="idle" aria-live="polite">
                 <span class="status-dot"></span>
                 <span class="status-text">Ready</span>
               </div>
@@ -2112,8 +2155,8 @@
               </div>
             </div>
             <div class="footer-primary-actions">
-              <button id="memoDraft" class="save-btn secondary" type="button">임시저장</button>
-              <button id="memoSaveClose" class="save-btn primary" type="button">저장 및 닫기</button>
+              <button id="memoDraft" class="save-btn secondary" type="button">지금 저장</button>
+              <button id="memoSaveClose" class="save-btn primary" type="button">닫기</button>
             </div>
           </div>
           <div id="toast" class="toast"></div>
@@ -2217,6 +2260,7 @@
       this.$catalystInput = this.shadowRoot.getElementById('catalystInput');
       this.$catalystRun = this.shadowRoot.getElementById('catalystRun');
       this.$catalystCancel = this.shadowRoot.getElementById('catalystCancel');
+      this.$catalystCharCount = this.shadowRoot.getElementById('catalystCharCount');
       this.$catalystSuggestions = Array.from(
         this.shadowRoot.querySelectorAll('.catalyst-suggestion')
       );
@@ -2629,7 +2673,9 @@
       if (this.$memoEditor) this.$memoEditor.value = this.state.memo || '';
       if (this.$memoPreview) this.renderMarkdownToPreview(this.state.memo || '');
       this.updateMemoChrome(this.state.memo || '');
-      this.setMemoAutoSaveText('자동 저장됨');
+      this.setMemoAutoSaveText('저장됨');
+      this.setStatusState('idle');
+      this.syncCatalystInputState();
       this.syncCodeMode(this.state.memo || '');
       if (this.$inlineEnabled)
         this.$inlineEnabled.checked = !!this.state.inlineEnabled;
@@ -3589,7 +3635,8 @@
          this.state.memo = value;
          this.syncCodeMode(value);
          this.updateMemoChrome(value);
-         this.setMemoAutoSaveText('자동 저장 중…');
+         this.setMemoAutoSaveText('저장 중…');
+         this.setStatusState('busy');
          if (this.$memoEditor && this.$memoEditor.value !== value) {
            this.$memoEditor.value = value;
          }
@@ -3602,7 +3649,8 @@
          clearTimeout(memoSaveTimer);
          memoSaveTimer = setTimeout(() => {
            LS.set(KEYS.memo, this.state.memo);
-           this.setMemoAutoSaveText('자동 저장됨 방금 전');
+           this.setMemoAutoSaveText('저장됨 · 방금 전');
+           this.setStatusState('saved');
            this.out.tempStatus('저장됨', 'Ready', 900);
          }, MEMO_SAVE_DELAY);
        };
@@ -3610,7 +3658,8 @@
        const saveMemoImmediately = () => {
          clearTimeout(memoSaveTimer);
          LS.set(KEYS.memo, this.state.memo);
-         this.setMemoAutoSaveText('자동 저장됨 방금 전');
+         this.setMemoAutoSaveText('저장됨 · 방금 전');
+         this.setStatusState('saved');
        };
        
        const saveMemo = () => {
@@ -3631,7 +3680,8 @@
           clearTimeout(editorSaveTimer);
           editorSaveTimer = setTimeout(() => {
             LS.set(KEYS.memo, this.state.memo);
-            this.setMemoAutoSaveText('자동 저장됨 방금 전');
+            this.setMemoAutoSaveText('저장됨 · 방금 전');
+            this.setStatusState('saved');
             this.out.tempStatus('저장됨', 'Ready', 900);
           }, EDITOR_SAVE_DELAY);
         };
@@ -3639,14 +3689,16 @@
         const saveEditorImmediately = () => {
           clearTimeout(editorSaveTimer);
           LS.set(KEYS.memo, this.state.memo);
-          this.setMemoAutoSaveText('자동 저장됨 방금 전');
+          this.setMemoAutoSaveText('저장됨 · 방금 전');
+          this.setStatusState('saved');
         };
         
         const saveAndRender = () => {
           this.state.memo = this.$memoEditor.value;
           this.syncCodeMode(this.state.memo);
           this.updateMemoChrome(this.state.memo);
-          this.setMemoAutoSaveText('자동 저장 중…');
+          this.setMemoAutoSaveText('저장 중…');
+          this.setStatusState('busy');
           this.scheduleRenderPreview(this.state.memo);
           if (this.$memo.value !== this.state.memo) this.$memo.value = this.state.memo;
           scheduleEditorSave();
@@ -3806,16 +3858,17 @@
         this.state.memo = this.$memo.value || '';
         LS.set(KEYS.memo, this.state.memo);
         this.updateMemoChrome(this.state.memo);
-        this.setMemoAutoSaveText('자동 저장됨 방금 전');
+        this.setMemoAutoSaveText('저장됨 · 방금 전');
+        this.setStatusState('saved');
         this.out.tempStatus(label || '저장됨', 'Ready', 900);
       };
       this.$memoDraft?.addEventListener('click', () => {
-        persistMemoNow('임시저장됨');
-        this.out.toast('임시저장했습니다.');
+        persistMemoNow('저장됨');
+        this.out.toast('저장했습니다.');
       });
       this.$memoSaveClose?.addEventListener('click', () => {
         persistMemoNow('저장됨');
-        this.out.toast('저장했습니다.');
+        this.out.toast('저장하고 닫았습니다.');
         this.$panel.classList.remove('open');
         this.updateOpen();
       });
@@ -3928,27 +3981,22 @@
       if (this.$catalystBtn) {
         this.$catalystBtn.addEventListener('click', () => {
           if (!this.$catalystBox) return;
-          const visible = this.$catalystBox.style.display !== 'none';
-          this.$catalystBox.style.display = visible ? 'none' : 'flex';
+          const visible = !this.$catalystBox.hidden;
+          this.setCatalystOpen(!visible);
           this.logEvent({ type: visible ? 'catalyst_close' : 'catalyst_open', label: visible ? 'close' : 'open' });
-          if (!visible) {
-            setTimeout(() => this.$catalystInput?.focus(), 0);
-          }
         });
       }
       if (this.$catalystCancel) {
          this.$catalystCancel.addEventListener('click', () => {
            if (this.$catalystInput) this.$catalystInput.value = '';
-           if (this.$catalystBox) this.$catalystBox.style.display = 'none';
+           this.syncCatalystInputState();
+           this.setCatalystOpen(false);
            this.logEvent({ type: 'catalyst_cancel', label: 'cancel' });
          });
       }
       if (this.$catalystRun) {
          this.$catalystRun.addEventListener('click', () => this.runCatalyst());
-         this.$catalystInput?.addEventListener('input', () => {
-           const v = this.$catalystInput.value || '';
-           if (v.length > 160) this.$catalystInput.value = v.slice(0,160);
-         });
+         this.$catalystInput?.addEventListener('input', () => this.syncCatalystInputState());
       }
       if (this.$catalystInput) {
         this.$catalystInput.addEventListener('keydown', (e) => {
@@ -3959,7 +4007,7 @@
       if (Array.isArray(this.$catalystSuggestions) && this.$catalystSuggestions.length) {
         this.$catalystSuggestions.forEach(btn => {
           btn.addEventListener('click', () => {
-            const text = btn.textContent?.trim();
+            const text = btn.dataset.prompt || btn.textContent?.trim();
             if (!text || !this.$catalystInput) return;
             this.$catalystInput.value = text;
             this.$catalystInput.focus();

--- a/frontend/src/test/FloatingActionBar.feature-flag.test.tsx
+++ b/frontend/src/test/FloatingActionBar.feature-flag.test.tsx
@@ -18,39 +18,6 @@ const withFab = async (enabled: boolean) => {
   });
 };
 
-const ensureTestAIMemoElementDefinition = () => {
-  if (customElements.get('ai-memo-pad')) return;
-
-  class TestAIMemoPad extends HTMLElement {
-    private panel: HTMLElement | null = null;
-    private readonly onWindowCommand = (event: Event) => {
-      const detail = (event as CustomEvent<{ action?: string }>).detail || {};
-      if (detail.action === 'toggle') {
-        this.panel?.classList.toggle('open');
-      }
-    };
-
-    connectedCallback() {
-      if (!this.shadowRoot) {
-        const shadow = this.attachShadow({ mode: 'open' });
-        const panel = document.createElement('div');
-        panel.id = 'panel';
-        shadow.appendChild(panel);
-        this.panel = panel;
-      } else {
-        this.panel = this.shadowRoot.getElementById('panel');
-      }
-      window.addEventListener('aiMemo:windowCommand', this.onWindowCommand);
-    }
-
-    disconnectedCallback() {
-      window.removeEventListener('aiMemo:windowCommand', this.onWindowCommand);
-    }
-  }
-
-  customElements.define('ai-memo-pad', TestAIMemoPad);
-};
-
 beforeEach(() => {
   localStorage.clear();
   window.history.replaceState({}, '', '/projects');

--- a/frontend/src/test/aiMemoWindowSystem.static.test.ts
+++ b/frontend/src/test/aiMemoWindowSystem.static.test.ts
@@ -18,6 +18,19 @@ describe("AI Memo window system assets", () => {
     expect(js).toContain("data-resize=\"se\"");
   });
 
+  it("keeps Catalyst on the unified assistant action contract", () => {
+    const js = readFileSync(
+      resolve(root, "public/ai-memo/ai-memo.js"),
+      "utf8",
+    );
+
+    expect(js).toContain("CATALYST_QUICK_ACTIONS");
+    expect(js).toContain("setCatalystOpen");
+    expect(js).toContain("id=\"catalystActionBar\"");
+    expect(js).toContain("생성 후 삽입");
+    expect(js).toContain("aria-live=\"polite\"");
+  });
+
   it("keeps fullscreen, docked, and resize CSS affordances", () => {
     const css = readFileSync(
       resolve(root, "public/ai-memo/ai-memo.css"),
@@ -28,6 +41,19 @@ describe("AI Memo window system assets", () => {
     expect(css).toContain(".panel.window-docked");
     expect(css).toContain(".resize-handle-se");
     expect(css).toContain(":host(.terminal) .panel");
+  });
+
+  it("keeps assistant panel visibility and status states CSS-driven", () => {
+    const css = readFileSync(
+      resolve(root, "public/ai-memo/ai-memo.css"),
+      "utf8",
+    );
+
+    expect(css).toContain(".catalyst-panel[hidden]");
+    expect(css).toContain('.status-bar[data-state="busy"]');
+    expect(css).toContain('.status-bar[data-state="saved"]');
+    expect(css).toContain('.status-bar[data-state="error"]');
+    expect(css).toContain("@media (prefers-reduced-motion: reduce)");
   });
 
   it("mounts the memo pad on the home route while keeping the blog listing suppressed", () => {


### PR DESCRIPTION
## Summary
- Refactor the AI memo Catalyst panel into a unified assistant action contract with quick actions, ARIA/hidden state, and input length/run-button state sync.
- Move memo save/status affordances to CSS-driven `data-state` rules and refresh save/close copy.
- Add static contract coverage for Catalyst/status behavior and remove an unused FAB test stub.

## Testing
- `git diff --cached --check`
- `node --check frontend/public/ai-memo/ai-memo.js`
- Custom static AI memo contract check
- `npm run test:run -- aiMemoWindowSystem.static.test.ts FloatingActionBar.feature-flag.test.tsx` (14 tests)
- `npm run type-check`
- `npm run lint`
- `npm run build`

## Risks
- Build still reports existing content/frontmatter, Browserslist, `gray-matter` eval, and chunk-size warnings.
- `npm audit` still reports 34 vulnerabilities after dependency install.

## Follow-ups
- Address audit and build warning cleanup separately from this UI refactor.