### PR TITLE
fix(test): restore FAB AI memo stub

### DIFF
--- a/frontend/src/test/FloatingActionBar.feature-flag.test.tsx
+++ b/frontend/src/test/FloatingActionBar.feature-flag.test.tsx
@@ -18,6 +18,39 @@ const withFab = async (enabled: boolean) => {
   });
 };
 
+const ensureTestAIMemoElementDefinition = () => {
+  if (customElements.get('ai-memo-pad')) return;
+
+  class TestAIMemoPad extends HTMLElement {
+    private panel: HTMLElement | null = null;
+    private readonly onWindowCommand = (event: Event) => {
+      const detail = (event as CustomEvent<{ action?: string }>).detail || {};
+      if (detail.action === 'toggle') {
+        this.panel?.classList.toggle('open');
+      }
+    };
+
+    connectedCallback() {
+      if (!this.shadowRoot) {
+        const shadow = this.attachShadow({ mode: 'open' });
+        const panel = document.createElement('div');
+        panel.id = 'panel';
+        shadow.appendChild(panel);
+        this.panel = panel;
+      } else {
+        this.panel = this.shadowRoot.getElementById('panel');
+      }
+      window.addEventListener('aiMemo:windowCommand', this.onWindowCommand);
+    }
+
+    disconnectedCallback() {
+      window.removeEventListener('aiMemo:windowCommand', this.onWindowCommand);
+    }
+  }
+
+  customElements.define('ai-memo-pad', TestAIMemoPad);
+};
+
 beforeEach(() => {
   ensureTestAIMemoElementDefinition();
   localStorage.clear();


### PR DESCRIPTION
## Summary
- Restore the test-only ai-memo-pad custom element stub used by FloatingActionBar feature flag tests.
- Fix the frontend type-check failure caused by calling ensureTestAIMemoElementDefinition without a local definition.

## Testing
- npm --prefix frontend run type-check
- npm --prefix frontend run test:run -- src/test/FloatingActionBar.feature-flag.test.tsx

## Risks
- Low risk: scoped to one test file and restores the previously intended test helper.
- Targeted vitest still emits existing React act and jsdom manifest warnings, but all 8 tests pass.

## Follow-ups
- Re-run failing PR checks on #63 and #64 after this base fix merges.