### PR TITLE
feat(agent): add image generation workflow

### DIFF
--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -621,7 +621,20 @@ export const STREAMING = {
  */
 export const VALID_TASK_MODES = parseJsonEnv(
   process.env.VALID_TASK_MODES,
-  ['sketch', 'prism', 'chain', 'catalyst', 'summary', 'custom', 'quiz']
+  [
+    'sketch',
+    'prism',
+    'chain',
+    'catalyst',
+    'summary',
+    'custom',
+    'quiz',
+    'visual_brief',
+    'cover_prompt',
+    'diagram_prompt',
+    'thumbnail_prompt',
+    'alt_text',
+  ]
 );
 
 // ============================================================================

--- a/backend/src/lib/agent/prompts/system.js
+++ b/backend/src/lib/agent/prompts/system.js
@@ -138,6 +138,25 @@ ${TOOL_USAGE_GUIDELINES}
 4. **Opinion Pieces**: Thoughts on tech trends and practices
 5. **Quick Tips**: Short, actionable advice
 
+## Editor Actions
+When the user asks you to update the active editor state, include a fenced \`post_actions\` JSON block after your human-readable answer. The backend will remove this block before showing the message and pass the actions to the editor.
+
+Allowed action shapes:
+\`\`\`post_actions
+{"actions":[
+  {"type":"set_title","value":"string"},
+  {"type":"set_slug","value":"string"},
+  {"type":"set_category","value":"string"},
+  {"type":"set_tags","value":["string"]},
+  {"type":"set_cover_image","url":"/images/..."},
+  {"type":"insert_markdown","markdown":"![alt](/images/...)"},
+  {"type":"replace_content","content":"markdown"},
+  {"type":"append_content","markdown":"markdown"}
+]}
+\`\`\`
+
+Use \`image_generation\` when the user asks for cover, inline, thumbnail, or visual candidate images. Generated images must come from that tool so the returned URLs are stored local \`/images/{year}/{slug}/...\` assets. Do not invent image URLs.
+
 ## Post Structure
 - **Title**: Clear, descriptive, SEO-friendly
 - **Introduction**: Hook the reader, state the problem

--- a/backend/src/routes/agent.js
+++ b/backend/src/routes/agent.js
@@ -30,6 +30,7 @@ import { getSessionMemory } from "../lib/agent/memory/session.js";
 import { requireFeature } from "../middleware/featureFlags.js";
 import { requireAdmin } from "../middleware/adminAuth.js";
 import { validateBody } from "../middleware/validation.js";
+import { runIdempotent } from "../lib/idempotency.js";
 import {
   agentRunBodySchema,
   memoryExtractBodySchema,
@@ -56,6 +57,65 @@ function resolveMaxIterations(value) {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return 4;
   return Math.max(1, Math.min(10, Math.floor(parsed)));
+}
+
+const AGENT_ACTION_TYPES = new Set([
+  "set_title",
+  "set_slug",
+  "set_category",
+  "set_tags",
+  "set_cover_image",
+  "insert_markdown",
+  "replace_content",
+  "append_content",
+]);
+
+function normalizeAgentAction(action) {
+  if (!action || typeof action !== "object") return null;
+  const type = typeof action.type === "string" ? action.type.trim() : "";
+  if (!AGENT_ACTION_TYPES.has(type)) return null;
+  return { ...action, type };
+}
+
+function extractPostActionsFromContent(content) {
+  const source = typeof content === "string" ? content : "";
+  const actions = [];
+  let cleaned = source;
+  const actionBlockRegex = /```post_actions\s*([\s\S]*?)```/g;
+  let match;
+
+  while ((match = actionBlockRegex.exec(source)) !== null) {
+    try {
+      const parsed = JSON.parse(match[1].trim());
+      const rawActions = Array.isArray(parsed) ? parsed : parsed?.actions;
+      if (Array.isArray(rawActions)) {
+        for (const action of rawActions) {
+          const normalized = normalizeAgentAction(action);
+          if (normalized) actions.push(normalized);
+        }
+      }
+      cleaned = cleaned.replace(match[0], "").trim();
+    } catch (error) {
+      logger.warn({}, "Failed to parse agent post_actions block", {
+        error: error.message,
+      });
+    }
+  }
+
+  return { content: cleaned, actions };
+}
+
+function collectToolActions(toolCalls = []) {
+  const actions = [];
+  for (const toolCall of toolCalls || []) {
+    const rawActions = toolCall?.result?.actions;
+    if (!Array.isArray(rawActions)) continue;
+    for (const action of rawActions) {
+      const normalized = normalizeAgentAction(action);
+      if (normalized) actions.push(normalized);
+    }
+  }
+  return actions;
 }
 
 function enrichAgentMessageWithLiveContext(message, sessionId) {
@@ -120,38 +180,68 @@ router.post("/run", validateBody(agentRunBodySchema), async (req, res) => {
       userId = "default-user",
     } = req.body;
 
-    const coordinator = getCoordinator();
-    const effectiveMessage = enrichAgentMessageWithLiveContext(
+    const effectiveMaxIterations = resolveMaxIterations(maxIterations);
+    const normalizedMode = normalizeMode(mode);
+    const idempotencyPayload = {
       message,
       sessionId,
+      mode: normalizedMode,
+      articleSlug,
+      tools: tools || null,
+      temperature: temperature ?? null,
+      maxIterations: effectiveMaxIterations,
+      userId,
+    };
+
+    return await runIdempotent(
+      req,
+      res,
+      "agent.run",
+      idempotencyPayload,
+      async () => {
+        const coordinator = getCoordinator();
+        const effectiveMessage = enrichAgentMessageWithLiveContext(
+          message,
+          sessionId,
+        );
+
+        const result = await coordinator.run({
+          sessionId,
+          messages: [{ role: "user", content: effectiveMessage }],
+          mode: normalizedMode,
+          context: {
+            articleSlug,
+            userId,
+          },
+          options: {
+            temperature,
+            maxIterations: effectiveMaxIterations,
+          },
+        });
+
+        const extracted = extractPostActionsFromContent(result.content);
+        const actions = [...collectToolActions(result.toolCalls), ...extracted.actions];
+
+        return {
+          statusCode: 200,
+          response: {
+            ok: true,
+            data: {
+              response: extracted.content,
+              actions,
+              sessionId: result.sessionId || sessionId,
+              toolsUsed: result.toolCalls?.map((tc) => tc.function?.name) || [],
+              memoryUpdated: true,
+              model: result.model,
+              tokens: result.usage,
+            },
+          },
+        };
+      },
+      {
+        lockSeconds: Math.max(60, effectiveMaxIterations * 60),
+      },
     );
-    const effectiveMaxIterations = resolveMaxIterations(maxIterations);
-
-    const result = await coordinator.run({
-      sessionId,
-      messages: [{ role: "user", content: effectiveMessage }],
-      mode: normalizeMode(mode),
-      context: {
-        articleSlug,
-        userId,
-      },
-      options: {
-        temperature,
-        maxIterations: effectiveMaxIterations,
-      },
-    });
-
-    res.json({
-      ok: true,
-      data: {
-        response: result.content,
-        sessionId: result.sessionId || sessionId,
-        toolsUsed: result.toolCalls?.map((tc) => tc.function?.name) || [],
-        memoryUpdated: true,
-        model: result.model,
-        tokens: result.usage,
-      },
-    });
   } catch (err) {
     logger.error({}, 'Agent run error', { error: err.message, stack: err.stack });
     res.status(500).json({

--- a/backend/src/services/agent/coordinator.service.js
+++ b/backend/src/services/agent/coordinator.service.js
@@ -439,9 +439,12 @@ ${toolsDescription}
         return { error: `Tool not found: ${name}` };
       }
 
+      const toolTimeout = Number.isFinite(tool.timeoutMs)
+        ? Math.max(3_000, Math.floor(tool.timeoutMs))
+        : TOOL_TIMEOUT;
       const result = await withTimeout(
-        tool.execute(args),
-        TOOL_TIMEOUT,
+        tool.execute(args, { runId, toolId }),
+        toolTimeout,
         "Tool execution timeout",
       );
 

--- a/backend/src/services/agent/tools/image-generation.tool.js
+++ b/backend/src/services/agent/tools/image-generation.tool.js
@@ -1,0 +1,365 @@
+/**
+ * Agent Image Generation Tool
+ *
+ * Lets the blog agent turn article context into stored raster image assets.
+ * The actual generation and storage invariants are delegated to the existing
+ * ai-image services used by the admin image route.
+ */
+
+import { z } from "zod";
+import { config } from "../../../config.js";
+import { createLogger } from "../../../lib/logger.js";
+import { litellmImageGenerationService } from "../../ai-image/litellm-image-generation.service.js";
+import { generatedImageStorageService } from "../../ai-image/generated-image-storage.service.js";
+
+const logger = createLogger("agent-image-generation");
+
+const OPERATIONS = [
+  "suggest_prompt",
+  "generate_cover",
+  "generate_inline",
+  "generate_variants",
+  "set_cover_candidate",
+];
+const SIZE_OPTIONS = [
+  "1024x1024",
+  "1536x1024",
+  "1024x1536",
+  "1792x1024",
+  "1024x1792",
+];
+const QUALITY_OPTIONS = ["low", "medium", "high", "standard", "hd", "auto"];
+
+function clamp(value, min, max) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return min;
+  return Math.max(min, Math.min(max, Math.floor(parsed)));
+}
+
+function text(value, maxLength = 1000) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+function normalizeTags(tags) {
+  if (Array.isArray(tags)) return tags.map((tag) => text(tag, 48)).filter(Boolean).slice(0, 12);
+  return String(tags || "")
+    .split(",")
+    .map((tag) => text(tag, 48))
+    .filter(Boolean)
+    .slice(0, 12);
+}
+
+function imageUrl(item) {
+  return item?.variantWebp?.url || item?.url || "";
+}
+
+function getMaxCount() {
+  return Math.min(Math.max(Number(config.ai?.image?.maxCount || 1), 1), 4);
+}
+
+function getMaxPromptLength() {
+  return Math.max(Number(config.ai?.image?.maxPromptLength || 4000), 1);
+}
+
+function buildInputSchema() {
+  return z.object({
+    operation: z.enum(OPERATIONS).default("suggest_prompt"),
+    year: z.coerce.string().regex(/^\d{4}$/).optional(),
+    slug: z.string().trim().min(1).max(140).optional(),
+    prompt: z.string().trim().max(getMaxPromptLength()).optional(),
+    title: z.string().trim().max(240).optional(),
+    category: z.string().trim().max(120).optional(),
+    tags: z.union([z.array(z.string()), z.string()]).optional(),
+    content: z.string().trim().max(12_000).optional(),
+    visualBrief: z.string().trim().max(1600).optional(),
+    style: z.string().trim().max(600).optional(),
+    n: z.coerce.number().int().min(1).max(getMaxCount()).optional(),
+    size: z.enum(SIZE_OPTIONS).default("1024x1024"),
+    quality: z.enum(QUALITY_OPTIONS).default("medium"),
+    outputFormat: z.enum(["png"]).default("png"),
+    alt: z.string().trim().max(180).optional(),
+  });
+}
+
+function buildPrompt(input) {
+  if (input.prompt?.trim()) return input.prompt.trim().slice(0, getMaxPromptLength());
+
+  const title = text(input.title || input.slug || "Untitled blog post", 180);
+  const category = text(input.category || "General", 80);
+  const tags = normalizeTags(input.tags);
+  const excerpt = text(input.content, 900);
+  const visualBrief = text(input.visualBrief, 900);
+  const style = text(input.style, 400);
+
+  const intent =
+    input.operation === "generate_inline"
+      ? "Create a clear inline editorial illustration or conceptual diagram for a technical blog section."
+      : "Create a polished editorial cover image for a technical blog post.";
+
+  return [
+    intent,
+    "Use crisp raster details, a modern tech-blog visual language, balanced composition, no visible text, no logos, and no watermark.",
+    style ? `Preferred style: ${style}` : "",
+    `Title: ${title}`,
+    `Category: ${category}`,
+    tags.length ? `Tags: ${tags.join(", ")}` : "",
+    visualBrief ? `Visual brief: ${visualBrief}` : "",
+    excerpt ? `Article excerpt: ${excerpt}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .slice(0, getMaxPromptLength());
+}
+
+function buildAlt(input) {
+  return (
+    text(input.alt, 180) ||
+    text(input.title, 160) ||
+    text(input.slug, 120) ||
+    "AI generated blog image"
+  );
+}
+
+function buildActions(operation, items) {
+  if (!Array.isArray(items) || items.length === 0) return [];
+
+  if (operation === "generate_cover" || operation === "set_cover_candidate") {
+    const first = items[0];
+    const url = imageUrl(first);
+    return url
+      ? [
+          {
+            type: "set_cover_image",
+            url,
+            alt: first.alt,
+            image: first,
+          },
+        ]
+      : [];
+  }
+
+  if (operation === "generate_inline") {
+    return items
+      .filter((item) => item?.markdown)
+      .map((item) => ({
+        type: "insert_markdown",
+        markdown: item.markdown,
+        url: imageUrl(item),
+        alt: item.alt,
+        image: item,
+      }));
+  }
+
+  return [];
+}
+
+function validateGenerationTarget(input) {
+  if (!input.year || !/^\d{4}$/.test(input.year)) {
+    return "year is required for image generation";
+  }
+  if (!input.slug) {
+    return "slug is required for image generation";
+  }
+  return null;
+}
+
+function requireFeatureEnabled() {
+  if (config.features?.adminAiImageEnabled !== true) {
+    return "AI image generation is disabled";
+  }
+  return null;
+}
+
+export function createImageGenerationTool(options = {}) {
+  const imageService = options.imageService || litellmImageGenerationService;
+  const storageService = options.storageService || generatedImageStorageService;
+  const imageTimeoutMs = Math.max(Number(config.ai?.image?.timeoutMs || 300_000), 5_000);
+
+  return {
+    name: "image_generation",
+    description:
+      "Suggest image prompts or generate stored raster images for blog cover, inline, and variant candidates. Generated images are always saved under /images/{year}/{slug}/ai before URLs are returned.",
+    timeoutMs: imageTimeoutMs + 30_000,
+    parameters: {
+      type: "object",
+      properties: {
+        operation: {
+          type: "string",
+          enum: OPERATIONS,
+          description:
+            "suggest_prompt returns a prompt only. generate_cover stores a cover and returns a set_cover_image action. generate_inline stores inline images and returns insert_markdown actions. generate_variants stores candidates without auto-applying them. set_cover_candidate stores candidates and marks the first as cover.",
+        },
+        year: {
+          type: "string",
+          description: "Post year as YYYY. Required for generation operations.",
+        },
+        slug: {
+          type: "string",
+          description: "Post slug. Required for generation operations.",
+        },
+        prompt: {
+          type: "string",
+          description:
+            "Optional final image prompt. If omitted, the tool builds one from title, category, tags, content, visualBrief, and style.",
+        },
+        title: { type: "string", description: "Post title or section title." },
+        category: { type: "string", description: "Post category." },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Post tags.",
+        },
+        content: {
+          type: "string",
+          description: "Relevant post or paragraph excerpt. Keep it concise.",
+        },
+        visualBrief: {
+          type: "string",
+          description: "Visual concept, composition, subject, and constraints.",
+        },
+        style: {
+          type: "string",
+          description: "Optional style direction.",
+        },
+        n: {
+          type: "number",
+          description: "Number of images to generate. Capped by server configuration.",
+          default: 1,
+        },
+        size: {
+          type: "string",
+          enum: SIZE_OPTIONS,
+          default: "1024x1024",
+        },
+        quality: {
+          type: "string",
+          enum: QUALITY_OPTIONS,
+          default: "medium",
+        },
+        alt: {
+          type: "string",
+          description: "Accessibility alt text for generated images.",
+        },
+      },
+      required: ["operation"],
+    },
+
+    async execute(args, executionContext = {}) {
+      const requestId =
+        executionContext.runId || `agent-image-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      try {
+        const input = buildInputSchema().parse(args || {});
+        const prompt = buildPrompt(input);
+        const alt = buildAlt(input);
+        const maxCount = getMaxCount();
+        const n =
+          input.n ||
+          (input.operation === "generate_variants" || input.operation === "set_cover_candidate"
+            ? Math.min(3, maxCount)
+            : 1);
+
+        if (input.operation === "suggest_prompt") {
+          return {
+            success: true,
+            operation: input.operation,
+            prompt,
+            alt,
+            size: input.size,
+            quality: input.quality,
+            n: clamp(n, 1, maxCount),
+            actions: [],
+          };
+        }
+
+        const featureError = requireFeatureEnabled();
+        if (featureError) {
+          return { success: false, operation: input.operation, error: featureError, actions: [] };
+        }
+
+        const targetError = validateGenerationTarget(input);
+        if (targetError) {
+          return { success: false, operation: input.operation, error: targetError, actions: [] };
+        }
+
+        if (!prompt || prompt.length < 8) {
+          return {
+            success: false,
+            operation: input.operation,
+            error: "prompt or article context is required for image generation",
+            actions: [],
+          };
+        }
+
+        logger.info({ requestId }, "Agent image generation requested", {
+          operation: input.operation,
+          year: input.year,
+          slug: input.slug,
+          count: clamp(n, 1, maxCount),
+          size: input.size,
+          quality: input.quality,
+        });
+
+        const generation = await imageService.generateImages(
+          {
+            prompt,
+            n: clamp(n, 1, maxCount),
+            size: input.size,
+            quality: input.quality,
+            outputFormat: input.outputFormat,
+          },
+          { requestId },
+        );
+
+        const stored = await storageService.saveImages({
+          year: input.year,
+          slug: input.slug,
+          subdir: config.ai?.image?.storageSubdir,
+          images: generation.items,
+          alt,
+        });
+        const actions = buildActions(input.operation, stored.items);
+
+        logger.info({ requestId }, "Agent image generation saved", {
+          operation: input.operation,
+          year: input.year,
+          slug: input.slug,
+          imageCount: stored.items.length,
+          actionCount: actions.length,
+          model: generation.model,
+          durationMs: generation.durationMs,
+        });
+
+        return {
+          success: true,
+          operation: input.operation,
+          dir: stored.dir,
+          model: generation.model,
+          created: generation.created,
+          durationMs: generation.durationMs,
+          usage: generation.usage,
+          metadata: generation.metadata,
+          prompt,
+          alt,
+          items: stored.items,
+          actions,
+        };
+      } catch (error) {
+        logger.error({ requestId }, "Agent image generation failed", {
+          error: error.message,
+        });
+        return {
+          success: false,
+          operation: args?.operation || "unknown",
+          error: error.message,
+          actions: [],
+        };
+      }
+    },
+  };
+}
+
+export default createImageGenerationTool;

--- a/backend/src/services/agent/tools/index.js
+++ b/backend/src/services/agent/tools/index.js
@@ -15,6 +15,7 @@ import { createBlogOpsTool } from './blog-ops.tool.js';
 import { createMCPClientTool } from './mcp-client.tool.js';
 import { createWebSearchTool } from './web-search.tool.js';
 import { createCodeExecutionTool } from './code-execution.tool.js';
+import { createImageGenerationTool } from './image-generation.tool.js';
 import { createLogger } from '../../../lib/logger.js';
 
 const logger = createLogger('tool-registry');
@@ -33,6 +34,7 @@ export class ToolRegistry {
       createBlogOpsTool(),
       createWebSearchTool(),
       createCodeExecutionTool(),
+      createImageGenerationTool(),
     ];
 
     for (const tool of builtInTools) {

--- a/backend/src/services/quiz.service.js
+++ b/backend/src/services/quiz.service.js
@@ -12,6 +12,14 @@ import {
   FALLBACK_DATA,
 } from "../config/constants.js";
 
+const VISUAL_TASK_MODES = new Set([
+  "visual_brief",
+  "cover_prompt",
+  "diagram_prompt",
+  "thumbnail_prompt",
+  "alt_text",
+]);
+
 // ---------------------------------------------------------------------------
 // Text helpers
 // ---------------------------------------------------------------------------
@@ -238,9 +246,81 @@ export function normalizeQuizData(value, maxQuestions = 2) {
   return { quiz };
 }
 
+function normalizeStringField(value, maxLength) {
+  const normalized = toText(value).replace(/\s+/g, " ").trim();
+  return normalized ? normalized.slice(0, maxLength) : "";
+}
+
+function normalizeStringArray(value, maxItems = 6, maxLength = 120) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => normalizeStringField(entry, maxLength))
+    .filter(Boolean)
+    .slice(0, maxItems);
+}
+
+function normalizeVisualTaskData(mode, value, payload = {}) {
+  const raw = value && typeof value === "object" ? value : {};
+  const title = normalizeStringField(payload.postTitle, TEXT_LIMITS.TASK_TITLE);
+
+  if (mode === "alt_text") {
+    const alt = normalizeStringField(raw.alt || raw.altText || raw.text, 180);
+    return alt ? { alt } : null;
+  }
+
+  if (mode === "visual_brief") {
+    const brief = raw.brief && typeof raw.brief === "object" ? raw.brief : raw;
+    const subject = normalizeStringField(brief.subject || title, 180);
+    const goal = normalizeStringField(brief.goal || brief.intent, 220);
+    const composition = normalizeStringField(brief.composition, 260);
+    const style = normalizeStringField(brief.style, 220);
+    const palette = normalizeStringArray(brief.palette, 6, 48);
+    const elements = normalizeStringArray(brief.elements, 8, 100);
+    const negativePrompt = normalizeStringField(
+      brief.negativePrompt || brief.negative_prompt,
+      240,
+    );
+    const prompt = normalizeStringField(raw.prompt, 1200);
+    const alt = normalizeStringField(raw.alt || raw.altText, 180);
+
+    if (!subject && !goal && !composition && !prompt) return null;
+
+    return {
+      brief: {
+        subject,
+        goal,
+        composition,
+        style,
+        palette,
+        elements,
+        negativePrompt,
+      },
+      prompt,
+      alt,
+    };
+  }
+
+  const prompt = normalizeStringField(raw.prompt || raw.imagePrompt, 1400);
+  const alt = normalizeStringField(raw.alt || raw.altText, 180);
+  const style = normalizeStringField(raw.style, 220);
+  const placement = normalizeStringField(raw.placement, 120);
+  const size = normalizeStringField(raw.size, 24);
+
+  if (!prompt) return null;
+
+  return {
+    prompt,
+    alt,
+    style,
+    placement,
+    size,
+  };
+}
+
 export function normalizeTaskData(mode, value, payload = {}) {
-  if (mode !== "quiz") return value;
-  return normalizeQuizData(value, clampQuizCount(payload.quizCount, 2));
+  if (mode === "quiz") return normalizeQuizData(value, clampQuizCount(payload.quizCount, 2));
+  if (VISUAL_TASK_MODES.has(mode)) return normalizeVisualTaskData(mode, value, payload);
+  return value;
 }
 
 // ---------------------------------------------------------------------------
@@ -341,6 +421,42 @@ export function projectTaskDataFromText(mode, text, payload) {
 
     case "summary":
       return { summary: rawText };
+
+    case "visual_brief": {
+      const points = sentencePoints(rawText, 3);
+      return {
+        brief: {
+          subject: payload.postTitle || points[0] || "Blog article visual",
+          goal: points[1] || "Represent the article's core idea visually.",
+          composition: points[2] || "Clean editorial composition with one clear focal point.",
+          style: "modern technical editorial illustration",
+          palette: [],
+          elements: points.slice(0, 3),
+          negativePrompt: "visible text, logos, watermark, cluttered layout",
+        },
+        prompt: rawText.slice(0, 1200),
+        alt: payload.postTitle || "Article visual concept",
+      };
+    }
+
+    case "cover_prompt":
+    case "diagram_prompt":
+    case "thumbnail_prompt":
+      return {
+        prompt: rawText.slice(0, 1400),
+        alt: payload.postTitle || "AI generated blog image",
+        style:
+          mode === "diagram_prompt"
+            ? "clean technical diagram"
+            : "modern technical editorial illustration",
+        placement: mode === "cover_prompt" ? "cover" : mode === "thumbnail_prompt" ? "thumbnail" : "inline",
+        size: mode === "cover_prompt" ? "1536x1024" : "1024x1024",
+      };
+
+    case "alt_text":
+      return {
+        alt: rawText.slice(0, 180),
+      };
 
     case "catalyst": {
       const ideas = sentencePoints(rawText, 3);
@@ -457,6 +573,76 @@ export function buildTaskPrompt(mode, payload) {
         temperature: AI_TEMPERATURES.SUMMARY,
       };
 
+    case "visual_brief":
+      return {
+        prompt: [
+          "Return STRICT JSON only for a blog image visual brief.",
+          '{"brief":{"subject":"string","goal":"string","composition":"string","style":"string","palette":["string"],"elements":["string"],"negativePrompt":"string"},"prompt":"string","alt":"string"}',
+          `Post: ${title.slice(0, TEXT_LIMITS.TASK_TITLE)}`,
+          "Content:",
+          text.slice(0, TEXT_LIMITS.TASK_PARAGRAPH),
+          "",
+          "Task: Produce a concise visual concept that can later be used for image generation. Do not generate an image. Avoid visible text, logos, watermarks, and unsafe or copyrighted imagery.",
+        ].join("\n"),
+        temperature: AI_TEMPERATURES.TEMPLATE || AI_TEMPERATURES.GENERATE,
+      };
+
+    case "cover_prompt":
+      return {
+        prompt: [
+          "Return STRICT JSON only for a blog cover image prompt.",
+          '{"prompt":"string","alt":"string","style":"string","placement":"cover","size":"1536x1024"}',
+          `Post: ${title.slice(0, TEXT_LIMITS.TASK_TITLE)}`,
+          "Content:",
+          text.slice(0, TEXT_LIMITS.TASK_PARAGRAPH),
+          "",
+          "Task: Write one production-ready text-to-image prompt for a polished technical blog cover. Include subject, composition, style, lighting, and constraints. No visible text, logos, or watermark.",
+        ].join("\n"),
+        temperature: AI_TEMPERATURES.TEMPLATE || AI_TEMPERATURES.GENERATE,
+      };
+
+    case "diagram_prompt":
+      return {
+        prompt: [
+          "Return STRICT JSON only for an inline technical diagram image prompt.",
+          '{"prompt":"string","alt":"string","style":"string","placement":"inline","size":"1024x1024"}',
+          `Post: ${title.slice(0, TEXT_LIMITS.TASK_TITLE)}`,
+          "Content:",
+          text.slice(0, TEXT_LIMITS.TASK_PARAGRAPH),
+          "",
+          "Task: Write one text-to-image prompt for a clean conceptual diagram or architecture illustration grounded in the content. Prefer simple shapes and clear hierarchy, but no readable text labels.",
+        ].join("\n"),
+        temperature: AI_TEMPERATURES.TEMPLATE || AI_TEMPERATURES.GENERATE,
+      };
+
+    case "thumbnail_prompt":
+      return {
+        prompt: [
+          "Return STRICT JSON only for a compact blog thumbnail image prompt.",
+          '{"prompt":"string","alt":"string","style":"string","placement":"thumbnail","size":"1024x1024"}',
+          `Post: ${title.slice(0, TEXT_LIMITS.TASK_TITLE)}`,
+          "Content:",
+          text.slice(0, TEXT_LIMITS.TASK_PARAGRAPH),
+          "",
+          "Task: Write one text-to-image prompt for a strong square thumbnail. It must read well at small sizes, with one focal subject and no visible text, logos, or watermark.",
+        ].join("\n"),
+        temperature: AI_TEMPERATURES.TEMPLATE || AI_TEMPERATURES.GENERATE,
+      };
+
+    case "alt_text":
+      return {
+        prompt: [
+          "Return STRICT JSON only for accessibility alt text.",
+          '{"alt":"string"}',
+          `Post: ${title.slice(0, TEXT_LIMITS.TASK_TITLE)}`,
+          "Image or visual description:",
+          text.slice(0, TEXT_LIMITS.TASK_PARAGRAPH),
+          "",
+          "Task: Write concise, useful alt text under 180 characters in the original language when possible. Do not start with 'image of' unless necessary.",
+        ].join("\n"),
+        temperature: AI_TEMPERATURES.SUMMARY,
+      };
+
     case "quiz": {
       const batchStart = quizBatchIndex * requestedQuizCount + 1;
       const batchEnd = batchStart + requestedQuizCount - 1;
@@ -563,6 +749,75 @@ export function getFallbackData(mode, payload) {
         summary:
           text.slice(0, FALLBACK_DATA.SUMMARY_LENGTH) +
           (text.length > FALLBACK_DATA.SUMMARY_LENGTH ? "..." : ""),
+      };
+    case "visual_brief": {
+      const sentences = sentencePoints(text, 3);
+      return {
+        brief: {
+          subject: payload.postTitle || sentences[0] || "Blog article visual",
+          goal: sentences[1] || "Represent the core idea of the article.",
+          composition: "Clean editorial composition with one clear focal point.",
+          style: "modern technical editorial illustration",
+          palette: [],
+          elements: sentences.slice(0, 3),
+          negativePrompt: "visible text, logos, watermark, cluttered layout",
+        },
+        prompt: [
+          "Create a polished modern technical blog image.",
+          payload.postTitle ? `Title: ${payload.postTitle}` : "",
+          text.slice(0, 500),
+          "No visible text, logos, or watermark.",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        alt: payload.postTitle || "Blog visual concept",
+      };
+    }
+    case "cover_prompt":
+      return {
+        prompt: [
+          "Create a polished editorial cover image for a technical blog post.",
+          payload.postTitle ? `Title: ${payload.postTitle}` : "",
+          text.slice(0, 700),
+          "Modern tech-blog style, strong composition, no visible text, no logos, no watermark.",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        alt: payload.postTitle || "Blog cover image",
+        style: "modern technical editorial illustration",
+        placement: "cover",
+        size: "1536x1024",
+      };
+    case "diagram_prompt":
+      return {
+        prompt: [
+          "Create a clean conceptual technical diagram for this blog section.",
+          text.slice(0, 700),
+          "Simple hierarchy, crisp raster details, no readable text labels, no logos, no watermark.",
+        ].join("\n"),
+        alt: payload.postTitle || "Technical diagram",
+        style: "clean technical diagram",
+        placement: "inline",
+        size: "1024x1024",
+      };
+    case "thumbnail_prompt":
+      return {
+        prompt: [
+          "Create a compact square thumbnail for a technical blog post.",
+          payload.postTitle ? `Title: ${payload.postTitle}` : "",
+          text.slice(0, 500),
+          "One focal subject, readable at small sizes, no visible text, no logos, no watermark.",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        alt: payload.postTitle || "Blog thumbnail",
+        style: "modern technical editorial illustration",
+        placement: "thumbnail",
+        size: "1024x1024",
+      };
+    case "alt_text":
+      return {
+        alt: (sentences[0] || text || "Generated blog image").slice(0, 180),
       };
     case "catalyst":
       return {

--- a/backend/test/agent-image-generation.tool.test.js
+++ b/backend/test/agent-image-generation.tool.test.js
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.APP_ENV = "test";
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || "gpt-4.1-mini";
+process.env.FEATURE_ADMIN_AI_IMAGE_ENABLED = "true";
+process.env.AI_IMAGE_PROXY_API_KEY = "test-image-key";
+process.env.AI_IMAGE_MODEL = "test-image-model";
+process.env.AI_IMAGE_MAX_COUNT = "4";
+
+const { createImageGenerationTool } = await import(
+  "../src/services/agent/tools/image-generation.tool.js"
+);
+
+test("image_generation suggest_prompt builds a prompt without generating images", async () => {
+  let generated = false;
+  const tool = createImageGenerationTool({
+    imageService: {
+      async generateImages() {
+        generated = true;
+      },
+    },
+    storageService: {
+      async saveImages() {
+        throw new Error("saveImages should not be called");
+      },
+    },
+  });
+
+  const result = await tool.execute({
+    operation: "suggest_prompt",
+    title: "Kubernetes release readiness",
+    category: "DevOps",
+    tags: ["kubernetes", "sre"],
+    content: "A checklist for release gates, rollback, monitoring, and alerts.",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.operation, "suggest_prompt");
+  assert.equal(generated, false);
+  assert.match(result.prompt, /Kubernetes release readiness/);
+  assert.deepEqual(result.actions, []);
+});
+
+test("image_generation generate_cover stores images and returns a cover action", async () => {
+  const tool = createImageGenerationTool({
+    imageService: {
+      async generateImages(input, options) {
+        assert.match(options.requestId, /test-run/);
+        assert.equal(input.n, 1);
+        assert.equal(input.outputFormat, "png");
+        return {
+          model: "test-image-model",
+          created: 1770000000,
+          durationMs: 42,
+          usage: null,
+          metadata: null,
+          items: [{ buffer: Buffer.from("png"), contentType: "image/png" }],
+        };
+      },
+    },
+    storageService: {
+      async saveImages(input) {
+        assert.equal(input.year, "2026");
+        assert.equal(input.slug, "kubernetes-release-readiness");
+        assert.equal(input.images.length, 1);
+        return {
+          dir: "/images/2026/kubernetes-release-readiness/ai",
+          items: [
+            {
+              filename: "generated.png",
+              path: "2026/kubernetes-release-readiness/ai/generated.png",
+              url: "/images/2026/kubernetes-release-readiness/ai/generated.png",
+              variantWebp: {
+                url: "/images/2026/kubernetes-release-readiness/ai/generated-w1024.webp",
+              },
+              alt: input.alt,
+              markdown:
+                "![Kubernetes release readiness](/images/2026/kubernetes-release-readiness/ai/generated-w1024.webp)",
+              source: "ai-generated",
+              width: 1024,
+              height: 1024,
+            },
+          ],
+        };
+      },
+    },
+  });
+
+  const result = await tool.execute(
+    {
+      operation: "generate_cover",
+      year: "2026",
+      slug: "kubernetes-release-readiness",
+      prompt: "Create a modern Kubernetes release readiness cover.",
+      alt: "Kubernetes release readiness",
+    },
+    { runId: "test-run" },
+  );
+
+  assert.equal(result.success, true);
+  assert.equal(result.items.length, 1);
+  assert.equal(result.actions.length, 1);
+  assert.equal(result.actions[0].type, "set_cover_image");
+  assert.equal(
+    result.actions[0].url,
+    "/images/2026/kubernetes-release-readiness/ai/generated-w1024.webp",
+  );
+});
+
+test("image_generation generation operations require year and slug", async () => {
+  const tool = createImageGenerationTool();
+  const result = await tool.execute({
+    operation: "generate_inline",
+    prompt: "Create a small technical illustration.",
+  });
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /year is required/);
+});

--- a/backend/test/visual-task.service.test.js
+++ b/backend/test/visual-task.service.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.APP_ENV = "test";
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || "gpt-4.1-mini";
+
+const {
+  buildTaskPrompt,
+  getFallbackData,
+  isValidTaskMode,
+  normalizeTaskData,
+  projectTaskDataFromText,
+} = await import("../src/services/quiz.service.js");
+
+test("visual task modes are valid and build strict JSON prompts", () => {
+  for (const mode of [
+    "visual_brief",
+    "cover_prompt",
+    "diagram_prompt",
+    "thumbnail_prompt",
+    "alt_text",
+  ]) {
+    assert.equal(isValidTaskMode(mode), true);
+    const built = buildTaskPrompt(mode, {
+      postTitle: "Postgres vacuum tuning",
+      content: "Explains autovacuum thresholds, bloat, and monitoring.",
+    });
+    assert.match(built.prompt, /STRICT JSON/);
+    assert.equal(typeof built.temperature, "number");
+  }
+});
+
+test("visual_brief task data is normalized to a stable shape", () => {
+  const normalized = normalizeTaskData(
+    "visual_brief",
+    {
+      brief: {
+        subject: "Database maintenance",
+        goal: "Explain bloat cleanup",
+        composition: "Central database cylinder with cleanup flow",
+        style: "clean technical editorial",
+        palette: ["blue", "green"],
+        elements: ["database", "vacuum", "metrics"],
+        negative_prompt: "visible text",
+      },
+      prompt: "Create a clean technical image about Postgres vacuum.",
+      altText: "Postgres vacuum maintenance concept",
+    },
+    { postTitle: "Postgres vacuum tuning" },
+  );
+
+  assert.equal(normalized.brief.subject, "Database maintenance");
+  assert.equal(normalized.brief.negativePrompt, "visible text");
+  assert.deepEqual(normalized.brief.palette, ["blue", "green"]);
+  assert.match(normalized.prompt, /Postgres vacuum/);
+  assert.equal(normalized.alt, "Postgres vacuum maintenance concept");
+});
+
+test("visual prompt fallback and text projection return usable prompt specs", () => {
+  const projected = projectTaskDataFromText(
+    "cover_prompt",
+    "Create a sharp editorial cover with a database focal point.",
+    { postTitle: "Postgres vacuum tuning" },
+  );
+  assert.equal(projected.placement, "cover");
+  assert.match(projected.prompt, /database focal point/);
+
+  const fallback = getFallbackData("diagram_prompt", {
+    postTitle: "Queue retry design",
+    content: "Outbox retry states and dead letter handling.",
+  });
+  assert.equal(fallback.placement, "inline");
+  assert.match(fallback.prompt, /conceptual technical diagram/);
+});

--- a/frontend/src/components/features/admin/BotChatPanel.tsx
+++ b/frontend/src/components/features/admin/BotChatPanel.tsx
@@ -5,14 +5,24 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
 import { Sparkles, Send, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/ui/use-toast";
+import { runBlogAgent, type AgentEditorAction } from "@/services/session/agent";
 
 interface BotChatPanelProps {
     title: string;
+    slug: string;
+    year: string;
+    category: string;
+    tags: string;
+    coverImage: string;
     content: string;
     setTitle: (title: string) => void;
+    setSlug: (slug: string) => void;
     setContent: (content: string) => void;
     setTags: (tags: string) => void;
     setCategory: (category: string) => void;
+    setCoverImage: (url: string) => void;
+    onInsertMarkdown: (markdown: string) => void;
+    getAccessToken: () => Promise<string | null>;
 }
 
 interface Message {
@@ -22,18 +32,141 @@ interface Message {
 
 export default function BotChatPanel({
     title,
+    slug,
+    year,
+    category,
+    tags,
+    coverImage,
     content,
     setTitle,
+    setSlug,
     setContent,
     setTags,
     setCategory,
+    setCoverImage,
+    onInsertMarkdown,
+    getAccessToken,
 }: BotChatPanelProps) {
     const [messages, setMessages] = useState<Message[]>([
-        { role: "assistant", content: "안녕하세요! 블로그 작성을 돕는 AI입니다. 초안 작성, 교정, 또는 Frontmatter(제목, 태그 등) 생성을 요청해보세요!" },
+        { role: "assistant", content: "안녕하세요. 현재 글 상태를 읽고 초안, 메타데이터, 커버/본문 이미지 생성을 도울 수 있습니다." },
     ]);
     const [input, setInput] = useState("");
     const [isTyping, setIsTyping] = useState(false);
+    const [sessionId] = useState(() => {
+        const id =
+            typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+                ? crypto.randomUUID()
+                : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        return `new-post-${id}`.slice(0, 128);
+    });
     const { toast } = useToast();
+
+    const buildAgentMessage = (userMessage: string) => {
+        const state = {
+            title,
+            slug,
+            year,
+            category,
+            tags: tags
+                .split(",")
+                .map((tag) => tag.trim())
+                .filter(Boolean),
+            coverImage: coverImage || null,
+            contentLength: content.length,
+            contentExcerpt: content.slice(0, 7000),
+        };
+
+        return [
+            "현재 작성 중인 게시글 상태(JSON):",
+            JSON.stringify(state, null, 2),
+            "",
+            "사용자 요청:",
+            userMessage,
+            "",
+            "에디터에 직접 반영할 변경이 있으면 post_actions JSON block을 함께 반환하세요. 이미지가 필요하면 image_generation tool을 사용하고, year와 slug가 없으면 먼저 필요한 값을 요청하세요.",
+        ].join("\n");
+    };
+
+    const applyActions = (actions: AgentEditorAction[] | undefined) => {
+        if (!actions?.length) return 0;
+
+        let applied = 0;
+        for (const action of actions) {
+            switch (action.type) {
+                case "set_title": {
+                    const value = action.value || action.title;
+                    if (value) {
+                        setTitle(value);
+                        applied += 1;
+                    }
+                    break;
+                }
+                case "set_slug": {
+                    const value = action.value || action.slug;
+                    if (value) {
+                        setSlug(value);
+                        applied += 1;
+                    }
+                    break;
+                }
+                case "set_category": {
+                    const value = action.value || action.category;
+                    if (value) {
+                        setCategory(value);
+                        applied += 1;
+                    }
+                    break;
+                }
+                case "set_tags": {
+                    const value = action.value || action.tags;
+                    if (Array.isArray(value)) {
+                        setTags(value.join(", "));
+                        applied += 1;
+                    } else if (value) {
+                        setTags(value);
+                        applied += 1;
+                    }
+                    break;
+                }
+                case "set_cover_image": {
+                    const value = action.url || action.value;
+                    if (value) {
+                        setCoverImage(value);
+                        applied += 1;
+                    }
+                    break;
+                }
+                case "insert_markdown": {
+                    const value = action.markdown || action.content || action.text;
+                    if (value) {
+                        onInsertMarkdown(value);
+                        applied += 1;
+                    }
+                    break;
+                }
+                case "replace_content": {
+                    const value = action.content || action.markdown;
+                    if (value) {
+                        setContent(value);
+                        applied += 1;
+                    }
+                    break;
+                }
+                case "append_content": {
+                    const value = action.markdown || action.content || action.text;
+                    if (value) {
+                        onInsertMarkdown(value);
+                        applied += 1;
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        return applied;
+    };
 
     const handleSend = async () => {
         if (!input.trim()) return;
@@ -44,31 +177,35 @@ export default function BotChatPanel({
         setIsTyping(true);
 
         try {
-            // Mock API latency
-            await new Promise((resolve) => setTimeout(resolve, 1500));
+            const token = await getAccessToken();
+            if (!token) throw new Error("먼저 로그인하세요");
 
-            let botResponse = "처리되었습니다.";
-
-            // Mock actions based on simple keyword matching for demonstration
-            if (userMessage.includes("초안") || userMessage.includes("작성해줘")) {
-                const draft = `# ${userMessage.replace("초안 작성해줘", "").trim() || "새 포스트"}\n\n도입부...\n\n본문 내용...\n\n결론...`;
-                setContent(draft);
-                botResponse = "요청하신 주제로 초안을 작성하여 에디터에 적용했습니다.";
-            } else if (userMessage.includes("구조") || userMessage.includes("제목") || userMessage.includes("태그")) {
-                setTitle(`AI 추천 제목: ${title || "새로운 블로그 글"}`);
-                setTags("AI추천, 기술블로그, 리뷰");
-                setCategory("Tech");
-                botResponse = "에디터에 제목, 태그, 카테고리를 추천값으로 자동 설정했습니다!";
-            } else if (userMessage.includes("교정") || userMessage.includes("다듬어줘")) {
-                setContent(content.replace(/존나/g, "매우").replace(/걍/g, "그냥"));
-                botResponse = "작성하신 본문의 문맥을 매끄럽게 교정했습니다.";
-            } else {
-                botResponse = "이해했습니다! 현재는 모의(Mock) 응답이므로, 실제 백엔드 LLM 연동 후 작동하게 됩니다.";
+            const result = await runBlogAgent(
+                {
+                    message: buildAgentMessage(userMessage),
+                    sessionId,
+                    maxIterations: 6,
+                    temperature: 0.4,
+                },
+                token,
+            );
+            const applied = applyActions(result.actions);
+            const toolSuffix =
+                result.toolsUsed.length > 0 ? `\n\n사용 도구: ${result.toolsUsed.join(", ")}` : "";
+            setMessages((prev) => [
+                ...prev,
+                {
+                    role: "assistant",
+                    content: `${result.response || "처리되었습니다."}${toolSuffix}`,
+                },
+            ]);
+            if (applied > 0) {
+                toast({ title: "AI 변경 적용", description: `${applied}개 작업을 에디터에 반영했습니다.` });
             }
-
-            setMessages((prev) => [...prev, { role: "assistant", content: botResponse }]);
-        } catch {
-            toast({ title: "오류", description: "AI 요청 실패", variant: "destructive" });
+        } catch (error) {
+            const description = error instanceof Error && error.message ? error.message : "AI 요청 실패";
+            setMessages((prev) => [...prev, { role: "assistant", content: `요청 처리에 실패했습니다: ${description}` }]);
+            toast({ title: "오류", description, variant: "destructive" });
         } finally {
             setIsTyping(false);
         }
@@ -93,7 +230,7 @@ export default function BotChatPanel({
                                     }`}
                             >
                                 <div
-                                    className={`px-3 py-2 rounded-lg text-sm ${msg.role === "user"
+                                    className={`whitespace-pre-wrap px-3 py-2 rounded-lg text-sm ${msg.role === "user"
                                         ? "bg-primary text-primary-foreground"
                                         : "bg-muted border text-foreground"
                                         }`}

--- a/frontend/src/pages/admin/NewPost.tsx
+++ b/frontend/src/pages/admin/NewPost.tsx
@@ -412,11 +412,20 @@ export default function NewPost() {
         <ResizablePanel defaultSize={30} minSize={25} className="hidden md:block">
           <BotChatPanel
             title={title}
+            slug={slug}
+            year={year}
+            category={category}
+            tags={tags}
+            coverImage={coverImage}
             content={content}
             setTitle={setTitle}
+            setSlug={setSlug}
             setContent={setContent}
             setTags={setTags}
             setCategory={setCategory}
+            setCoverImage={setCoverImage}
+            onInsertMarkdown={insertAtCursor}
+            getAccessToken={getValidAccessToken}
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/frontend/src/services/session/agent.ts
+++ b/frontend/src/services/session/agent.ts
@@ -1,0 +1,75 @@
+import { bearerAuth } from '@/lib/auth';
+import { getApiBaseUrl } from '@/utils/network/apiBase';
+
+export type AgentEditorAction =
+  | { type: 'set_title'; value?: string; title?: string }
+  | { type: 'set_slug'; value?: string; slug?: string }
+  | { type: 'set_category'; value?: string; category?: string }
+  | { type: 'set_tags'; value?: string | string[]; tags?: string | string[] }
+  | { type: 'set_cover_image'; url?: string; value?: string }
+  | { type: 'insert_markdown'; markdown?: string; content?: string; text?: string }
+  | { type: 'replace_content'; content?: string; markdown?: string }
+  | { type: 'append_content'; markdown?: string; content?: string; text?: string };
+
+export type AgentRunResponse = {
+  response: string;
+  actions?: AgentEditorAction[];
+  sessionId: string;
+  toolsUsed: string[];
+  memoryUpdated: boolean;
+  model?: string;
+  tokens?: unknown;
+};
+
+function getErrorMessage(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== 'object') return fallback;
+  const record = payload as { error?: unknown; message?: unknown };
+  if (typeof record.error === 'string') return record.error;
+  if (record.error && typeof record.error === 'object') {
+    const nested = record.error as { message?: unknown; code?: unknown };
+    if (typeof nested.message === 'string') return nested.message;
+    if (typeof nested.code === 'string') return nested.code;
+  }
+  if (typeof record.message === 'string') return record.message;
+  return fallback;
+}
+
+function createIdempotencyKey(): string {
+  const randomId =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `agent-run:${randomId}`;
+}
+
+export async function runBlogAgent(
+  payload: {
+    message: string;
+    sessionId: string;
+    maxIterations?: number;
+    temperature?: number;
+  },
+  token: string,
+): Promise<AgentRunResponse> {
+  const base = getApiBaseUrl();
+  const response = await fetch(`${base}/api/v1/agent/run`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': createIdempotencyKey(),
+      ...bearerAuth(token),
+    },
+    body: JSON.stringify({
+      message: payload.message,
+      sessionId: payload.sessionId,
+      mode: 'blog',
+      maxIterations: payload.maxIterations ?? 6,
+      temperature: payload.temperature ?? 0.4,
+    }),
+  });
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok || !json?.ok) {
+    throw new Error(getErrorMessage(json, 'AI agent request failed'));
+  }
+  return json.data as AgentRunResponse;
+}


### PR DESCRIPTION
## Summary
- Add an `image_generation` Agent ToolRegistry tool that reuses the existing LiteLLM image generation and local storage services.
- Return editor actions from `/api/v1/agent/run` and wire `BotChatPanel` to the real blog agent flow in `NewPost`.
- Add visual planning task modes for chat tasks: `visual_brief`, `cover_prompt`, `diagram_prompt`, `thumbnail_prompt`, and `alt_text`.

## Testing
- `backend`: `npm test`
- `frontend`: `npm run type-check`
- `frontend`: `npm run lint`
- `git diff --check`

## Risks
- Image generation remains synchronous through the existing service; long-running generation should still move to an outbox/job flow later.
- Agent-applied editor actions depend on model compliance with the documented `post_actions` contract.

## Follow-ups
- Add async image generation jobs/outbox support.
- Add publish-time image quality gate and generated OG image pipeline.