### PR TITLE
fix(markdown): improve code block readability

### DIFF
--- a/frontend/src/components/features/blog/MarkdownRenderer.tsx
+++ b/frontend/src/components/features/blog/MarkdownRenderer.tsx
@@ -459,6 +459,153 @@ function inferCodeLanguage(codeString: string): {
   return { displayLanguage: 'code' };
 }
 
+type MarkdownCodeBlockPresentation =
+  | { kind: 'text-panel' }
+  | { kind: 'code-block'; syntaxLanguage?: string; displayLanguage: string };
+
+const CJK_PROSE_PATTERN =
+  /[\u1100-\u11FF\u3130-\u318F\u3040-\u30FF\u3400-\u9FFF\uAC00-\uD7AF]/;
+
+const NATURAL_LANGUAGE_LETTER_PATTERN =
+  /[A-Za-z\u1100-\u11FF\u3130-\u318F\u3040-\u30FF\u3400-\u9FFF\uAC00-\uD7AF]/;
+
+const MARKDOWN_PROSE_MARKER_PATTERN =
+  /(^|\s)(\*\*[^*\n]+\*\*|__[^_\n]+__|\[[^\]\n]+\]\([^)\n]+\)|`[^`\n]+`)/;
+
+const CODE_LINE_START_PATTERN =
+  /^(import|export|const|let|var|function|class|interface|type|enum|return|if|else|for|while|switch|case|try|catch|finally|throw|new|await|async|def|from|package|public|private|protected|select|insert|update|delete|create|alter|drop)\b/i;
+
+const CODE_OPERATOR_PATTERN = /(=>|===|!==|==|!=|&&|\|\||[{};])/;
+const ASSIGNMENT_LINE_PATTERN = /^[\w.$-]+\s*=\s*\S+/;
+const STRUCTURED_KEY_VALUE_PATTERN =
+  /^["']?[\w.-]+["']?\s*:\s*(?:["'{[\d]|true\b|false\b|null\b|$|[\w.-]+$)/i;
+
+function isLikelyCodeLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+
+  if (CODE_LINE_START_PATTERN.test(trimmed)) return true;
+  if (CODE_OPERATOR_PATTERN.test(trimmed)) return true;
+  if (ASSIGNMENT_LINE_PATTERN.test(trimmed)) return true;
+  if (
+    !CJK_PROSE_PATTERN.test(trimmed) &&
+    STRUCTURED_KEY_VALUE_PATTERN.test(trimmed)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function hasNaturalLanguageFlow(line: string): boolean {
+  const words = line.trim().split(/\s+/).filter(Boolean);
+  return words.length >= 3 && NATURAL_LANGUAGE_LETTER_PATTERN.test(line);
+}
+
+function isProseLikeLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed || isLikelyCodeLine(trimmed)) return false;
+
+  if (CJK_PROSE_PATTERN.test(trimmed)) {
+    return /[\s.,:;!?()[\]{}'"“”‘’…·-]/.test(trimmed) || trimmed.length >= 12;
+  }
+
+  return (
+    MARKDOWN_PROSE_MARKER_PATTERN.test(trimmed) &&
+    hasNaturalLanguageFlow(trimmed)
+  );
+}
+
+function isProseLikeUnlabeledBlock(codeString: string): boolean {
+  const meaningfulLines = codeString
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+
+  if (meaningfulLines.length === 0) return false;
+
+  const proseLineCount = meaningfulLines.filter(isProseLikeLine).length;
+  if (proseLineCount === 0) return false;
+
+  const codeLineCount = meaningfulLines.filter(isLikelyCodeLine).length;
+  if (codeLineCount > 0 && codeLineCount >= proseLineCount) return false;
+
+  return proseLineCount >= Math.ceil(meaningfulLines.length / 2);
+}
+
+function classifyMarkdownCodeBlock(
+  codeString: string,
+  explicitLanguage: string | undefined
+): MarkdownCodeBlockPresentation {
+  if (explicitLanguage === 'text') {
+    return { kind: 'text-panel' };
+  }
+
+  if (explicitLanguage) {
+    return { kind: 'code-block', ...normalizeCodeLanguage(explicitLanguage) };
+  }
+
+  const inferredLanguage = inferCodeLanguage(codeString);
+  if (inferredLanguage.displayLanguage === 'shell') {
+    return { kind: 'code-block', ...inferredLanguage };
+  }
+
+  if (isProseLikeUnlabeledBlock(codeString)) {
+    return { kind: 'text-panel' };
+  }
+
+  return { kind: 'code-block', ...inferredLanguage };
+}
+
+const TEXT_FENCE_PANEL_STYLES = {
+  panel:
+    'article-readable article-text-panel my-8 max-w-full whitespace-pre-wrap break-words rounded-xl border border-border/70 bg-muted/30 px-4 py-5 font-mono text-sm leading-7 text-foreground shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:px-5 sm:py-6 sm:text-base sm:leading-8',
+  terminalPanel:
+    'border-primary/30 bg-[hsl(var(--terminal-code-bg))] text-primary/90 shadow-[0_0_24px_hsl(var(--primary)/0.08)]',
+} as const;
+
+const TEXT_FENCE_PANEL_INLINE_STYLE = {
+  overflowX: 'visible',
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'break-word',
+  wordBreak: 'keep-all',
+} as const;
+
+const CODE_BLOCK_WRAPPING_STYLE = {
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'anywhere',
+  wordBreak: 'break-word',
+} satisfies React.CSSProperties;
+
+const ARTICLE_EMPHASIS_STYLES = {
+  strong: 'article-emphasis-strong',
+  em: 'article-emphasis-em',
+} as const;
+
+interface TextFencePanelProps {
+  codeString: string;
+  isTerminalTheme: boolean;
+}
+
+function TextFencePanel({
+  codeString,
+  isTerminalTheme,
+}: TextFencePanelProps) {
+  return (
+    <pre
+      aria-label='Preformatted article panel'
+      data-testid='markdown-text-panel'
+      style={TEXT_FENCE_PANEL_INLINE_STYLE}
+      className={cn(
+        TEXT_FENCE_PANEL_STYLES.panel,
+        isTerminalTheme && TEXT_FENCE_PANEL_STYLES.terminalPanel
+      )}
+    >
+      {codeString}
+    </pre>
+  );
+}
+
 const INLINE_SAFE_TAGS = new Set([
   'a',
   'abbr',
@@ -497,6 +644,7 @@ function hasNonInlineNode(node: unknown): boolean {
 
   if (
     node.type === CodeBlock ||
+    node.type === TextFencePanel ||
     node.type === ClickableImage ||
     node.type === EmbeddedVideo ||
     node.type === NormalizedVideoSource ||
@@ -728,7 +876,7 @@ function CodeBlock({
       <div className='relative overflow-hidden'>
         <div
           className={cn(
-            'overflow-x-auto transition-[max-height] duration-500 ease-in-out',
+            'overflow-x-visible transition-[max-height] duration-500 ease-in-out',
             collapsed ? 'overflow-y-hidden' : 'overflow-y-visible'
           )}
           style={
@@ -767,20 +915,23 @@ function CodeBlock({
                 : '0 18px 36px rgba(15, 23, 42, 0.12)',
               fontSize: '0.92rem',
               lineHeight: 1.75,
+              overflowX: 'visible',
+              ...CODE_BLOCK_WRAPPING_STYLE,
             }}
             codeTagProps={{
               style: {
                 fontFamily:
                   "'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Consolas, monospace",
                 fontSize: '0.92rem',
+                ...CODE_BLOCK_WRAPPING_STYLE,
               },
             }}
             className={cn(
-              'rounded-xl shadow-lg !overflow-x-auto',
+              'article-code-highlighter rounded-xl shadow-lg !overflow-x-visible',
               isTerminalTheme && 'rounded-t-none !rounded-b-xl',
               !isTerminalTheme && '!pt-11'
             )}
-            wrapLongLines={false}
+            wrapLongLines
           >
             {codeString}
           </SyntaxHighlighter>
@@ -1059,6 +1210,12 @@ function MarkdownRendererInner({
           {children}
         </blockquote>
       ),
+      strong: ({ children }: { children?: ReactNode }) => (
+        <strong className={ARTICLE_EMPHASIS_STYLES.strong}>{children}</strong>
+      ),
+      em: ({ children }: { children?: ReactNode }) => (
+        <em className={ARTICLE_EMPHASIS_STYLES.em}>{children}</em>
+      ),
       pre({
         children,
         node,
@@ -1071,15 +1228,27 @@ function MarkdownRendererInner({
         }
 
         const match = /language-([\w-]+)/.exec(codeBlockData.className || '');
-        const resolvedLanguage = match
-          ? normalizeCodeLanguage(match[1])
-          : inferCodeLanguage(codeBlockData.codeString);
+        const explicitLanguage = match?.[1]?.trim().toLowerCase();
+
+        const presentation = classifyMarkdownCodeBlock(
+          codeBlockData.codeString,
+          explicitLanguage
+        );
+
+        if (presentation.kind === 'text-panel') {
+          return (
+            <TextFencePanel
+              codeString={codeBlockData.codeString}
+              isTerminalTheme={isTerminal}
+            />
+          );
+        }
 
         return (
           <CodeBlock
             codeString={codeBlockData.codeString}
-            syntaxLanguage={resolvedLanguage.syntaxLanguage}
-            displayLanguage={resolvedLanguage.displayLanguage}
+            syntaxLanguage={presentation.syntaxLanguage}
+            displayLanguage={presentation.displayLanguage}
             isTerminalTheme={isTerminal}
             copiedCode={copiedCode}
             onCopy={copyToClipboard}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1857,6 +1857,61 @@
   @apply rounded-xl border border-border/50 shadow-sm;
 }
 
+.article-flow.prose > .article-text-panel {
+  overflow-x: visible;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: keep-all;
+}
+
+.article-flow .article-emphasis-strong {
+  color: hsl(var(--text-strong, var(--foreground)));
+  font-weight: 800;
+  text-decoration: underline;
+  text-decoration-color: hsl(var(--primary) / 0.28);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+.article-flow .article-emphasis-em {
+  color: hsl(var(--text, var(--foreground)));
+  font-style: italic;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: hsl(var(--primary) / 0.18);
+  text-decoration-thickness: 0.06em;
+  text-underline-offset: 0.16em;
+}
+
+.terminal .article-flow .article-emphasis-strong {
+  color: hsl(var(--terminal-glow));
+  text-decoration-color: hsl(var(--terminal-glow) / 0.36);
+}
+
+.terminal .article-flow .article-emphasis-em {
+  color: hsl(var(--terminal-amber));
+  text-decoration-color: hsl(var(--terminal-amber) / 0.3);
+}
+
+.article-code-card {
+  min-width: 0;
+}
+
+.article-code-card :where(.article-code-highlighter) {
+  overflow-x: visible !important;
+}
+
+.article-code-card
+  :where(.article-code-highlighter, .article-code-highlighter code) {
+  white-space: pre-wrap !important;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.article-code-card .article-code-highlighter span {
+  white-space: pre-wrap !important;
+}
+
 /* 기본 테마 목록 스타일 */
 :not(.terminal) .prose ul,
 :not(.terminal) .prose ol {
@@ -1917,6 +1972,7 @@
 .article-flow
   > :where(
     .article-readable,
+    .article-text-panel,
     p,
     ul,
     ol,
@@ -1991,6 +2047,7 @@
   .article-flow
     > :where(
       .article-readable,
+      .article-text-panel,
       p,
       ul,
       ol,
@@ -2004,7 +2061,7 @@
       cite,
       small
     ) {
-    grid-column: 3 / 11;
+    grid-column: 1 / -1;
     max-width: none;
   }
 

--- a/frontend/src/test/MarkdownRenderer.codeblocks.test.tsx
+++ b/frontend/src/test/MarkdownRenderer.codeblocks.test.tsx
@@ -1,9 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { LanguageProvider } from '@/contexts/LanguageContext';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import MarkdownRenderer from '@/components/features/blog/MarkdownRenderer';
+
+const indexCss = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8');
+
+const K8S_PROBE_INDENTED_EXCERPT = [
+  '    startupProbe: 무거운 Spring Boot나 JVM 앱이 기지개를 켤 때, livenessProbe가 이를 장애로 오진하여 성급하게 목을 치는 참사를 막는 **유예 기간의 방패**다. 이 방패가 걷히기 전까지 다른 메스는 모두 잠잠하다.',
+  '',
+  '    livenessProbe: 이 검사에 실패하면 kubelet은 지체 없이 컨테이너의 뇌수(PID 1)에 SIGTERM 시그널을 박아 넣어 프로세스를 박살 내고 새로 띄운다. 교착 상태(Deadlock)에 빠진 좀비를 처리하는 물리적인 철퇴다. ',
+  '',
+  '    readinessProbe: 이는 실패하더라도 프로세스를 살려두되, API Server에 즉각 보고하여 Service의 iptables 라우팅 타겟 목록에서 이 Pod의 IP를 파내버린다. "심장은 뛰지만 트래픽을 받을 정신은 없는" 상태를 사회망으로부터 완벽히 격리하는 섬세한 장치다.',
+].join('\n');
+
+const K8S_PROBE_PANEL_TEXT = K8S_PROBE_INDENTED_EXCERPT.replace(
+  /^ {4}/gm,
+  ''
+);
+
+function getRequiredElement(container: HTMLElement, selector: string) {
+  const element = container.querySelector<HTMLElement>(selector);
+  if (!element) {
+    throw new Error(`Expected selector to match an element: ${selector}`);
+  }
+  return element;
+}
 
 function renderMarkdown(
   content: string,
@@ -31,32 +56,201 @@ function renderMarkdown(
 }
 
 describe('MarkdownRenderer code blocks', () => {
+  it('renders the k8s probe indented prose block as a readable text panel', () => {
+    const { container } = renderMarkdown(K8S_PROBE_INDENTED_EXCERPT, {
+      postPath: '2026/k8s-start',
+    });
+
+    const textPanel = screen.getByTestId('markdown-text-panel');
+
+    expect(textPanel).toBeInTheDocument();
+    expect(textPanel.textContent).toBe(K8S_PROBE_PANEL_TEXT);
+    expect(container.querySelector('.article-code-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-copy-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-collapse-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^code$/i)).not.toBeInTheDocument();
+  });
+
   it('renders fenced shell snippets without an explicit language as full code blocks', () => {
-    renderMarkdown(
+    const { container } = renderMarkdown(
       '```\npvecm qdevice remove\nrm -rf /etc/corosync/qdevice/\n```'
     );
 
+    expect(container.querySelector('.article-code-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('markdown-text-panel')).not.toBeInTheDocument();
     expect(screen.getByTestId('code-copy-btn')).toBeInTheDocument();
     expect(screen.getByText(/shell/i)).toBeInTheDocument();
     expect(screen.getByText('pvecm qdevice remove')).toBeInTheDocument();
   });
 
-  it('renders explicit text fences as code blocks with a text label', () => {
-    renderMarkdown('```text\nline 1\nline 2\n```');
+  it('renders unlabeled code-like snippets as full code blocks', () => {
+    const { container } = renderMarkdown(
+      '```\nfunction demo() { return 1; }\nconst ok = true;\n```'
+    );
 
+    const codeCard = getRequiredElement(container, '.article-code-card');
+
+    expect(codeCard).toHaveTextContent('function demo() { return 1; }');
+    expect(codeCard).toHaveTextContent('const ok = true;');
     expect(screen.getByTestId('code-copy-btn')).toBeInTheDocument();
-    expect(screen.getByText(/text/i)).toBeInTheDocument();
-    expect(screen.getByText('line 1')).toBeInTheDocument();
+    expect(screen.getByText(/^code$/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('markdown-text-panel')).not.toBeInTheDocument();
+  });
+
+  it('wraps regular fenced code while preserving code card chrome', () => {
+    const longLine = `const generatedLabel = '${'wrapped-code-token-'.repeat(12)}';`;
+    const { container } = renderMarkdown(
+      ['```ts', longLine, 'console.log(generatedLabel);', '```'].join('\n')
+    );
+
+    const codeCard = getRequiredElement(container, '.article-code-card');
+    const highlighter = getRequiredElement(
+      container,
+      '.article-code-card .article-code-highlighter'
+    );
+    const highlighterStyle = getComputedStyle(highlighter);
+
+    expect(codeCard).toHaveClass('article-code-card');
+    expect(codeCard.matches('.article-flow > .article-code-card')).toBe(true);
+    expect(screen.getByTestId('code-copy-btn')).toBeInTheDocument();
+    expect(screen.getByText(/typescript/i)).toBeInTheDocument();
+    expect(highlighter).toHaveClass(
+      'article-code-highlighter',
+      '!overflow-x-visible'
+    );
+    expect(highlighter).not.toHaveClass('!overflow-x-auto');
+    expect(highlighterStyle.whiteSpace).toBe('pre-wrap');
+    expect(highlighterStyle.getPropertyValue('overflow-wrap')).toBe('anywhere');
+    expect(highlighterStyle.overflowX).not.toBe('auto');
+    expect(highlighterStyle.overflowX).not.toBe('scroll');
+  });
+
+  it('keeps article readable text on the same desktop grid span as wide media', () => {
+    const { container } = renderMarkdown(
+      [
+        'Readable paragraph with body copy.',
+        '',
+        '![Wide media](/images/2026/example.png)',
+        '',
+        '```js',
+        'const ok = true;',
+        '```',
+      ].join('\n')
+    );
+    const paragraph = getRequiredElement(
+      container,
+      '.article-flow > p.article-readable'
+    );
+    const mediaFrame = getRequiredElement(
+      container,
+      '.article-flow > .article-media-frame[data-layout="wide"]'
+    );
+    const codeCard = getRequiredElement(container, '.article-flow > .article-code-card');
+    const articleReadableDesktopGrid = indexCss.match(
+      /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.article-flow[\s\S]*?>\s*:where\([\s\S]*?\.article-readable[\s\S]*?\)\s*\{[\s\S]*?grid-column:\s*([^;]+);/
+    );
+    const wideMediaDesktopGrid = indexCss.match(
+      /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?\.article-flow\s*>\s*\.article-media-frame\[data-layout='wide'\],[\s\S]*?grid-column:\s*([^;]+);/
+    );
+
+    expect(paragraph.matches('.article-flow > .article-readable')).toBe(true);
+    expect(mediaFrame.matches('.article-flow > .article-media-frame')).toBe(true);
+    expect(codeCard.matches('.article-flow > .article-code-card')).toBe(true);
+    expect(articleReadableDesktopGrid?.[1]?.replace(/\s+/g, ' ').trim()).toBe(
+      '1 / -1'
+    );
+    expect(wideMediaDesktopGrid?.[1]?.replace(/\s+/g, ' ').trim()).toBe(
+      '1 / -1'
+    );
+  });
+
+  it('renders explicit text fences as readable preformatted article panels', () => {
+    const { container } = renderMarkdown(
+      '```text\nroot\n├── left\n│   └── child\n└── right\n```'
+    );
+
+    const textPanel = screen.getByTestId('markdown-text-panel');
+
+    expect(textPanel).toBeInTheDocument();
+    expect(textPanel.textContent).toBe(
+      'root\n├── left\n│   └── child\n└── right'
+    );
+    expect(textPanel).toHaveClass(
+      'article-readable',
+      'article-text-panel',
+      'whitespace-pre-wrap',
+      'break-words'
+    );
+    expect(textPanel).not.toHaveClass('whitespace-pre');
+    expect(textPanel).not.toHaveClass('overflow-x-auto');
+    expect(textPanel).not.toHaveClass('overscroll-x-contain');
+    expect(textPanel.matches('.article-flow > .article-text-panel')).toBe(true);
+    expect(textPanel).not.toHaveAttribute('tabindex');
+    expect(container.querySelector('.article-code-card')).not.toBeInTheDocument();
+    expect(
+      container.querySelector('.article-code-highlighter')
+    ).not.toBeInTheDocument();
+    expect(textPanel.querySelector('code')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-copy-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('code-collapse-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^text$/i)).not.toBeInTheDocument();
+  });
+
+  it('wraps long text fence lines without horizontal scrolling classes', () => {
+    const longLine =
+      'this-is-a-very-long-preformatted-prose-line-that-should-wrap-within-the-readable-article-panel-instead-of-requiring-horizontal-scrolling';
+
+    renderMarkdown(
+      ['```text', 'start', `  ${longLine}`, 'end', '```'].join('\n')
+    );
+
+    const textPanel = screen.getByTestId('markdown-text-panel');
+
+    const computedStyle = getComputedStyle(textPanel);
+
+    expect(textPanel.textContent).toBe(`start\n  ${longLine}\nend`);
+    expect(textPanel).toHaveClass('whitespace-pre-wrap', 'break-words');
+    expect(textPanel).not.toHaveClass('whitespace-pre');
+    expect(textPanel).not.toHaveClass('overflow-x-auto');
+    expect(textPanel).not.toHaveClass('overscroll-x-contain');
+    expect(computedStyle.whiteSpace).toBe('pre-wrap');
+    expect(computedStyle.getPropertyValue('overflow-wrap')).toBe('break-word');
+    expect(computedStyle.wordBreak).toBe('keep-all');
+    expect(computedStyle.overflowX).not.toBe('auto');
+    expect(computedStyle.overflowX).not.toBe('scroll');
   });
 
   it('keeps inline code as inline code without block affordances', () => {
     const { container } = renderMarkdown('Use `append` here.');
+    const inlineCode = screen.getByText('append', { selector: 'code' });
 
     expect(screen.queryByTestId('code-copy-btn')).not.toBeInTheDocument();
     expect(container.querySelector('pre')).not.toBeInTheDocument();
-    expect(
-      screen.getByText('append', { selector: 'code' })
-    ).toBeInTheDocument();
+    expect(inlineCode).toBeInTheDocument();
+    expect(inlineCode).toHaveAttribute('data-inline-code', 'true');
+    expect(inlineCode).toHaveClass('bg-muted', 'px-1.5', 'py-0.5', 'rounded');
+    expect(inlineCode).not.toHaveClass(
+      'article-emphasis-strong',
+      'article-emphasis-em'
+    );
+  });
+
+  it('renders strong and emphasis with semantic tags and strengthened article classes', () => {
+    renderMarkdown('Body **strong copy** and *emphasized copy* keep `code` plain.');
+
+    const strong = screen.getByText('strong copy', { selector: 'strong' });
+    const emphasis = screen.getByText('emphasized copy', { selector: 'em' });
+    const inlineCode = screen.getByText('code', { selector: 'code' });
+
+    expect(strong.tagName).toBe('STRONG');
+    expect(strong).toHaveClass('article-emphasis-strong');
+    expect(emphasis.tagName).toBe('EM');
+    expect(emphasis).toHaveClass('article-emphasis-em');
+    expect(inlineCode).toHaveAttribute('data-inline-code', 'true');
+    expect(inlineCode).not.toHaveClass(
+      'article-emphasis-strong',
+      'article-emphasis-em'
+    );
   });
 
   it('does not send inline identifiers into pre blocks', () => {


### PR DESCRIPTION
## Summary
- Render explicit `text` fences and prose-like unlabeled markdown blocks as readable article panels instead of code cards.
- Wrap long text and code block lines while keeping code copy/collapse affordances for real code.
- Align readable article text panels with wide media width and strengthen bold/emphasis rendering.
- Add renderer regression coverage for text panels, code wrapping, inline code, and emphasis classes.

## Testing
- `npm run test:run -- src/test/MarkdownRenderer.codeblocks.test.tsx`
- `npm run type-check`
- targeted ESLint on changed files
- `git diff --check`
- `npx vite build --config config/vite.config.ts --outDir /tmp/red-black-tree-frontend-build-code-readability --emptyOutDir`
- Playwright QA on `/blog/2026/k8s-start` and `/blog/2026/red-black-tree-insert-big-node-model`

## Risks
- `lsp_diagnostics` could not run locally because `typescript-language-server` and `biome` are not installed.
- The local worktree still has unrelated generated manifest changes and untracked post/image files; they were intentionally excluded from this PR.