### PR TITLE
fix(admin): improve dashboard tab navigation

### DIFF
--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, type KeyboardEvent, type ReactNode } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import {
   Settings,
@@ -38,7 +38,7 @@ type NavTab =
 const NAV_TABS: {
   id: NavTab;
   label: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   group?: 'infra' | 'ops' | 'config';
 }[] = [
   {
@@ -115,9 +115,61 @@ export function AdminDashboard({ userEmail, onLogout }: AdminDashboardProps) {
   }
 
   const activeTab = section;
+  const activeTabIndex = NAV_TABS.findIndex(tab => tab.id === activeTab);
 
   const setActiveTab = (tab: NavTab) => {
     navigate(`/admin/config/${tab}`, { replace: false });
+  };
+
+  const focusNavTab = (index: number) => {
+    const focus = () => {
+      const buttons = document.querySelectorAll<HTMLButtonElement>(
+        '[data-admin-nav-tab]',
+      );
+      buttons[index]?.focus();
+    };
+
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(focus);
+      return;
+    }
+
+    window.setTimeout(focus, 0);
+  };
+
+  const activateNavTabAt = (index: number) => {
+    const tab = NAV_TABS[index];
+    if (!tab) return;
+    setActiveTab(tab.id);
+    focusNavTab(index);
+  };
+
+  const handleNavKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      activateNavTabAt((index + 1) % NAV_TABS.length);
+      return;
+    }
+
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      activateNavTabAt((index - 1 + NAV_TABS.length) % NAV_TABS.length);
+      return;
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      activateNavTabAt(0);
+      return;
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      activateNavTabAt(NAV_TABS.length - 1);
+    }
   };
 
   return (
@@ -144,13 +196,21 @@ export function AdminDashboard({ userEmail, onLogout }: AdminDashboardProps) {
             <nav
               className='flex items-center gap-0.5 overflow-x-auto scrollbar-hide'
               aria-label='Admin navigation'
+              role='tablist'
             >
-              {NAV_TABS.map(tab => (
+              {NAV_TABS.map((tab, index) => (
                 <button
                   key={tab.id}
+                  id={`admin-tab-${tab.id}`}
+                  data-admin-nav-tab
                   type='button'
+                  role='tab'
                   onClick={() => setActiveTab(tab.id)}
-                  aria-current={activeTab === tab.id ? 'page' : undefined}
+                  onKeyDown={event => handleNavKeyDown(event, index)}
+                  aria-controls={`admin-panel-${tab.id}`}
+                  aria-label={tab.label}
+                  aria-selected={activeTab === tab.id}
+                  tabIndex={index === activeTabIndex ? 0 : -1}
                   className={`
                     admin-nav-btn
                     relative flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md
@@ -204,7 +264,12 @@ export function AdminDashboard({ userEmail, onLogout }: AdminDashboardProps) {
       {/* ── Main Content ── */}
       <main className='p-3 md:p-4 max-w-screen-2xl mx-auto'>
         {/* Tab content with fade-in on switch */}
-        <div className='admin-tab-content'>
+        <div
+          id={`admin-panel-${activeTab}`}
+          className='admin-tab-content'
+          role='tabpanel'
+          aria-labelledby={`admin-tab-${activeTab}`}
+        >
           <Suspense fallback={<div className='flex items-center justify-center py-12'><div className='h-5 w-5 border-2 border-zinc-300 border-t-zinc-600 rounded-full animate-spin' /></div>}>
           {activeTab === 'health' && <SystemHealth />}
           {activeTab === 'rag' && <RAGManager />}

--- a/frontend/src/test/AdminDashboard.nav.test.tsx
+++ b/frontend/src/test/AdminDashboard.nav.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import { AdminDashboard } from '@/pages/admin/AdminDashboard';
+
+vi.mock('@/components/features/admin/ConfigManager', () => ({
+  ConfigManager: () => <div>Env panel</div>,
+}));
+
+vi.mock('@/components/features/admin/WorkersManager', () => ({
+  WorkersManager: () => <div>Workers panel</div>,
+}));
+
+vi.mock('@/components/features/admin/ai', () => ({
+  AIManager: () => <div>AI panel</div>,
+}));
+
+vi.mock('@/components/features/admin/secrets', () => ({
+  SecretsManager: () => <div>Secrets panel</div>,
+}));
+
+vi.mock('@/components/features/admin/rag', () => ({
+  RAGManager: () => <div>RAG panel</div>,
+}));
+
+vi.mock('@/components/features/admin/health', () => ({
+  SystemHealth: () => <div>Health panel</div>,
+}));
+
+vi.mock('@/components/features/admin/analytics', () => ({
+  AnalyticsManager: () => <div>Analytics panel</div>,
+}));
+
+vi.mock('@/components/features/admin/logs', () => ({
+  LogViewer: () => <div>Logs panel</div>,
+}));
+
+vi.mock('@/components/features/admin/content', () => ({
+  ContentManager: () => <div>Content panel</div>,
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+  return <span data-testid="path">{location.pathname}</span>;
+}
+
+function renderDashboard(initialPath = '/admin/config/health') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="/admin/config/:section"
+          element={
+            <>
+              <LocationProbe />
+              <AdminDashboard
+                userEmail="admin@example.com"
+                onLogout={() => {}}
+              />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminDashboard navigation', () => {
+  it('exposes top-level admin sections as tabs', async () => {
+    renderDashboard();
+    await screen.findByText('Health panel');
+
+    expect(
+      screen.getByRole('tablist', { name: 'Admin navigation' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Health' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tab', { name: 'RAG' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+    expect(screen.getByRole('tabpanel')).toHaveAttribute(
+      'aria-labelledby',
+      'admin-tab-health',
+    );
+  });
+
+  it('moves between admin sections with keyboard navigation', async () => {
+    renderDashboard();
+    await screen.findByText('Health panel');
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Health' }), {
+      key: 'ArrowRight',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('path')).toHaveTextContent('/admin/config/rag');
+    });
+    expect(screen.getByRole('tab', { name: 'RAG' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await screen.findByText('RAG panel');
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'RAG' }), {
+      key: 'End',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('path')).toHaveTextContent(
+        '/admin/config/workers',
+      );
+    });
+    expect(screen.getByRole('tab', { name: 'Workers' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await screen.findByText('Workers panel');
+  });
+});


### PR DESCRIPTION
## Summary
- Make the top-level React admin navigation expose real tablist/tab/tabpanel semantics.
- Add mobile-safe accessible labels for icon-only admin section buttons.
- Add Arrow/Home/End keyboard navigation between admin sections.
- Add focused AdminDashboard navigation tests.

## Verification
- git diff --check
- cd frontend && npm run test:run -- AdminDashboard.nav.test.tsx
- cd frontend && npm run type-check -- --pretty false

## WebLatch
- Submitted latest admin source archive via CS WebLatch as job 57 after starting the local bridge.
- ChatGPT returned Rate Limit after repeated prompt-submit/completion-wait attempts, so no model response was captured for this iteration.
