### PR TITLE
fix(ai): retry legacy completions for chat failures

### DIFF
--- a/backend/src/services/ai/ai.service.js
+++ b/backend/src/services/ai/ai.service.js
@@ -138,6 +138,7 @@ export class AIService {
         temperature: options.temperature,
         model: options.model,
         systemPrompt: options.systemPrompt,
+        maxTokens: options.maxTokens,
         timeout: options.timeout,
       });
 
@@ -244,6 +245,7 @@ export class AIService {
       const response = await client.chat(messages, {
         temperature: options.temperature,
         model: options.model,
+        maxTokens: options.maxTokens,
         timeout: options.timeout,
       });
 

--- a/backend/src/services/ai/openai-client.service.js
+++ b/backend/src/services/ai/openai-client.service.js
@@ -119,6 +119,128 @@ export class OpenAICompatClient {
     return this._openai;
   }
 
+  _shouldTryLegacyCompletions(error) {
+    if (process.env.AI_ENABLE_LEGACY_COMPLETIONS_FALLBACK === "false") {
+      return false;
+    }
+
+    const status = error?.status || error?.code;
+    const message = error?.message || "";
+    return (
+      status === 401 ||
+      status === 404 ||
+      status === 405 ||
+      /Authentication is required|not found|method not allowed/i.test(message)
+    );
+  }
+
+  _messageContentToText(content) {
+    if (typeof content === "string") {
+      return content;
+    }
+
+    if (Array.isArray(content)) {
+      if (content.some((part) => part?.type === "image_url" || part?.image_url)) {
+        throw new Error("Legacy completions fallback does not support image content");
+      }
+
+      return content
+        .map((part) => {
+          if (typeof part === "string") return part;
+          if (typeof part?.text === "string") return part.text;
+          if (typeof part?.content === "string") return part.content;
+          return "";
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+
+    if (typeof content?.text === "string") {
+      return content.text;
+    }
+
+    if (typeof content?.content === "string") {
+      return content.content;
+    }
+
+    return "";
+  }
+
+  _messagesToLegacyPrompt(messages) {
+    const lines = [];
+
+    for (const message of messages || []) {
+      const text = this._messageContentToText(message.content).trim();
+      if (!text) continue;
+
+      const role = String(message.role || "user").toLowerCase();
+      const label =
+        role === "system"
+          ? "System"
+          : role === "assistant"
+            ? "Assistant"
+            : role === "tool"
+              ? "Tool"
+              : "User";
+
+      lines.push(`${label}: ${text}`);
+    }
+
+    lines.push("Assistant:");
+    const prompt = lines.join("\n\n").trim();
+    if (!prompt || prompt === "Assistant:") {
+      throw new Error("Legacy completions fallback requires text messages");
+    }
+
+    return prompt;
+  }
+
+  async _chatViaLegacyCompletions(messages, options, originalModel, requestId, startTime) {
+    const model =
+      options.legacyCompletionsModel ||
+      process.env.AI_LEGACY_COMPLETIONS_MODEL ||
+      originalModel;
+    const prompt = this._messagesToLegacyPrompt(messages);
+
+    logger.warn(
+      { operation: "chat", requestId },
+      "Retrying chat request via legacy completions endpoint",
+      { originalModel, model },
+    );
+
+    const response = await this._openai.completions.create(
+      {
+        model,
+        prompt,
+        temperature: options.temperature ?? 0.7,
+        max_tokens: options.maxTokens || options.max_tokens || 1024,
+        stream: false,
+      },
+      {
+        timeout: options.timeout || DEFAULT_TIMEOUT,
+      },
+    );
+
+    const duration = Date.now() - startTime;
+    this._recordSuccess();
+
+    const result = {
+      content: response.choices[0]?.text || "",
+      model: response.model || model,
+      provider: "openai-compat-legacy-completions",
+      usage: response.usage,
+      finishReason: response.choices[0]?.finish_reason,
+    };
+
+    logger.info({ operation: "chat", requestId }, "Legacy completions completed", {
+      duration,
+      model: result.model,
+      responseLength: result.content?.length,
+    });
+
+    return result;
+  }
+
   /**
    * Check if circuit breaker is open
    */
@@ -219,6 +341,24 @@ export class OpenAICompatClient {
 
       return result;
     } catch (error) {
+      if (this._shouldTryLegacyCompletions(error)) {
+        try {
+          return await this._chatViaLegacyCompletions(
+            messages,
+            options,
+            model,
+            requestId,
+            startTime,
+          );
+        } catch (fallbackError) {
+          logger.warn(
+            { operation: "chat", requestId },
+            "Legacy completions fallback failed",
+            { model, error: fallbackError.message },
+          );
+        }
+      }
+
       const duration = Date.now() - startTime;
       this._recordFailure();
 

--- a/backend/src/workers/ai-worker.js
+++ b/backend/src/workers/ai-worker.js
@@ -26,6 +26,7 @@ async function handleGenerateTask(task) {
     temperature: options.temperature,
     model: options.model,
     systemPrompt: options.systemPrompt,
+    maxTokens: options.maxTokens,
     timeout: options.timeout,
   });
   
@@ -39,6 +40,7 @@ async function handleChatTask(task) {
   const response = await client.chat(messages, {
     temperature: options.temperature,
     model: options.model,
+    maxTokens: options.maxTokens,
     timeout: options.timeout,
   });
   

--- a/backend/test/openai-client-legacy-completions.test.js
+++ b/backend/test/openai-client-legacy-completions.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 process.env.APP_ENV = "test";
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || "gpt-4.1";
 process.env.AI_ENABLE_LEGACY_COMPLETIONS_FALLBACK = "true";
 process.env.AI_LEGACY_COMPLETIONS_MODEL = "gpt-5-mini";
 

--- a/backend/test/openai-client-legacy-completions.test.js
+++ b/backend/test/openai-client-legacy-completions.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.APP_ENV = "test";
+process.env.AI_ENABLE_LEGACY_COMPLETIONS_FALLBACK = "true";
+process.env.AI_LEGACY_COMPLETIONS_MODEL = "gpt-5-mini";
+
+const { OpenAICompatClient } = await import("../src/services/ai/openai-client.service.js");
+
+test("chat retries through legacy completions when chat completions are unavailable", async () => {
+  const client = new OpenAICompatClient({
+    baseUrl: "https://air.example.test/v1",
+    apiKey: "sk-test",
+    model: "gpt-4.1",
+  });
+
+  let completionPayload;
+  client._openai = {
+    chat: {
+      completions: {
+        create: async () => {
+          const error = new Error("Authentication is required.");
+          error.status = 401;
+          throw error;
+        },
+      },
+    },
+    completions: {
+      create: async (payload) => {
+        completionPayload = payload;
+        return {
+          choices: [{ text: "OK", finish_reason: "stop" }],
+          model: payload.model,
+          usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+        };
+      },
+    },
+  };
+
+  const result = await client.chat(
+    [
+      { role: "system", content: "Answer tersely." },
+      { role: "user", content: "Reply with exactly OK" },
+    ],
+    { temperature: 0, maxTokens: 12 },
+  );
+
+  assert.equal(result.content, "OK");
+  assert.equal(result.model, "gpt-5-mini");
+  assert.equal(result.provider, "openai-compat-legacy-completions");
+  assert.equal(completionPayload.model, "gpt-5-mini");
+  assert.equal(completionPayload.max_tokens, 12);
+  assert.match(completionPayload.prompt, /System: Answer tersely\./);
+  assert.match(completionPayload.prompt, /User: Reply with exactly OK/);
+});


### PR DESCRIPTION
## Summary
- Add a legacy `/v1/completions` retry path when chat completions return provider-level auth/not-found/method failures.
- Allow runtime override with `AI_LEGACY_COMPLETIONS_MODEL`, used for the current `air.nodove.com` recovery path.
- Pass `maxTokens` through sync and worker AI paths and cover the retry behavior with a backend unit test.

## Testing
- `node --check backend/src/services/ai/openai-client.service.js backend/src/services/ai/ai.service.js backend/src/workers/ai-worker.js`
- In production API pod: `node --test test/openai-client-legacy-completions.test.js`
- Production smoke: 5 anonymous calls across `/api/v1/ai/sketch`, `/api/v1/ai/prism`, and `/api/v1/ai/chain` all returned HTTP 200, `ok=true`, `fallback=false`.

## Risks
- Worker D1 still reports default model `gpt-4.1`; production hotfix sets `AI_LEGACY_COMPLETIONS_MODEL=gpt-5-mini` until Worker config can be corrected.
- `/api/v1/ai/models` still returns the existing Worker route-ownership 404 and is outside this backend retry fix.

## Runtime note
- Applied a Kubernetes ConfigMap hotfix to `api` and `ai-worker` deployments so production is already recovered while this PR is reviewed.