### PR TITLE
Fix markdown media caption flow

### DIFF
--- a/frontend/src/components/features/blog/MarkdownRenderer.tsx
+++ b/frontend/src/components/features/blog/MarkdownRenderer.tsx
@@ -515,6 +515,43 @@ function hasNonInlineNode(node: unknown): boolean {
   return children.some(child => hasNonInlineNode(child));
 }
 
+function hasMeaningfulInlineContent(children: ReactNode[]): boolean {
+  return children.some(child => {
+    if (child == null || child === false) return false;
+    if (typeof child === 'string' || typeof child === 'number') {
+      return String(child).trim().length > 0;
+    }
+    if (!isValidElement(child)) return true;
+    return extractRawTextFromNode(child).trim().length > 0;
+  });
+}
+
+function splitMixedParagraphChildren(children: ReactNode[]): ReactNode[][] {
+  const segments: ReactNode[][] = [];
+  let inlineSegment: ReactNode[] = [];
+
+  const flushInlineSegment = () => {
+    if (hasMeaningfulInlineContent(inlineSegment)) {
+      segments.push(inlineSegment);
+    }
+    inlineSegment = [];
+  };
+
+  children.forEach(child => {
+    if (hasNonInlineNode(child)) {
+      flushInlineSegment();
+      segments.push([child]);
+      return;
+    }
+
+    inlineSegment.push(child);
+  });
+
+  flushInlineSegment();
+
+  return segments;
+}
+
 const DEFAULT_MEDIA_LAYOUT: ArticleMediaLayout = 'wide';
 
 const MEDIA_LAYOUT_ALIASES: Record<string, ArticleMediaLayout> = {
@@ -934,54 +971,57 @@ function MarkdownRendererInner({
       },
       p: ({ children }: { children?: ReactNode }) => {
         const childArray = Children.toArray(children);
+        const renderInlineParagraph = (
+          inlineChildren: ReactNode[],
+          key?: number
+        ) => {
+          if (inlineEnabled) {
+            return (
+              <div className='article-readable' key={key}>
+                <SparkInline postTitle={postTitle} wrapperTag='p'>
+                  {inlineChildren}
+                </SparkInline>
+              </div>
+            );
+          }
+
+          return (
+            <p
+              key={key}
+              className={cn(
+                'article-readable mb-6 leading-8 text-justify',
+                isTerminal && 'border-l border-border/50 pl-4'
+              )}
+            >
+              {inlineChildren}
+            </p>
+          );
+        };
         const containsNonInlineContent = childArray.some(child =>
           hasNonInlineNode(child)
         );
 
         if (containsNonInlineContent) {
-          const hasInlineText = childArray.some(
-            child => typeof child === 'string' && child.trim().length > 0
-          );
-
-          if (!hasInlineText) {
-            return (
-              <>
-                {childArray.map((child, idx) => (
-                  <Fragment key={idx}>{child}</Fragment>
-                ))}
-              </>
-            );
-          }
-
           return (
-            <div className='article-wide-block space-y-4'>
-              {childArray.map((child, idx) => (
-                <Fragment key={idx}>{child}</Fragment>
+            <>
+              {splitMixedParagraphChildren(childArray).map((segment, idx) => (
+                <Fragment key={idx}>
+                  {segment.some(child => hasNonInlineNode(child))
+                    ? segment.map((child, childIdx) => (
+                        <Fragment key={childIdx}>{child}</Fragment>
+                      ))
+                    : renderInlineParagraph(segment)}
+                </Fragment>
               ))}
-            </div>
+            </>
           );
         }
 
         if (inlineEnabled) {
-          return (
-            <div className='article-readable'>
-              <SparkInline postTitle={postTitle} wrapperTag='p'>
-                {children}
-              </SparkInline>
-            </div>
-          );
+          return renderInlineParagraph(childArray);
         }
 
-        return (
-          <p
-            className={cn(
-              'article-readable mb-6 leading-8 text-justify',
-              isTerminal && 'border-l border-border/50 pl-4'
-            )}
-          >
-            {children}
-          </p>
-        );
+        return renderInlineParagraph(childArray);
       },
       ul: ({ children }: { children?: ReactNode }) => (
         <ul

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1914,7 +1914,22 @@
   min-width: 0;
 }
 
-.article-flow > :where(.article-readable, p, ul, ol, blockquote, h4, h5, h6) {
+.article-flow
+  > :where(
+    .article-readable,
+    p,
+    ul,
+    ol,
+    blockquote,
+    h4,
+    h5,
+    h6,
+    em,
+    strong,
+    span,
+    cite,
+    small
+  ) {
   width: 100%;
   max-width: var(--article-readable-max);
   margin-left: auto;
@@ -1973,7 +1988,22 @@
     column-gap: clamp(1rem, 2vw, 1.75rem);
   }
 
-  .article-flow > :where(.article-readable, p, ul, ol, blockquote, h4, h5, h6) {
+  .article-flow
+    > :where(
+      .article-readable,
+      p,
+      ul,
+      ol,
+      blockquote,
+      h4,
+      h5,
+      h6,
+      em,
+      strong,
+      span,
+      cite,
+      small
+    ) {
     grid-column: 3 / 11;
     max-width: none;
   }

--- a/frontend/src/test/MarkdownRenderer.images.test.tsx
+++ b/frontend/src/test/MarkdownRenderer.images.test.tsx
@@ -88,6 +88,28 @@ describe("MarkdownRenderer image paths", () => {
     expect(inlineGif).toHaveAttribute("data-src", "/images/2026/awk-1/12.gif");
   });
 
+  it("keeps image follow-up emphasis inside the readable article flow", () => {
+    const { container } = renderMarkdown(
+      [
+        "![이벤트 소싱 처리 흐름](/images/2026/hedgefunds_atomicity/event_sourcing.png)",
+        "_명령, 이벤트 기록, 상태 재구성이 분리된 append-only 처리 모델._",
+      ].join("\n"),
+      "2026/hedgefunds_transcation_manage",
+    );
+
+    const flow = container.querySelector(".article-flow");
+    const figure = flow?.querySelector("figure.article-media-frame");
+    const description = figure?.nextElementSibling;
+
+    expect(figure).not.toBeNull();
+    expect(description?.tagName).toBe("P");
+    expect(description).toHaveClass("article-readable");
+    expect(description).toHaveTextContent(
+      "명령, 이벤트 기록, 상태 재구성이 분리된 append-only 처리 모델.",
+    );
+    expect(flow?.querySelector(":scope > em")).toBeNull();
+  });
+
   it("renders markdown video assets as autoplaying inline videos", () => {
     const { container } = renderMarkdown("![Demo](image/demo/clip.mp4)");
 


### PR DESCRIPTION
## Summary
- Split mixed markdown paragraphs so media blocks and following inline emphasis render as separate article-flow items.
- Keep follow-up emphasis text inside the readable article column instead of falling into the first CSS grid column.
- Add a CSS fallback for direct inline children and a regression test for image-following emphasis text.

## Testing
- `npm run test:run -- MarkdownRenderer.images.test.tsx`
- `npx eslint src/components/features/blog/MarkdownRenderer.tsx src/test/MarkdownRenderer.images.test.tsx --config config/eslint.config.js --max-warnings 0`
- `npm run type-check`
- Playwright browser check on `/blog/2026/hedgefunds_transcation_manage`: `directEmCount: 0`, follow-up text rendered as `article-readable`, `grid-column: 3 / 11`.

## Risks
- Existing mixed paragraphs that intentionally relied on inline text sharing a wide media wrapper may now render the inline segment as normal readable text. This matches the article layout model and is covered for the observed caption case.

## Follow-ups
- None.