### PR TITLE
fix(cors): allow chat preflight headers

### DIFF
--- a/workers/api-gateway/src/lib/cors.ts
+++ b/workers/api-gateway/src/lib/cors.ts
@@ -13,7 +13,7 @@ const DEFAULT_ALLOWED_ORIGINS = [
 ];
 
 const ACCESS_CONTROL_ALLOW_HEADERS =
-  'Content-Type, Authorization, X-Requested-With, X-API-Key, Setup-Token, X-Device-Fingerprint';
+  'Content-Type, Authorization, X-Requested-With, X-API-Key, Setup-Token, X-Device-Fingerprint, X-Principal-Sub, Idempotency-Key';
 
 function parseAllowedOrigins(raw: string | null | undefined): string[] {
   return String(raw || '')

--- a/workers/api-gateway/test/comments-proxy.test.ts
+++ b/workers/api-gateway/test/comments-proxy.test.ts
@@ -67,6 +67,26 @@ describe('comments route ownership on worker D1', () => {
     );
   });
 
+  it('allows general chat and memory preflight headers', async () => {
+    const response = await SELF.fetch('https://example.com/api/v1/chat/session/test/message', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://noblog.nodove.com',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers':
+          'content-type,authorization,x-principal-sub,idempotency-key',
+      },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://noblog.nodove.com'
+    );
+    const allowHeaders = response.headers.get('Access-Control-Allow-Headers') || '';
+    expect(allowHeaders).toMatch(/X-Principal-Sub/i);
+    expect(allowHeaders).toMatch(/Idempotency-Key/i);
+  });
+
   it('creates and lists comments from D1', async () => {
     const createResponse = await SELF.fetch('https://example.com/api/v1/comments', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- Allow `X-Principal-Sub` and `Idempotency-Key` in API gateway CORS responses.
- Add a worker preflight regression test for general chat and memory headers.
- Scope is patch-only; the local work-log markdown file is intentionally excluded.

## Testing
- `npm test -- comments-proxy.test.ts` in `workers/api-gateway`
- `npm run typecheck` in `workers/api-gateway`
- Production worker was already deployed and browser-origin fetch verified after the patch.

## Risks
- Low: expands allowed request headers for already allowed origins only.

## Follow-ups
- None.