### PR TITLE
fix(admin): refresh token on API 401 retry

### DIFF
--- a/frontend/src/services/admin/apiClient.ts
+++ b/frontend/src/services/admin/apiClient.ts
@@ -1,6 +1,7 @@
 import { useAuthStore } from '@/stores/session/useAuthStore';
 import { getApiBaseUrl } from '@/utils/network/apiBase';
 import { bearerAuth } from '@/lib/auth';
+import { refreshAccessToken } from '@/services/session/auth';
 
 interface AdminApiResult<T> {
   ok: boolean;
@@ -13,11 +14,56 @@ interface AdminApiFetchOptions extends Omit<RequestInit, 'body'> {
   pathPrefix?: string;
 }
 
+function buildAdminHeaders(
+  token: string | null,
+  headers?: HeadersInit,
+): Headers {
+  const nextHeaders = new Headers(headers);
+  if (!nextHeaders.has('Content-Type')) {
+    nextHeaders.set('Content-Type', 'application/json');
+  }
+  if (token) {
+    nextHeaders.set('Authorization', bearerAuth(token).Authorization);
+  }
+  return nextHeaders;
+}
+
+async function forceRefreshAdminAccessToken(): Promise<string | null> {
+  const { refreshToken, clearAuth } = useAuthStore.getState();
+  if (!refreshToken) {
+    clearAuth();
+    return null;
+  }
+
+  try {
+    const result = await refreshAccessToken(refreshToken);
+    useAuthStore
+      .getState()
+      .setTokens(result.accessToken, result.refreshToken);
+    return result.accessToken;
+  } catch {
+    clearAuth();
+    return null;
+  }
+}
+
+function buildAdminRequestInit(
+  options: RequestInit,
+  token: string | null,
+  body?: unknown,
+): RequestInit {
+  return {
+    ...options,
+    headers: buildAdminHeaders(token, options.headers),
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  };
+}
+
 export async function adminApiFetch<T>(
   endpoint: string,
   options: AdminApiFetchOptions = {}
 ): Promise<AdminApiResult<T>> {
-  const { getValidAccessToken, clearAuth } = useAuthStore.getState();
+  const { getValidAccessToken } = useAuthStore.getState();
   const API_BASE = getApiBaseUrl();
   const { body, pathPrefix = '', ...fetchOptions } = options;
 
@@ -28,35 +74,15 @@ export async function adminApiFetch<T>(
     }
 
     const url = `${API_BASE}${pathPrefix}${endpoint}`;
-    const init: RequestInit = {
-      ...fetchOptions,
-      headers: {
-        'Content-Type': 'application/json',
-        ...bearerAuth(token),
-        ...((fetchOptions.headers as Record<string, string>) || {}),
-      },
-      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-    };
-
-    let res = await fetch(url, init);
+    let res = await fetch(url, buildAdminRequestInit(fetchOptions, token, body));
 
     if (res.status === 401) {
-      const newToken = await getValidAccessToken();
+      const newToken = await forceRefreshAdminAccessToken();
       if (!newToken) {
-        clearAuth();
         return { ok: false, error: 'Session expired. Please log in again.' };
       }
 
-      const retryInit: RequestInit = {
-        ...fetchOptions,
-        headers: {
-          'Content-Type': 'application/json',
-          ...bearerAuth(newToken),
-          ...((fetchOptions.headers as Record<string, string>) || {}),
-        },
-        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-      };
-      res = await fetch(url, retryInit);
+      res = await fetch(url, buildAdminRequestInit(fetchOptions, newToken, body));
     }
 
     const json = await res.json().catch(() => ({}));
@@ -84,12 +110,14 @@ export async function adminFetchRaw(
   const { getValidAccessToken } = useAuthStore.getState();
   const token = await getValidAccessToken();
 
-  return fetch(url, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? bearerAuth(token) : {}),
-      ...((options.headers as Record<string, string>) || {}),
-    },
-  });
+  let res = await fetch(url, buildAdminRequestInit(options, token));
+
+  if (res.status === 401) {
+    const newToken = await forceRefreshAdminAccessToken();
+    if (newToken) {
+      res = await fetch(url, buildAdminRequestInit(options, newToken));
+    }
+  }
+
+  return res;
 }

--- a/frontend/src/test/adminApiClient.test.ts
+++ b/frontend/src/test/adminApiClient.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRefreshAccessToken, mockState } = vi.hoisted(() => ({
+  mockRefreshAccessToken: vi.fn(),
+  mockState: {
+    refreshToken: 'refresh-token',
+    getValidAccessToken: vi.fn(),
+    setTokens: vi.fn(),
+    clearAuth: vi.fn(),
+  },
+}));
+
+vi.mock('@/stores/session/useAuthStore', () => ({
+  useAuthStore: {
+    getState: () => mockState,
+  },
+}));
+
+vi.mock('@/utils/network/apiBase', () => ({
+  getApiBaseUrl: () => 'https://api.example.com',
+}));
+
+vi.mock('@/services/session/auth', () => ({
+  refreshAccessToken: mockRefreshAccessToken,
+}));
+
+import { adminApiFetch, adminFetchRaw } from '@/services/admin/apiClient';
+
+function authorizationHeader(fetchMock: ReturnType<typeof vi.fn>, index: number) {
+  const [, init] = fetchMock.mock.calls[index];
+  return new Headers(init?.headers).get('Authorization');
+}
+
+describe('admin API client auth retry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.refreshToken = 'refresh-token';
+    mockState.getValidAccessToken.mockResolvedValue('old-access-token');
+    mockRefreshAccessToken.mockResolvedValue({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      tokenType: 'Bearer',
+      expiresIn: 900,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('forces token refresh before retrying adminApiFetch after a 401', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{}', { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { saved: true } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adminApiFetch<{ saved: boolean }>('/secrets', {
+      pathPrefix: '/api/v1/admin',
+      method: 'POST',
+      body: { key: 'OPENAI_API_KEY' },
+    });
+
+    expect(result).toEqual({ ok: true, data: { saved: true } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(authorizationHeader(fetchMock, 0)).toBe('Bearer old-access-token');
+    expect(authorizationHeader(fetchMock, 1)).toBe('Bearer new-access-token');
+    expect(mockRefreshAccessToken).toHaveBeenCalledWith('refresh-token');
+    expect(mockState.setTokens).toHaveBeenCalledWith(
+      'new-access-token',
+      'new-refresh-token',
+    );
+    expect(mockState.clearAuth).not.toHaveBeenCalled();
+  });
+
+  it('retries adminFetchRaw with a refreshed token after a 401', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{}', { status: 401 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await adminFetchRaw(
+      'https://api.example.com/api/v1/admin/config/current',
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(authorizationHeader(fetchMock, 0)).toBe('Bearer old-access-token');
+    expect(authorizationHeader(fetchMock, 1)).toBe('Bearer new-access-token');
+    expect(mockRefreshAccessToken).toHaveBeenCalledWith('refresh-token');
+  });
+});


### PR DESCRIPTION
## Summary
- Force-refresh the admin access token after backend 401 responses before retrying API calls.
- Apply the retry behavior to both structured adminApiFetch and raw adminFetchRaw callers.
- Preserve auth clearing behavior when refresh is unavailable or fails.
- Add focused tests for retrying with the refreshed token.

## Verification
- git diff --check
- cd frontend && npm run test:run -- adminApiClient.test.ts
- cd frontend && npm run type-check -- --pretty false

## WebLatch
- Iteration 3 deferred an immediate ChatGPT resubmission because Iteration 2 job 57 had just failed with ChatGPT Rate Limit after repeated prompt-submit/completion-wait attempts.
