### PR TITLE
Fix admin backend config and improve authoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,9 +33,9 @@ jobs:
       SITE_BASE_URL: https://noblog.nodove.com
       VITE_SITE_BASE_URL: https://noblog.nodove.com
       # Unified backend base URL (e.g., https://api.nodove.com or https://your-server:5080)
-      # Configure this as a repository secret named VITE_API_BASE_URL
-      VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
-      VITE_CHAT_BASE_URL: ${{ secrets.VITE_CHAT_BASE_URL }}
+      API_BASE_URL: ${{ vars.API_BASE_URL || secrets.API_BASE_URL || vars.VITE_API_BASE_URL || secrets.VITE_API_BASE_URL || 'https://api.nodove.com' }}
+      VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL || secrets.VITE_API_BASE_URL || vars.API_BASE_URL || secrets.API_BASE_URL || 'https://api.nodove.com' }}
+      VITE_CHAT_BASE_URL: ${{ vars.VITE_CHAT_BASE_URL || secrets.VITE_CHAT_BASE_URL || vars.API_BASE_URL || secrets.API_BASE_URL || 'https://api.nodove.com' }}
       VITE_CHAT_API_KEY: ${{ secrets.VITE_CHAT_API_KEY }}
       # Feature flags for frontend (configure as repository secrets)
       # Set VITE_FEATURE_FAB to 'true' to enable FAB by default

--- a/frontend/scripts/generate-runtime-config.js
+++ b/frontend/scripts/generate-runtime-config.js
@@ -11,6 +11,8 @@ const __dirname = path.dirname(__filename);
 const frontendRoot = path.resolve(__dirname, '..');
 const repoRoot = path.resolve(frontendRoot, '..');
 const outputPath = path.join(frontendRoot, 'public', 'runtime-config.json');
+const LOCAL_DEV_API_BASE_URL = 'http://localhost:5080';
+const DEFAULT_PRODUCTION_API_BASE_URL = 'https://api.nodove.com';
 
 function loadRuntimeConfigEnv() {
   dotenv.config({ path: path.join(repoRoot, '.env') });
@@ -28,10 +30,20 @@ export function buildRuntimeConfigFromEnv(
   options = {}
 ) {
   const siteBaseUrl = options.siteBaseUrl || resolveSiteBaseUrl();
+  const lifecycle = String(env.npm_lifecycle_event || '');
+  const isProductionArtifact =
+    env.CI === 'true' ||
+    env.GITHUB_ACTIONS === 'true' ||
+    env.NODE_ENV === 'production' ||
+    lifecycle === 'prebuild' ||
+    lifecycle === 'build' ||
+    lifecycle === 'deploy';
   const apiBaseUrl =
     env.API_BASE_URL ||
     env.VITE_API_BASE_URL ||
-    (env.NODE_ENV === 'production' ? '' : 'http://localhost:5080');
+    (isProductionArtifact
+      ? DEFAULT_PRODUCTION_API_BASE_URL
+      : LOCAL_DEV_API_BASE_URL);
 
   if (!apiBaseUrl) {
     throw new Error(

--- a/frontend/src/components/features/admin/ConfigManager.tsx
+++ b/frontend/src/components/features/admin/ConfigManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -51,6 +51,19 @@ interface ConfigStateResponse {
 
 const EMPTY_CONFIG_VALUES: Record<string, ConfigValue> = {};
 
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+async function readAdminResponseError(res: Response, fallback: string): Promise<string> {
+  const payload = await res.json().catch(() => null);
+  const message =
+    typeof payload?.error === 'string'
+      ? payload.error
+      : payload?.error?.message || payload?.message || fallback;
+  return `${message} (${res.status})`;
+}
+
 export function ConfigManager() {
   const { toast } = useToast();
   const [activeTab, setActiveTab] = useState('app');
@@ -58,13 +71,34 @@ export function ConfigManager() {
   const [visibleSecrets, setVisibleSecrets] = useState<Set<string>>(new Set());
   const [hasChanges, setHasChanges] = useState(false);
 
-  const API_BASE = getApiBaseUrl();
+  const apiBaseResolution = useMemo(() => {
+    try {
+      return { value: getApiBaseUrl(), error: null as Error | null };
+    } catch (error) {
+      return {
+        value: '',
+        error:
+          error instanceof Error
+            ? error
+            : new Error('API base URL is not configured'),
+      };
+    }
+  }, []);
+  const API_BASE = apiBaseResolution.value;
+  const apiBaseError = apiBaseResolution.error;
 
-  const { data: categoriesData, isLoading: categoriesLoading } = useQuery({
-    queryKey: ['config-categories'],
+  const {
+    data: categoriesData,
+    isLoading: categoriesLoading,
+    isError: categoriesFailed,
+    error: categoriesError,
+    refetch: refetchCategories,
+  } = useQuery({
+    queryKey: ['config-categories', API_BASE],
+    enabled: !apiBaseError,
     queryFn: async () => {
       const res = await adminFetchRaw(`${API_BASE}/api/v1/admin/config/categories`);
-      if (!res.ok) throw new Error('Failed to fetch categories');
+      if (!res.ok) throw new Error(await readAdminResponseError(res, 'Failed to fetch categories'));
       const json = await res.json();
       return json.data.categories as ConfigCategory[];
     },
@@ -73,12 +107,15 @@ export function ConfigManager() {
   const {
     data: configData,
     isLoading: configLoading,
+    isError: configFailed,
+    error: configError,
     refetch: refetchConfig,
   } = useQuery({
-    queryKey: ['config-current'],
+    queryKey: ['config-current', API_BASE],
+    enabled: !apiBaseError,
     queryFn: async () => {
       const res = await adminFetchRaw(`${API_BASE}/api/v1/admin/config/current`);
-      if (!res.ok) throw new Error('Failed to fetch config');
+      if (!res.ok) throw new Error(await readAdminResponseError(res, 'Failed to fetch config'));
       const json = await res.json();
       return json.data as ConfigStateResponse;
     },
@@ -321,6 +358,47 @@ export function ConfigManager() {
       <div className='rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-8 flex items-center gap-3 text-sm text-zinc-400'>
         <RefreshCw className='h-4 w-4 animate-spin shrink-0' aria-hidden='true' />
         <span>Loading configuration…</span>
+      </div>
+    );
+  }
+
+  if (apiBaseError || categoriesFailed || configFailed) {
+    const message =
+      apiBaseError?.message ||
+      getErrorMessage(categoriesError, '') ||
+      getErrorMessage(configError, '') ||
+      'Backend configuration API is unavailable';
+
+    return (
+      <div className='rounded-xl border border-red-200 bg-red-50/70 p-5 dark:border-red-900/40 dark:bg-red-950/20'>
+        <div className='flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between'>
+          <div className='space-y-2'>
+            <div className='flex items-center gap-2 text-red-700 dark:text-red-300'>
+              <AlertCircle className='h-4 w-4 shrink-0' aria-hidden='true' />
+              <h2 className='text-sm font-semibold'>Backend config API unavailable</h2>
+            </div>
+            <p className='max-w-3xl break-words text-sm leading-relaxed text-red-700/90 dark:text-red-200/90'>
+              {message}
+            </p>
+            {API_BASE && (
+              <p className='font-mono text-xs text-red-700/70 dark:text-red-200/70'>
+                API base: {API_BASE}
+              </p>
+            )}
+          </div>
+          <button
+            type='button'
+            onClick={() => {
+              void refetchCategories();
+              void refetchConfig();
+            }}
+            disabled={Boolean(apiBaseError)}
+            className='inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 text-xs font-semibold text-red-700 shadow-sm transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800/60 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-900/30'
+          >
+            <RefreshCw className='h-3.5 w-3.5' aria-hidden='true' />
+            Retry
+          </button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/components/features/admin/health/SystemHealth.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.tsx
@@ -42,17 +42,26 @@ interface ProviderHealth {
 export async function checkBackendHealth(): Promise<{
   ok: boolean;
   latencyMs: number;
+  error?: string;
 }> {
-  const base = getApiBaseUrl();
   const start = Date.now();
   try {
+    const base = getApiBaseUrl();
     const res = await fetch(`${base}/api/v1/healthz`, {
       method: "GET",
       signal: AbortSignal.timeout(5000),
     });
-    return { ok: res.ok, latencyMs: Date.now() - start };
-  } catch {
-    return { ok: false, latencyMs: 0 };
+    return {
+      ok: res.ok,
+      latencyMs: Date.now() - start,
+      error: res.ok ? undefined : `HTTP ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      latencyMs: 0,
+      error: err instanceof Error ? err.message : "Health check failed",
+    };
   }
 }
 
@@ -61,9 +70,9 @@ async function checkRAGHealth(): Promise<{
   chroma: boolean;
   latencyMs: number;
 }> {
-  const base = getApiBaseUrl();
   const start = Date.now();
   try {
+    const base = getApiBaseUrl();
     const res = await fetch(`${base}/api/v1/rag/health`, {
       method: "GET",
       signal: AbortSignal.timeout(5000),
@@ -82,8 +91,8 @@ async function checkRAGHealth(): Promise<{
 }
 
 async function getProviders(token: string): Promise<ProviderHealth[]> {
-  const base = getApiBaseUrl();
   try {
+    const base = getApiBaseUrl();
     const res = await fetch(`${base}/api/v1/admin/ai/providers`, {
       headers: bearerAuth(token),
       signal: AbortSignal.timeout(10000),
@@ -100,8 +109,8 @@ async function checkProviderHealth(
   providerId: string,
   token: string,
 ): Promise<{ status: string; latencyMs?: number; error?: string }> {
-  const base = getApiBaseUrl();
   try {
+    const base = getApiBaseUrl();
     const res = await fetch(
       `${base}/api/v1/admin/ai/providers/${providerId}/health`,
       {
@@ -132,8 +141,8 @@ interface AgentHealth {
 }
 
 async function checkAgentHealthRequest(): Promise<AgentHealth> {
-  const base = getApiBaseUrl();
   try {
+    const base = getApiBaseUrl();
     const res = await fetch(`${base}/api/v1/agent/health`, {
       method: "GET",
       signal: AbortSignal.timeout(8000),
@@ -216,6 +225,7 @@ export function SystemHealth() {
         displayName: "Backend API",
         status: result.ok ? "healthy" : "down",
         latencyMs: result.latencyMs,
+        error: result.error,
       },
     ]);
     setCoreLoading(false);

--- a/frontend/src/lib/runtime/preloadRuntimeConfig.ts
+++ b/frontend/src/lib/runtime/preloadRuntimeConfig.ts
@@ -17,6 +17,49 @@ function isRuntimeConfig(value: unknown): value is Partial<PublicRuntimeConfig> 
   return typeof value === 'object' && value !== null;
 }
 
+function isLocalHostname(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1'
+  );
+}
+
+function isLocalServiceUrl(value: unknown): boolean {
+  if (typeof value !== 'string' || !value.trim()) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return isLocalHostname(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function discardUnsafeRuntimeServiceUrls(
+  runtimeConfig: RuntimeConfigPatch,
+  runtimeWindow: RuntimeWindow
+): RuntimeConfigPatch {
+  const hostname = runtimeWindow.location?.hostname || '';
+  if (!hostname || isLocalHostname(hostname)) {
+    return runtimeConfig;
+  }
+
+  const nextConfig = { ...runtimeConfig };
+  if (isLocalServiceUrl(nextConfig.apiBaseUrl)) {
+    delete nextConfig.apiBaseUrl;
+  }
+  if (isLocalServiceUrl(nextConfig.chatBaseUrl)) {
+    delete nextConfig.chatBaseUrl;
+  }
+  if (isLocalServiceUrl(nextConfig.chatWsBaseUrl)) {
+    delete nextConfig.chatWsBaseUrl;
+  }
+  return nextConfig;
+}
+
 function readBooleanEnv(value: string | boolean | undefined): boolean | undefined {
   if (typeof value === 'boolean') return value;
   if (typeof value !== 'string') return undefined;
@@ -119,7 +162,10 @@ export async function preloadRuntimeConfig(
     }
 
     const runtimeWindow = window as RuntimeWindow;
-    const runtimeConfig = json as RuntimeConfigPatch;
+    const runtimeConfig = discardUnsafeRuntimeServiceUrls(
+      json as RuntimeConfigPatch,
+      runtimeWindow
+    );
 
     runtimeWindow.APP_CONFIG = {
       ...(runtimeWindow.APP_CONFIG ?? {}),

--- a/frontend/src/pages/admin/NewPost.tsx
+++ b/frontend/src/pages/admin/NewPost.tsx
@@ -1,5 +1,12 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
+import {
+  Copy,
+  FilePlus2,
+  LogOut,
+  RotateCcw,
+  UploadCloud,
+} from "lucide-react";
 import {
   createPostPR,
   type CreatePostPayload,
@@ -17,9 +24,19 @@ import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/componen
 import { ScrollArea } from "@/components/ui/scroll-area";
 import BotChatPanel from "@/components/features/admin/BotChatPanel";
 import AiImageGeneratorPanel from "@/components/features/admin/AiImageGeneratorPanel";
+import { cn } from "@/lib/utils";
 
 function getErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message ? error.message : fallback;
+}
+
+function slugifyTitle(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\-\s_]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 export default function NewPost() {
@@ -35,8 +52,11 @@ export default function NewPost() {
   const [published, setPublished] = useState(true);
   const [coverImage, setCoverImage] = useState("");
   const [content, setContent] = useState("");
+  const [slugEdited, setSlugEdited] = useState(false);
+  const [isDraggingImages, setIsDraggingImages] = useState(false);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploaded, setUploaded] = useState<
     Array<{ url: string; variantWebp?: { url: string } | null }>
@@ -50,6 +70,51 @@ export default function NewPost() {
     await storeLogout();
     window.dispatchEvent(new Event("admin-auth-changed"));
   };
+
+  const handleTitleChange = useCallback(
+    (value: string) => {
+      setTitle(value);
+      if (!slugEdited) {
+        setSlug(slugifyTitle(value));
+      }
+    },
+    [slugEdited],
+  );
+
+  const handleSlugChange = useCallback((value: string) => {
+    setSlugEdited(true);
+    setSlug(value);
+  }, []);
+
+  const insertAtCursor = useCallback((text: string) => {
+    const trimmedText = text.trimEnd();
+    const insertion = `${trimmedText}\n`;
+    const textarea = textareaRef.current;
+
+    setContent((prev) => {
+      if (!textarea) {
+        return prev
+          ? `${prev}${prev.endsWith("\n") ? "" : "\n"}${insertion}`
+          : insertion;
+      }
+
+      const start = textarea.selectionStart ?? prev.length;
+      const end = textarea.selectionEnd ?? start;
+      const before = prev.slice(0, start);
+      const after = prev.slice(end);
+      const prefix = before && !before.endsWith("\n") ? "\n" : "";
+      const suffix = after && !insertion.endsWith("\n\n") ? "\n" : "";
+      const next = `${before}${prefix}${insertion}${suffix}${after}`;
+      const cursor = before.length + prefix.length + insertion.length;
+
+      window.requestAnimationFrame(() => {
+        textarea.focus();
+        textarea.setSelectionRange(cursor, cursor);
+      });
+
+      return next;
+    });
+  }, []);
 
   const createPr = useMutation({
     mutationFn: async () => {
@@ -112,7 +177,6 @@ export default function NewPost() {
       );
       setUploaded((prev) => [...res.items, ...prev]);
 
-      // Auto-insert images into the editor
       res.items.forEach((u) => {
         insertAtCursor(`![image](${u.variantWebp?.url || u.url})`);
       });
@@ -162,9 +226,8 @@ export default function NewPost() {
     }
   };
 
-  const handleDrop = async (e: React.DragEvent<HTMLTextAreaElement>) => {
-    e.preventDefault();
-    const items = e.dataTransfer.items;
+  const getImageFilesFromDataTransfer = (dataTransfer: DataTransfer): File[] => {
+    const items = dataTransfer.items;
     const imageFiles: File[] = [];
     if (items) {
       for (let i = 0; i < items.length; i++) {
@@ -174,16 +237,28 @@ export default function NewPost() {
         }
       }
     }
-    if (imageFiles.length > 0) {
-      await handleImageUploads(imageFiles);
+    if (!imageFiles.length && dataTransfer.files?.length) {
+      for (const file of Array.from(dataTransfer.files)) {
+        if (file.type.match("^image/")) imageFiles.push(file);
+      }
     }
+    return imageFiles;
   };
 
-  const insertAtCursor = (text: string) => {
-    setContent((prev) =>
-      prev ? `${prev}${prev.endsWith("\n") ? "" : "\n"}${text}\n` : `${text}\n`,
-    );
+  const handleEditorDrop = async (e: React.DragEvent<HTMLElement>) => {
+    const imageFiles = getImageFilesFromDataTransfer(e.dataTransfer);
+    if (!imageFiles.length) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDraggingImages(false);
+    await handleImageUploads(imageFiles);
   };
+
+  const postPath = useMemo(
+    () => (/^[0-9]{4}$/.test(year) && slug.trim() ? `${year}/${slug.trim()}` : ""),
+    [year, slug],
+  );
 
   const previewContent = useMemo(() => {
     const lines: string[] = [];
@@ -195,6 +270,12 @@ export default function NewPost() {
     if (lines.length) lines.push("");
     return [lines.join("\n"), content].filter(Boolean).join("\n");
   }, [title, coverImage, tags, category, published, content]);
+
+  const editorStats = useMemo(() => {
+    const words = content.trim() ? content.trim().split(/\s+/).length : 0;
+    const images = (content.match(/!\[[^\]]*]\([^)]+\)/g) || []).length;
+    return { words, images, characters: content.length };
+  }, [content]);
 
   return (
     <div className="container mx-auto px-0 md:px-4 py-4 md:py-8 h-[calc(100vh-80px)] max-w-[1400px]">
@@ -211,6 +292,7 @@ export default function NewPost() {
                   <div className="flex items-center gap-3">
                     <span className="text-sm text-green-600">로그인됨</span>
                     <Button variant="secondary" onClick={logout}>
+                      <LogOut className="h-4 w-4" aria-hidden="true" />
                       로그아웃
                     </Button>
                   </div>
@@ -223,7 +305,7 @@ export default function NewPost() {
                       <Input
                         id="title"
                         value={title}
-                        onChange={(e) => setTitle(e.target.value)}
+                        onChange={(e) => handleTitleChange(e.target.value)}
                         placeholder="글 제목"
                       />
                     </div>
@@ -232,7 +314,7 @@ export default function NewPost() {
                       <Input
                         id="slug"
                         value={slug}
-                        onChange={(e) => setSlug(e.target.value)}
+                        onChange={(e) => handleSlugChange(e.target.value)}
                         placeholder="my-new-post"
                       />
                     </div>
@@ -297,23 +379,68 @@ export default function NewPost() {
                   />
 
                   <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-                    <div>
-                      <Label htmlFor="content">내용 (Markdown) - 이미지 복사/붙여넣기 지원</Label>
+                    <div
+                      onDragEnter={(event) => {
+                        if (getImageFilesFromDataTransfer(event.dataTransfer).length) {
+                          setIsDraggingImages(true);
+                        }
+                      }}
+                      onDragOver={(event) => {
+                        if (getImageFilesFromDataTransfer(event.dataTransfer).length) {
+                          event.preventDefault();
+                          setIsDraggingImages(true);
+                        }
+                      }}
+                      onDragLeave={(event) => {
+                        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+                          setIsDraggingImages(false);
+                        }
+                      }}
+                      onDrop={(event) => void handleEditorDrop(event)}
+                      className="space-y-2"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <Label htmlFor="content">내용 (Markdown)</Label>
+                        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                          <span className="font-mono">{editorStats.words}w</span>
+                          <span className="font-mono">{editorStats.images}img</span>
+                          {uploading && (
+                            <span className="inline-flex items-center gap-1 text-primary">
+                              <UploadCloud className="h-3 w-3 animate-pulse motion-reduce:animate-none" aria-hidden="true" />
+                              upload
+                            </span>
+                          )}
+                        </div>
+                      </div>
                       <Textarea
                         id="content"
+                        ref={textareaRef}
                         value={content}
                         onChange={(e) => setContent(e.target.value)}
                         onPaste={handlePaste}
-                        onDrop={handleDrop}
-                        onDragOver={(e) => e.preventDefault()}
-                        className="min-h-[460px] font-mono"
-                        placeholder="# 새 글 시작...&#10;클립보드 이미지를 여기에 바로 붙여넣거나(Drag & Drop) 드래그하세요."
+                        onDrop={(event) => void handleEditorDrop(event)}
+                        onDragOver={(event) => {
+                          if (getImageFilesFromDataTransfer(event.dataTransfer).length) {
+                            event.preventDefault();
+                          }
+                        }}
+                        className={cn(
+                          "min-h-[460px] font-mono transition-colors",
+                          isDraggingImages &&
+                            "border-primary bg-primary/5 ring-2 ring-primary/20",
+                        )}
+                        placeholder="# 새 글 시작..."
                       />
                     </div>
-                    <div>
-                      <Label>미리보기</Label>
-                      <div className="border rounded-md p-4 min-h-[460px] bg-background">
-                        <MarkdownRenderer content={previewContent} />
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between gap-3">
+                        <Label>미리보기</Label>
+                        <span className="rounded-md border bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                          live
+                        </span>
+                      </div>
+                      <div className="border rounded-md p-4 min-h-[460px] bg-background overflow-auto">
+                        <MarkdownRenderer content={previewContent} postPath={postPath} />
                       </div>
                     </div>
                   </div>
@@ -330,6 +457,7 @@ export default function NewPost() {
                         />
                       </div>
                       <Button onClick={doUpload} disabled={uploading} variant="secondary">
+                        <UploadCloud className="h-4 w-4" aria-hidden="true" />
                         {uploading ? "업로드 중…" : "수동 이미지 업로드"}
                       </Button>
                     </div>
@@ -348,6 +476,7 @@ export default function NewPost() {
                             void handleImageUploads(failedUploadAttempt.files);
                           }}
                         >
+                          <RotateCcw className="h-4 w-4" aria-hidden="true" />
                           실패한 업로드 다시 시도
                         </Button>
                       </div>
@@ -382,6 +511,7 @@ export default function NewPost() {
                                   )
                                 }
                               >
+                                <Copy className="h-3 w-3" aria-hidden="true" />
                                 복사
                               </Button>
                             </li>
@@ -398,6 +528,7 @@ export default function NewPost() {
                       onClick={() => createPr.mutate()}
                       disabled={createPr.isPending}
                     >
+                      <FilePlus2 className="h-4 w-4" aria-hidden="true" />
                       {createPr.isPending ? "PR 생성 중…" : "PR 생성 및 배포하기"}
                     </Button>
                   </div>

--- a/frontend/src/test/NewPost.test.tsx
+++ b/frontend/src/test/NewPost.test.tsx
@@ -1,0 +1,173 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CreatePostPayload } from '@/services/session/admin';
+
+const mockCreatePostPR = vi.fn();
+const mockUploadPostImages = vi.fn();
+const mockToast = vi.fn();
+const mockLogout = vi.fn();
+const mockGetValidAccessToken = vi.fn();
+
+vi.mock('@/services/session/admin', () => ({
+  createPostPR: (...args: unknown[]) => mockCreatePostPR(...args),
+  uploadPostImages: (...args: unknown[]) => mockUploadPostImages(...args),
+}));
+
+vi.mock('@/stores/session/useAuthStore', () => ({
+  useAuthStore: () => ({
+    logout: mockLogout,
+    getValidAccessToken: mockGetValidAccessToken,
+  }),
+}));
+
+vi.mock('@/hooks/ui/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock('@/components/features/blog/MarkdownRenderer', () => ({
+  default: ({ content, postPath }: { content: string; postPath?: string }) => (
+    <div data-testid="markdown-preview">
+      <span data-testid="preview-post-path">{postPath}</span>
+      <pre>{content}</pre>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/features/admin/AiImageGeneratorPanel', () => ({
+  default: () => <div data-testid="ai-image-panel" />,
+}));
+
+vi.mock('@/components/features/admin/BotChatPanel', () => ({
+  default: () => <div data-testid="bot-chat-panel" />,
+}));
+
+import NewPost from '@/pages/admin/NewPost';
+
+function renderNewPost() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NewPost />
+    </QueryClientProvider>,
+  );
+}
+
+function imageDropEvent(file: File) {
+  return {
+    dataTransfer: {
+      items: [
+        {
+          kind: 'file',
+          type: file.type,
+          getAsFile: () => file,
+        },
+      ],
+      files: [file],
+    },
+  };
+}
+
+function changeField(label: string, value: string) {
+  fireEvent.change(screen.getByLabelText(label), {
+    target: { value },
+  });
+}
+
+describe('NewPost authoring workflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetValidAccessToken.mockResolvedValue('admin-access-token');
+    mockCreatePostPR.mockResolvedValue({
+      status: 'pending',
+      outboxId: 'outbox-1',
+      branch: 'post/2026-live-preview',
+      path: 'frontend/public/posts/2026/live-preview.md',
+    });
+    mockUploadPostImages.mockResolvedValue({
+      dir: '/images/2026/live-preview',
+      items: [
+        {
+          url: '/images/2026/live-preview/drop.png',
+          variantWebp: { url: '/images/2026/live-preview/drop.webp' },
+        },
+      ],
+    });
+
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    };
+  });
+
+  it('uploads dropped images and renders the inserted markdown immediately', async () => {
+    renderNewPost();
+
+    changeField('제목', 'Live Preview');
+    await waitFor(() => {
+      expect(screen.getByLabelText('슬러그')).toHaveValue('live-preview');
+    });
+    const editor = screen.getByLabelText('내용 (Markdown)');
+    fireEvent.change(editor, { target: { value: 'Intro paragraph' } });
+
+    const file = new File(['png'], 'drop.png', { type: 'image/png' });
+    fireEvent.drop(editor, imageDropEvent(file));
+
+    await waitFor(() => {
+      expect(mockUploadPostImages).toHaveBeenCalledWith(
+        { year: '2026', slug: 'live-preview' },
+        [file],
+        'admin-access-token',
+      );
+    });
+
+    await waitFor(() => {
+      expect((editor as HTMLTextAreaElement).value).toContain(
+        '![image](/images/2026/live-preview/drop.webp)',
+      );
+    });
+    expect((editor as HTMLTextAreaElement).value.match(/!\[image]/g)).toHaveLength(1);
+
+    expect(screen.getByTestId('preview-post-path')).toHaveTextContent(
+      '2026/live-preview',
+    );
+    expect(screen.getByTestId('markdown-preview')).toHaveTextContent(
+      '![image](/images/2026/live-preview/drop.webp)',
+    );
+  });
+
+  it('submits the current editor state to the create-post PR backend contract', async () => {
+    renderNewPost();
+
+    changeField('제목', 'Release Notes');
+    changeField('카테고리', 'Engineering');
+    changeField('태그 (쉼표로 구분)', 'react, admin');
+    changeField('내용 (Markdown)', '## Change\n\nDone.');
+    fireEvent.click(screen.getByRole('button', { name: /PR 생성 및 배포하기/ }));
+
+    await waitFor(() => {
+      expect(mockCreatePostPR).toHaveBeenCalledTimes(1);
+    });
+
+    const [payload, token] = mockCreatePostPR.mock.calls[0] as [
+      CreatePostPayload,
+      string,
+    ];
+    expect(token).toBe('admin-access-token');
+    expect(payload).toMatchObject({
+      title: 'Release Notes',
+      slug: 'release-notes',
+      year: '2026',
+      content: expect.stringContaining('## Change'),
+      frontmatter: {
+        category: 'Engineering',
+        tags: ['react', 'admin'],
+        published: true,
+      },
+    });
+  });
+});

--- a/frontend/src/test/chatUploadAuth.test.ts
+++ b/frontend/src/test/chatUploadAuth.test.ts
@@ -11,10 +11,20 @@ vi.mock('@/services/session/userContentAuth', () => ({
 describe('chat upload authentication', () => {
   beforeEach(() => {
     localStorage.clear();
+    (window as Window & {
+      APP_CONFIG?: { apiBaseUrl?: string; chatBaseUrl?: string };
+      __APP_CONFIG?: { apiBaseUrl?: string; chatBaseUrl?: string };
+    }).APP_CONFIG = {
+      apiBaseUrl: 'https://api.example.com',
+      chatBaseUrl: 'https://api.example.com',
+    };
+    delete (window as Window & { __APP_CONFIG?: unknown }).__APP_CONFIG;
   });
 
   afterEach(() => {
     localStorage.clear();
+    delete (window as Window & { APP_CONFIG?: unknown }).APP_CONFIG;
+    delete (window as Window & { __APP_CONFIG?: unknown }).__APP_CONFIG;
     vi.restoreAllMocks();
   });
 

--- a/frontend/src/test/runtimeConfig.test.ts
+++ b/frontend/src/test/runtimeConfig.test.ts
@@ -100,6 +100,7 @@ describe('runtime config preload', () => {
       value: { hostname: 'noblog.nodove.com' },
     });
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.nodove.com');
+    vi.stubEnv('VITE_CHAT_BASE_URL', '');
 
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(

--- a/frontend/src/test/runtimeConfig.test.ts
+++ b/frontend/src/test/runtimeConfig.test.ts
@@ -6,11 +6,17 @@ import {
 } from '@/lib/runtime/preloadRuntimeConfig';
 
 describe('runtime config preload', () => {
+  const originalLocation = window.location;
+
   beforeEach(() => {
     delete (window as Window & { APP_CONFIG?: unknown }).APP_CONFIG;
   });
 
   afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
     delete (window as Window & { APP_CONFIG?: unknown }).APP_CONFIG;
@@ -86,5 +92,35 @@ describe('runtime config preload', () => {
         commentsEnabled: true,
       },
     });
+  });
+
+  it('does not let a stale local runtime API base override production build config', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { hostname: 'noblog.nodove.com' },
+    });
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.nodove.com');
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          apiBaseUrl: 'http://localhost:5080',
+          chatBaseUrl: 'http://127.0.0.1:5080',
+          terminalGatewayUrl: 'wss://terminal.example.com',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    await preloadRuntimeConfig(fetchMock);
+
+    expect((window as Window & { APP_CONFIG?: Record<string, unknown> }).APP_CONFIG).toMatchObject({
+      apiBaseUrl: 'https://api.nodove.com',
+      terminalGatewayUrl: 'wss://terminal.example.com',
+    });
+    expect(
+      (window as Window & { APP_CONFIG?: Record<string, unknown> }).APP_CONFIG
+        ?.chatBaseUrl
+    ).toBeUndefined();
   });
 });

--- a/frontend/src/test/runtimeConfigGenerator.test.ts
+++ b/frontend/src/test/runtimeConfigGenerator.test.ts
@@ -41,4 +41,17 @@ describe("runtime config generator", () => {
     expect(runtimeConfig.terminalGatewayUrl).toBeNull();
     expect(runtimeConfig.capabilities.hasTerminalGatewayUrl).toBe(false);
   });
+
+  it("uses the public API gateway for production artifacts when no explicit API base is set", () => {
+    const runtimeConfig = buildRuntimeConfigFromEnv(
+      {
+        CI: "true",
+        APP_ENV: "production",
+      },
+      { siteBaseUrl: "https://noblog.nodove.com" }
+    );
+
+    expect(runtimeConfig.apiBaseUrl).toBe("https://api.nodove.com");
+    expect(runtimeConfig.chatBaseUrl).toBe("https://api.nodove.com");
+  });
 });

--- a/workers/api-gateway/src/routes/agent.ts
+++ b/workers/api-gateway/src/routes/agent.ts
@@ -1,0 +1,24 @@
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import type { HonoEnv } from '../types';
+import { requireAdmin } from '../middleware/auth';
+import { proxyToBackendWithPolicy } from '../lib/backend-proxy';
+
+const agent = new Hono<HonoEnv>();
+
+async function proxyAgentRequest(c: Context<HonoEnv>) {
+  const pathname = new URL(c.req.url).pathname;
+  return proxyToBackendWithPolicy(c, {
+    upstreamPath: pathname,
+    stream: pathname.endsWith('/stream'),
+    forceAiModels: true,
+    sanitizeClientModel: true,
+    backendUnavailableMessage: 'Could not connect to agent backend',
+  });
+}
+
+agent.use('*', requireAdmin);
+agent.all('/', proxyAgentRequest);
+agent.all('/*', proxyAgentRequest);
+
+export default agent;

--- a/workers/api-gateway/src/routes/registry.ts
+++ b/workers/api-gateway/src/routes/registry.ts
@@ -11,6 +11,7 @@ import {
 import auth from './auth';
 import comments from './comments';
 import ai from './ai';
+import agent from './agent';
 import chat from './chat';
 import images from './images';
 import og from './og';
@@ -46,6 +47,7 @@ export const WORKER_ROUTE_REGISTRY: WorkerRouteRegistryEntry[] = [
   { boundaryId: 'auth', path: '/auth', router: auth },
   { boundaryId: 'comments', path: '/comments', router: comments },
   { boundaryId: 'ai', path: '/ai', router: ai },
+  { boundaryId: 'agent', path: '/agent', router: agent },
   { boundaryId: 'chat', path: '/chat', router: chat },
   { boundaryId: 'images', path: '/images', router: images },
   { boundaryId: 'og', path: '/og', router: og },

--- a/workers/api-gateway/test/proxy-host-header.test.ts
+++ b/workers/api-gateway/test/proxy-host-header.test.ts
@@ -1,5 +1,5 @@
 import { env, SELF } from 'cloudflare:test';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Env } from '../src/types';
 import { signJwt } from '../src/lib/jwt';
@@ -8,6 +8,11 @@ declare module 'cloudflare:test' {
   interface ProvidedEnv extends Pick<Env, 'BACKEND_ORIGIN' | 'BACKEND_KEY' | 'JWT_SECRET'> {}
 }
 
+beforeEach(() => {
+  env.BACKEND_ORIGIN = 'https://backend.example';
+  env.BACKEND_KEY = 'comments-backend-key';
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
   env.BACKEND_ORIGIN = 'https://backend.example';
@@ -15,7 +20,7 @@ afterEach(() => {
 });
 
 describe('generic backend proxy', () => {
-  it('does not expose agent or execute paths through the public backend proxy', async () => {
+  it('guards agent proxy at the edge and keeps execute blocked', async () => {
     const upstreamFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(null, {
         status: 204,
@@ -29,9 +34,46 @@ describe('generic backend proxy', () => {
       method: 'POST',
     });
 
-    expect(agentResponse.status).toBe(404);
+    expect(agentResponse.status).toBe(401);
     expect(executeResponse.status).toBe(404);
     expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it('proxies admin-authenticated agent requests to the backend', async () => {
+    const upstreamFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, {
+        status: 200,
+      })
+    );
+    const token = await signJwt(
+      {
+        sub: 'admin-1',
+        role: 'admin',
+        username: 'admin',
+        email: 'admin@example.com',
+        emailVerified: true,
+        type: 'access',
+      },
+      env as Env
+    );
+
+    const response = await SELF.fetch('https://example.com/api/v1/agent/run', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message: 'Draft intro', sessionId: 'post-1' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+    const [upstreamUrl, requestInit] = upstreamFetch.mock.calls[0] ?? [];
+    const forwardedHeaders = new Headers(requestInit?.headers);
+
+    expect(upstreamUrl).toBe('https://backend.example/api/v1/agent/run');
+    expect(forwardedHeaders.get('X-Backend-Key')).toBe('comments-backend-key');
+    expect(forwardedHeaders.get('Authorization')).toBe(`Bearer ${token}`);
   });
 
   it('does not overwrite Host while forwarding backend-owned paths', async () => {


### PR DESCRIPTION
## Summary
- Restore production admin config/backend connectivity by defaulting production runtime config to https://api.nodove.com and ignoring stale localhost runtime config on non-local hosts.
- Improve admin post authoring with title slugging, image paste/drop upload insertion, editor stats, and backend-connected markdown preview paths.
- Add API Gateway /api/v1/agent routing with admin auth and backend AI model policy forwarding.

## Verification
- npm --prefix workers/api-gateway run typecheck
- npm --prefix workers/api-gateway run test -- proxy-host-header.test.ts
- npm --prefix frontend run test:run
- npm --prefix frontend run type-check
- npm --prefix frontend run lint
- npm --prefix frontend run build:dev
- GitHub Pages workflow_dispatch succeeded: https://github.com/choisimo/blog/actions/runs/26559690247
- Live API checks: /api/v1/healthz => 200, /api/v1/admin/config/categories => 401, /api/v1/agent/health => 401, /api/v1/public/config => 200 with apiBaseUrl https://api.nodove.com.

## Notes
- Deployed API Gateway directly to production Worker version 1057af01-428a-42c9-b424-8718e1222acc.
- Live authenticated admin smoke was not run because this environment has no admin session credentials.
- Existing unrelated local dirty files were left untouched.