### PR TITLE
fix(admin): retry Flutter API after token refresh

### DIFF
--- a/admin_flutter_app/lib/core/api_client.dart
+++ b/admin_flutter_app/lib/core/api_client.dart
@@ -17,9 +17,11 @@ class PickedUpload {
 }
 
 class AdminApiClient {
-  AdminApiClient(this.auth);
+  AdminApiClient(this.auth, {http.Client? client})
+      : _client = client ?? http.Client();
 
   final AuthStore auth;
+  final http.Client _client;
 
   Future<Map<String, dynamic>> get(
     String path, {
@@ -80,14 +82,31 @@ class AdminApiClient {
     }
     final uri = auth.uri(path, query);
     final encoded = body == null ? null : jsonEncode(body);
-    final response = await switch (method) {
-      'GET' => http.get(uri, headers: requestHeaders),
-      'POST' => http.post(uri, headers: requestHeaders, body: encoded),
-      'PUT' => http.put(uri, headers: requestHeaders, body: encoded),
-      'DELETE' => http.delete(uri, headers: requestHeaders, body: encoded),
+    var response = await _send(method, uri, requestHeaders, encoded);
+    if (authRequired && response.statusCode == 401) {
+      final token = await auth.refreshAccessTokenNow();
+      if (token == null) {
+        throw Exception('Session expired. Please log in again.');
+      }
+      requestHeaders['Authorization'] = 'Bearer $token';
+      response = await _send(method, uri, requestHeaders, encoded);
+    }
+    return _decode(response);
+  }
+
+  Future<http.Response> _send(
+    String method,
+    Uri uri,
+    Map<String, String> headers,
+    String? body,
+  ) {
+    return switch (method) {
+      'GET' => _client.get(uri, headers: headers),
+      'POST' => _client.post(uri, headers: headers, body: body),
+      'PUT' => _client.put(uri, headers: headers, body: body),
+      'DELETE' => _client.delete(uri, headers: headers, body: body),
       _ => throw UnsupportedError(method),
     };
-    return _decode(response);
   }
 
   Future<Map<String, dynamic>> multipart(
@@ -100,6 +119,28 @@ class AdminApiClient {
     if (token == null) {
       throw Exception('Not authenticated. Please log in again.');
     }
+    var response = await http.Response.fromStream(
+      await _sendMultipart(path, token, fields, files, fileField),
+    );
+    if (response.statusCode == 401) {
+      final refreshed = await auth.refreshAccessTokenNow();
+      if (refreshed == null) {
+        throw Exception('Session expired. Please log in again.');
+      }
+      response = await http.Response.fromStream(
+        await _sendMultipart(path, refreshed, fields, files, fileField),
+      );
+    }
+    return _decode(response);
+  }
+
+  Future<http.StreamedResponse> _sendMultipart(
+    String path,
+    String token,
+    Map<String, String> fields,
+    List<PickedUpload> files,
+    String fileField,
+  ) {
     final request = http.MultipartRequest('POST', auth.uri(path));
     request.headers['Authorization'] = 'Bearer $token';
     request.fields.addAll(fields);
@@ -113,9 +154,7 @@ class AdminApiClient {
             : MediaType.parse(file.contentType!),
       ));
     }
-    final streamed = await request.send();
-    final response = await http.Response.fromStream(streamed);
-    return _decode(response);
+    return _client.send(request);
   }
 
   Stream<String> streamLines(String path,
@@ -124,22 +163,33 @@ class AdminApiClient {
     if (token == null) {
       throw Exception('Not authenticated. Please log in again.');
     }
-    final client = http.Client();
+    var response = await _sendStreamRequest(path, query, token);
+    if (response.statusCode == 401) {
+      await response.stream.drain<void>();
+      final refreshed = await auth.refreshAccessTokenNow();
+      if (refreshed == null) {
+        throw Exception('Session expired. Please log in again.');
+      }
+      response = await _sendStreamRequest(path, query, refreshed);
+    }
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception('Stream failed (${response.statusCode})');
+    }
+    await for (final chunk in response.stream
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())) {
+      if (chunk.trim().isNotEmpty) yield chunk;
+    }
+  }
+
+  Future<http.StreamedResponse> _sendStreamRequest(
+    String path,
+    Map<String, String?> query,
+    String token,
+  ) {
     final request = http.Request('GET', auth.uri(path, query));
     request.headers['Authorization'] = 'Bearer $token';
-    try {
-      final response = await client.send(request);
-      if (response.statusCode < 200 || response.statusCode >= 300) {
-        throw Exception('Stream failed (${response.statusCode})');
-      }
-      await for (final chunk in response.stream
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())) {
-        if (chunk.trim().isNotEmpty) yield chunk;
-      }
-    } finally {
-      client.close();
-    }
+    return _client.send(request);
   }
 
   Map<String, dynamic> _decode(http.Response response) {

--- a/admin_flutter_app/lib/core/api_client.dart
+++ b/admin_flutter_app/lib/core/api_client.dart
@@ -173,6 +173,7 @@ class AdminApiClient {
       response = await _sendStreamRequest(path, query, refreshed);
     }
     if (response.statusCode < 200 || response.statusCode >= 300) {
+      await response.stream.drain<void>();
       throw Exception('Stream failed (${response.statusCode})');
     }
     await for (final chunk in response.stream

--- a/admin_flutter_app/lib/core/auth_store.dart
+++ b/admin_flutter_app/lib/core/auth_store.dart
@@ -8,6 +8,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'json_utils.dart';
 
 class AuthStore extends ChangeNotifier {
+  AuthStore({http.Client? client}) : _client = client ?? http.Client();
+
   static const _secureStorage = FlutterSecureStorage();
   static const defaultBaseUrl = String.fromEnvironment(
     'ADMIN_API_BASE_URL',
@@ -17,6 +19,8 @@ class AuthStore extends ChangeNotifier {
   static const _accessTokenKey = 'noblog.admin.accessToken';
   static const _refreshTokenKey = 'noblog.admin.refreshToken';
   static const _userKey = 'noblog.admin.user';
+
+  final http.Client _client;
 
   String baseUrl = defaultBaseUrl;
   String? accessToken;
@@ -133,7 +137,7 @@ class AuthStore extends ChangeNotifier {
   Future<void> logout() async {
     final token = refreshToken;
     try {
-      await http.post(
+      await _client.post(
         uri('/api/v1/auth/logout'),
         headers: const {'Content-Type': 'application/json'},
         body: jsonEncode({'refreshToken': token}),
@@ -165,6 +169,10 @@ class AuthStore extends ChangeNotifier {
     if (accessToken != null && !isTokenExpired(accessToken!)) {
       return accessToken;
     }
+    return refreshAccessTokenNow();
+  }
+
+  Future<String?> refreshAccessTokenNow() async {
     if (refreshToken == null ||
         isTokenExpired(refreshToken!, bufferSeconds: 0)) {
       await clearLocal();
@@ -172,7 +180,7 @@ class AuthStore extends ChangeNotifier {
     }
     final http.Response response;
     try {
-      response = await http.post(
+      response = await _client.post(
         uri('/api/v1/auth/refresh'),
         headers: const {'Content-Type': 'application/json'},
         body: jsonEncode({'refreshToken': refreshToken}),
@@ -215,12 +223,12 @@ class AuthStore extends ChangeNotifier {
   }
 
   Future<Map<String, dynamic>> getTotpStatus() async {
-    final response = await http.get(uri('/api/v1/auth/totp/status'));
+    final response = await _client.get(uri('/api/v1/auth/totp/status'));
     return _unwrap(response, 'Failed to load TOTP status');
   }
 
   Future<Map<String, dynamic>> getTotpSetup({String? setupToken}) async {
-    final response = await http.get(
+    final response = await _client.get(
       uri('/api/v1/auth/totp/setup'),
       headers: <String, String>{
         if (setupToken != null && setupToken.isNotEmpty)
@@ -232,7 +240,7 @@ class AuthStore extends ChangeNotifier {
 
   Future<Map<String, dynamic>> verifyTotpSetup(String code,
       {String? setupToken}) async {
-    final response = await http.post(
+    final response = await _client.post(
       uri('/api/v1/auth/totp/setup/verify'),
       headers: <String, String>{
         'Content-Type': 'application/json',
@@ -245,7 +253,7 @@ class AuthStore extends ChangeNotifier {
   }
 
   Future<String> createTotpChallenge() async {
-    final response = await http.post(
+    final response = await _client.post(
       uri('/api/v1/auth/totp/challenge'),
       headers: const {'Content-Type': 'application/json'},
     );
@@ -254,7 +262,7 @@ class AuthStore extends ChangeNotifier {
   }
 
   Future<void> verifyTotpCode(String challengeId, String code) async {
-    final response = await http.post(
+    final response = await _client.post(
       uri('/api/v1/auth/totp/verify'),
       headers: const {'Content-Type': 'application/json'},
       body: jsonEncode({'challengeId': challengeId, 'code': code}),
@@ -268,7 +276,7 @@ class AuthStore extends ChangeNotifier {
   }
 
   Future<void> consumeOAuthHandoff(String handoff) async {
-    final response = await http.post(
+    final response = await _client.post(
       uri('/api/v1/auth/oauth/handoff/consume'),
       headers: const {'Content-Type': 'application/json'},
       body: jsonEncode({'handoff': handoff}),
@@ -284,7 +292,7 @@ class AuthStore extends ChangeNotifier {
   Future<Map<String, dynamic>> getMe() async {
     final token = await getValidAccessToken();
     if (token == null) throw Exception('Not authenticated');
-    final response = await http.get(uri('/api/v1/auth/me'),
+    final response = await _client.get(uri('/api/v1/auth/me'),
         headers: {'Authorization': 'Bearer $token'});
     final data = await _unwrap(response, 'Failed to load user');
     return asMap(data['user']);

--- a/admin_flutter_app/test/widget_test.dart
+++ b/admin_flutter_app/test/widget_test.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -22,6 +24,38 @@ String _jwt(String subject) {
       })))
       .replaceAll('=', '');
   return '$header.$payload.smoke';
+}
+
+http.StreamedResponse _streamedResponse(
+  String body,
+  int statusCode, {
+  Map<String, String>? headers,
+}) {
+  return http.StreamedResponse(
+    Stream.value(utf8.encode(body)),
+    statusCode,
+    headers: headers ?? const {},
+  );
+}
+
+http.StreamedResponse _streamedJson(Object body, int statusCode) {
+  return _streamedResponse(
+    jsonEncode(body),
+    statusCode,
+    headers: const {'Content-Type': 'application/json'},
+  );
+}
+
+class _HandlerClient extends http.BaseClient {
+  _HandlerClient(this._handler);
+
+  final FutureOr<http.StreamedResponse> Function(http.BaseRequest request)
+      _handler;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    return _handler(request);
+  }
 }
 
 void main() {
@@ -147,6 +181,125 @@ void main() {
     ]);
     expect(auth.accessToken, _jwt('new-access'));
     expect(auth.refreshToken, _jwt('new-refresh'));
+  });
+
+  test('admin API multipart refreshes and retries once after 401', () async {
+    late final AuthStore auth;
+    final seenAuthorization = <String?>[];
+    var uploadRequestCount = 0;
+    final client = _HandlerClient((request) async {
+      await request.finalize().drain<void>();
+      if (request.url.path == '/api/v1/auth/refresh') {
+        return _streamedJson({
+          'ok': true,
+          'data': {
+            'accessToken': _jwt('new-access'),
+            'refreshToken': _jwt('new-refresh'),
+            'tokenType': 'Bearer',
+            'expiresIn': 900,
+          },
+        }, 200);
+      }
+
+      if (request.url.path == '/api/v1/admin/posts/images') {
+        uploadRequestCount += 1;
+        seenAuthorization.add(request.headers['Authorization']);
+        if (uploadRequestCount == 1) {
+          return _streamedResponse('{}', 401);
+        }
+        return _streamedJson({
+          'ok': true,
+          'data': {'url': '/images/uploaded.png'},
+        }, 200);
+      }
+
+      return _streamedResponse('not found', 404);
+    });
+    auth = AuthStore(client: client);
+    auth.baseUrl = 'https://api.example.com';
+    await auth.saveTokens(
+      accessToken: _jwt('old-access'),
+      refreshToken: _jwt('old-refresh'),
+      user: {'role': 'admin'},
+    );
+    final api = AdminApiClient(auth, client: client);
+
+    final result = await api.multipart(
+      '/api/v1/admin/posts/images',
+      fields: const {'postId': 'post-1'},
+      files: [
+        PickedUpload(
+          name: 'cover.png',
+          bytes: Uint8List.fromList(utf8.encode('image')),
+          contentType: 'image/png',
+        ),
+      ],
+    );
+
+    expect(result['url'], '/images/uploaded.png');
+    expect(uploadRequestCount, 2);
+    expect(seenAuthorization, [
+      'Bearer ${_jwt('old-access')}',
+      'Bearer ${_jwt('new-access')}',
+    ]);
+  });
+
+  test('admin API stream refreshes and retries once after 401', () async {
+    late final AuthStore auth;
+    final seenAuthorization = <String?>[];
+    var streamRequestCount = 0;
+    var unauthorizedStreamDrained = false;
+    final client = _HandlerClient((request) async {
+      await request.finalize().drain<void>();
+      if (request.url.path == '/api/v1/auth/refresh') {
+        return _streamedJson({
+          'ok': true,
+          'data': {
+            'accessToken': _jwt('new-access'),
+            'refreshToken': _jwt('new-refresh'),
+            'tokenType': 'Bearer',
+            'expiresIn': 900,
+          },
+        }, 200);
+      }
+
+      if (request.url.path == '/api/v1/admin/logs/stream') {
+        streamRequestCount += 1;
+        seenAuthorization.add(request.headers['Authorization']);
+        if (streamRequestCount == 1) {
+          return http.StreamedResponse(
+            Stream<List<int>>.fromIterable([utf8.encode('expired')]).map(
+              (chunk) {
+                unauthorizedStreamDrained = true;
+                return chunk;
+              },
+            ),
+            401,
+          );
+        }
+        return _streamedResponse('line one\n\nline two\n', 200);
+      }
+
+      return _streamedResponse('not found', 404);
+    });
+    auth = AuthStore(client: client);
+    auth.baseUrl = 'https://api.example.com';
+    await auth.saveTokens(
+      accessToken: _jwt('old-access'),
+      refreshToken: _jwt('old-refresh'),
+      user: {'role': 'admin'},
+    );
+    final api = AdminApiClient(auth, client: client);
+
+    final lines = await api.streamLines('/api/v1/admin/logs/stream').toList();
+
+    expect(lines, ['line one', 'line two']);
+    expect(streamRequestCount, 2);
+    expect(unauthorizedStreamDrained, isTrue);
+    expect(seenAuthorization, [
+      'Bearer ${_jwt('old-access')}',
+      'Bearer ${_jwt('new-access')}',
+    ]);
   });
 
   testWidgets('shows loading state before auth initialization', (tester) async {

--- a/admin_flutter_app/test/widget_test.dart
+++ b/admin_flutter_app/test/widget_test.dart
@@ -1,11 +1,28 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:noblog_admin_flutter/core/api_client.dart';
 import 'package:noblog_admin_flutter/core/auth_store.dart';
 import 'package:noblog_admin_flutter/main.dart';
+
+String _jwt(String subject) {
+  final header = base64Url
+      .encode(utf8.encode(jsonEncode({'alg': 'none', 'typ': 'JWT'})))
+      .replaceAll('=', '');
+  final payload = base64Url
+      .encode(utf8.encode(jsonEncode({
+        'sub': subject,
+        'exp': 4102444800,
+      })))
+      .replaceAll('=', '');
+  return '$header.$payload.smoke';
+}
 
 void main() {
   setUp(() {
@@ -70,6 +87,66 @@ void main() {
         'secure-access');
     expect(await secureStorage.read(key: 'noblog.admin.refreshToken'),
         'secure-refresh');
+  });
+
+  test('admin API client refreshes and retries once after 401', () async {
+    late final AuthStore auth;
+    final seenAuthorization = <String?>[];
+    var configRequestCount = 0;
+    final client = MockClient((request) async {
+      if (request.url.path == '/api/v1/auth/refresh') {
+        return http.Response(
+          jsonEncode({
+            'ok': true,
+            'data': {
+              'accessToken': _jwt('new-access'),
+              'refreshToken': _jwt('new-refresh'),
+              'tokenType': 'Bearer',
+              'expiresIn': 900,
+            },
+          }),
+          200,
+          headers: {'Content-Type': 'application/json'},
+        );
+      }
+
+      if (request.url.path == '/api/v1/admin/config/current') {
+        configRequestCount += 1;
+        seenAuthorization.add(request.headers['Authorization']);
+        if (configRequestCount == 1) {
+          return http.Response('{}', 401);
+        }
+        return http.Response(
+          jsonEncode({
+            'ok': true,
+            'data': {'saved': true},
+          }),
+          200,
+          headers: {'Content-Type': 'application/json'},
+        );
+      }
+
+      return http.Response('not found', 404);
+    });
+    auth = AuthStore(client: client);
+    auth.baseUrl = 'https://api.example.com';
+    await auth.saveTokens(
+      accessToken: _jwt('old-access'),
+      refreshToken: _jwt('old-refresh'),
+      user: {'role': 'admin'},
+    );
+    final api = AdminApiClient(auth, client: client);
+
+    final result = await api.get('/api/v1/admin/config/current');
+
+    expect(result['saved'], isTrue);
+    expect(configRequestCount, 2);
+    expect(seenAuthorization, [
+      'Bearer ${_jwt('old-access')}',
+      'Bearer ${_jwt('new-access')}',
+    ]);
+    expect(auth.accessToken, _jwt('new-access'));
+    expect(auth.refreshToken, _jwt('new-refresh'));
   });
 
   testWidgets('shows loading state before auth initialization', (tester) async {


### PR DESCRIPTION
## Summary
- Retry Flutter admin JSON requests once after a 401 by forcing a refresh-token exchange.
- Route AuthStore requests through an injectable HTTP client so refresh behavior is testable and consistent.
- Apply the same refresh retry to admin multipart uploads and log streaming.

## Verification
- git diff --check
- flutter test
- flutter analyze
- flutter test --no-pub
- flutter analyze --no-pub