### PR TITLE
fix(admin): harden worker mutation inputs

### DIFF
--- a/backend/src/routes/workers.js
+++ b/backend/src/routes/workers.js
@@ -65,7 +65,11 @@ function toTomlBasicStringValue(value) {
   if (!['string', 'number', 'boolean'].includes(typeof value)) {
     return null;
   }
-  return String(value)
+  const stringValue = String(value);
+  if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/.test(stringValue)) {
+    return null;
+  }
+  return stringValue
     .replace(/\\/g, '\\\\')
     .replace(/"/g, '\\"')
     .replace(/\n/g, '\\n')
@@ -113,7 +117,7 @@ function replaceWorkerVar(content, env, key, value) {
     if (!inTargetSection) return line;
 
     const assignment = line.match(
-      /^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"[^"]*"(.*)$/
+      /^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"(?:[^"\\]|\\.)*"(.*)$/
     );
     if (!assignment || assignment[2] !== key) return line;
 
@@ -234,8 +238,9 @@ router.post('/:workerId/vars', requireAdmin, requireWorkerMutationCapability, as
 
 router.post('/:workerId/secret', requireAdmin, requireWorkerMutationCapability, async (req, res) => {
   const { workerId } = req.params;
-  const { key, value } = req.body;
-  const env = normalizeWorkerMutationEnv(req.body?.env, 'production');
+  const body = req.body && typeof req.body === 'object' ? req.body : {};
+  const { key, value } = body;
+  const env = normalizeWorkerMutationEnv(body.env, 'production');
   if (!env) {
     return workerMutationBadRequest(
       res,

--- a/backend/src/routes/workers.js
+++ b/backend/src/routes/workers.js
@@ -10,6 +10,8 @@ const router = Router();
 
 const WORKERS_ROOT = config.paths?.workersDir || path.join(config.content.repoRoot, 'workers');
 const workerMutationsEnabled = process.env.ADMIN_WORKER_MUTATIONS === 'true';
+const WORKER_MUTATION_ENVS = new Set(['development', 'production']);
+const WORKER_VAR_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 
 const WORKERS_CONFIG = WORKER_DEPLOYMENTS.map((worker) => ({
@@ -41,6 +43,85 @@ function requireWorkerMutationCapability(req, res, next) {
     });
   }
   next();
+}
+
+function workerMutationBadRequest(res, code, message) {
+  return res.status(400).json({
+    ok: false,
+    error: { code, message },
+  });
+}
+
+function normalizeWorkerMutationEnv(rawEnv, fallback) {
+  const env = String(rawEnv || fallback).trim();
+  return WORKER_MUTATION_ENVS.has(env) ? env : null;
+}
+
+function isValidWorkerVarKey(key) {
+  return typeof key === 'string' && WORKER_VAR_KEY_PATTERN.test(key);
+}
+
+function toTomlBasicStringValue(value) {
+  if (!['string', 'number', 'boolean'].includes(typeof value)) {
+    return null;
+  }
+  return String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
+function normalizeWorkerVarUpdates(vars) {
+  if (!vars || typeof vars !== 'object' || Array.isArray(vars)) {
+    return { error: 'vars object required' };
+  }
+
+  const updates = [];
+  for (const [key, rawValue] of Object.entries(vars)) {
+    if (!isValidWorkerVarKey(key)) {
+      return { error: `Invalid variable key: ${key}` };
+    }
+    const value = toTomlBasicStringValue(rawValue);
+    if (value === null) {
+      return { error: `Invalid value for ${key}; expected string, number, or boolean` };
+    }
+    updates.push({ key, value });
+  }
+
+  if (updates.length === 0) {
+    return { error: 'vars must include at least one variable' };
+  }
+
+  return { updates };
+}
+
+function replaceWorkerVar(content, env, key, value) {
+  const targetSection = env === 'production' ? 'env.production.vars' : 'vars';
+  const lines = content.split(/\r?\n/);
+  let inTargetSection = false;
+  let updated = false;
+
+  const nextLines = lines.map((line) => {
+    const header = line.match(/^\s*\[([^\]]+)\]\s*$/);
+    if (header) {
+      inTargetSection = header[1] === targetSection;
+      return line;
+    }
+
+    if (!inTargetSection) return line;
+
+    const assignment = line.match(
+      /^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"[^"]*"(.*)$/
+    );
+    if (!assignment || assignment[2] !== key) return line;
+
+    updated = true;
+    return `${assignment[1]}${key} = "${value}"${assignment[3]}`;
+  });
+
+  return { content: nextLines.join('\n'), updated };
 }
 
 router.get('/list', requireAdmin, async (req, res) => {
@@ -106,7 +187,18 @@ router.get('/:workerId/config', requireAdmin, async (req, res) => {
 
 router.post('/:workerId/vars', requireAdmin, requireWorkerMutationCapability, async (req, res) => {
   const { workerId } = req.params;
-  const { vars, env = 'development' } = req.body;
+  const env = normalizeWorkerMutationEnv(req.body?.env, 'development');
+  if (!env) {
+    return workerMutationBadRequest(
+      res,
+      'INVALID_WORKER_ENV',
+      'env must be development or production'
+    );
+  }
+  const normalizedVars = normalizeWorkerVarUpdates(req.body?.vars);
+  if (normalizedVars.error) {
+    return workerMutationBadRequest(res, 'INVALID_WORKER_VARS', normalizedVars.error);
+  }
   const worker = WORKERS_CONFIG.find((w) => w.id === workerId);
 
   if (!worker) {
@@ -116,27 +208,25 @@ router.post('/:workerId/vars', requireAdmin, requireWorkerMutationCapability, as
   try {
     const wranglerPath = path.join(WORKERS_ROOT, worker.wranglerPath);
     let content = await fs.readFile(wranglerPath, 'utf8');
+    const updated = [];
 
-    for (const [key, value] of Object.entries(vars)) {
-      if (env === 'development') {
-        const regex = new RegExp(`^(\\[vars\\][\\s\\S]*?)${key}\\s*=\\s*"[^"]*"`, 'm');
-        if (regex.test(content)) {
-          content = content.replace(regex, `$1${key} = "${value}"`);
-        }
-      } else if (env === 'production') {
-        const regex = new RegExp(
-          `^(\\[env\\.production\\.vars\\][\\s\\S]*?)${key}\\s*=\\s*"[^"]*"`,
-          'm'
-        );
-        if (regex.test(content)) {
-          content = content.replace(regex, `$1${key} = "${value}"`);
-        }
-      }
+    for (const { key, value } of normalizedVars.updates) {
+      const result = replaceWorkerVar(content, env, key, value);
+      content = result.content;
+      if (result.updated) updated.push(key);
+    }
+
+    if (updated.length === 0) {
+      return workerMutationBadRequest(
+        res,
+        'WORKER_VARS_NOT_FOUND',
+        `No matching ${env} worker variables found`
+      );
     }
 
     await fs.writeFile(wranglerPath, content, 'utf8');
 
-    res.json({ ok: true, data: { message: 'Variables updated', path: wranglerPath } });
+    res.json({ ok: true, data: { message: 'Variables updated', path: wranglerPath, updated } });
   } catch (err) {
     res.status(500).json({ ok: false, error: err.message });
   }
@@ -144,15 +234,27 @@ router.post('/:workerId/vars', requireAdmin, requireWorkerMutationCapability, as
 
 router.post('/:workerId/secret', requireAdmin, requireWorkerMutationCapability, async (req, res) => {
   const { workerId } = req.params;
-  const { key, value, env = 'production' } = req.body;
+  const { key, value } = req.body;
+  const env = normalizeWorkerMutationEnv(req.body?.env, 'production');
+  if (!env) {
+    return workerMutationBadRequest(
+      res,
+      'INVALID_WORKER_ENV',
+      'env must be development or production'
+    );
+  }
   const worker = WORKERS_CONFIG.find((w) => w.id === workerId);
 
   if (!worker) {
     return res.status(404).json({ ok: false, error: 'Worker not found' });
   }
 
-  if (!key || !value) {
-    return res.status(400).json({ ok: false, error: 'key and value required' });
+  if (!isValidWorkerVarKey(key) || typeof value !== 'string' || value.length === 0) {
+    return workerMutationBadRequest(
+      res,
+      'INVALID_WORKER_SECRET',
+      'key must be a valid variable name and value must be a non-empty string'
+    );
   }
 
   try {
@@ -172,7 +274,15 @@ router.post('/:workerId/secret', requireAdmin, requireWorkerMutationCapability, 
 
 router.post('/:workerId/deploy', requireAdmin, requireWorkerMutationCapability, async (req, res) => {
   const { workerId } = req.params;
-  const { env = 'production', dryRun = false } = req.body;
+  const env = normalizeWorkerMutationEnv(req.body?.env, 'production');
+  if (!env) {
+    return workerMutationBadRequest(
+      res,
+      'INVALID_WORKER_ENV',
+      'env must be development or production'
+    );
+  }
+  const dryRun = req.body?.dryRun === true;
   const worker = WORKERS_CONFIG.find((w) => w.id === workerId);
 
   if (!worker) {
@@ -326,7 +436,7 @@ function runWranglerCommand(args, cwd, stdin = null) {
   return new Promise((resolve, reject) => {
     const proc = spawn('npx', ['wrangler', ...args], {
       cwd,
-      shell: true,
+      shell: false,
       env: { ...process.env },
     });
 

--- a/backend/test/workers-mutations.test.js
+++ b/backend/test/workers-mutations.test.js
@@ -1,0 +1,156 @@
+import test, { after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+import express from 'express';
+
+const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'blog-workers-mutations-'));
+const workerDir = path.join(tempRoot, 'workers', 'api-gateway');
+const wranglerPath = path.join(workerDir, 'wrangler.toml');
+
+process.env.REPO_ROOT = tempRoot;
+process.env.ADMIN_BEARER_TOKEN = 'workers-mutation-token';
+process.env.ADMIN_WORKER_MUTATIONS = 'true';
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '15m';
+process.env.APP_ENV = 'test';
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || 'gpt-4.1-mini';
+
+const { default: workersRouter } = await import('../src/routes/workers.js');
+
+async function writeWranglerToml() {
+  await fs.mkdir(workerDir, { recursive: true });
+  await fs.writeFile(
+    wranglerPath,
+    `name = "blog-api-gateway"
+main = "src/index.js"
+compatibility_date = "2026-01-01"
+
+[vars]
+BACKEND_ORIGIN = "https://old.example.com"
+SAFE_FLAG = "old"
+
+[env.production]
+name = "blog-api-gateway-production"
+
+[env.production.vars]
+BACKEND_ORIGIN = "https://prod.example.com"
+`,
+    'utf8'
+  );
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/admin/workers', workersRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err?.status || 500).json({
+      ok: false,
+      error: err?.message || 'Unhandled test error',
+    });
+  });
+  return app;
+}
+
+async function withServer(callback) {
+  const server = http.createServer(createApp());
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+    await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+function adminHeaders() {
+  return {
+    Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+beforeEach(async () => {
+  await writeWranglerToml();
+});
+
+after(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+test('worker vars mutation validates and escapes TOML string values', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/admin/workers/api-gateway/vars`, {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        env: 'development',
+        vars: {
+          BACKEND_ORIGIN: 'https://new.example.com/"quoted"\nnext',
+        },
+      }),
+    });
+
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.deepEqual(payload.data.updated, ['BACKEND_ORIGIN']);
+
+    const content = await fs.readFile(wranglerPath, 'utf8');
+    assert.match(content, /BACKEND_ORIGIN = "https:\/\/new\.example\.com\/\\"quoted\\"\\nnext"/);
+    assert.match(content, /\[env\.production\.vars\]\nBACKEND_ORIGIN = "https:\/\/prod\.example\.com"/);
+  });
+});
+
+test('worker vars mutation rejects invalid variable keys before writing', async () => {
+  const before = await fs.readFile(wranglerPath, 'utf8');
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/admin/workers/api-gateway/vars`, {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        env: 'development',
+        vars: {
+          'BACKEND_ORIGIN;touch tmp/pwned': 'https://bad.example.com',
+        },
+      }),
+    });
+
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'INVALID_WORKER_VARS');
+  });
+
+  assert.equal(await fs.readFile(wranglerPath, 'utf8'), before);
+});
+
+test('worker secret mutation rejects shell metacharacters in secret keys', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/admin/workers/api-gateway/secret`, {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        env: 'production',
+        key: 'SAFE_KEY;echo pwned',
+        value: 'secret-value',
+      }),
+    });
+
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'INVALID_WORKER_SECRET');
+  });
+});

--- a/backend/test/workers-mutations.test.js
+++ b/backend/test/workers-mutations.test.js
@@ -112,6 +112,36 @@ test('worker vars mutation validates and escapes TOML string values', async () =
   });
 });
 
+test('worker vars mutation can update a previously escaped TOML value', async () => {
+  await withServer(async (baseUrl) => {
+    const first = await fetch(`${baseUrl}/api/v1/admin/workers/api-gateway/vars`, {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        vars: {
+          BACKEND_ORIGIN: 'https://first.example.com/"quoted"',
+        },
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const second = await fetch(`${baseUrl}/api/v1/admin/workers/api-gateway/vars`, {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        vars: {
+          BACKEND_ORIGIN: 'https://second.example.com',
+        },
+      }),
+    });
+
+    assert.equal(second.status, 200);
+    const content = await fs.readFile(wranglerPath, 'utf8');
+    assert.match(content, /BACKEND_ORIGIN = "https:\/\/second\.example\.com"/);
+    assert.doesNotMatch(content, /first\.example/);
+  });
+});
+
 test('worker vars mutation rejects invalid variable keys before writing', async () => {
   const before = await fs.readFile(wranglerPath, 'utf8');
 
@@ -136,6 +166,29 @@ test('worker vars mutation rejects invalid variable keys before writing', async 
   assert.equal(await fs.readFile(wranglerPath, 'utf8'), before);
 });
 
+test('worker vars mutation rejects unsupported control characters', async () => {
+  const before = await fs.readFile(wranglerPath, 'utf8');
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/admin/workers/api-gateway/vars`, {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        vars: {
+          BACKEND_ORIGIN: 'https://bad.example.com\u000B',
+        },
+      }),
+    });
+
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'INVALID_WORKER_VARS');
+  });
+
+  assert.equal(await fs.readFile(wranglerPath, 'utf8'), before);
+});
+
 test('worker secret mutation rejects shell metacharacters in secret keys', async () => {
   await withServer(async (baseUrl) => {
     const response = await fetch(`${baseUrl}/api/v1/admin/workers/api-gateway/secret`, {
@@ -146,6 +199,22 @@ test('worker secret mutation rejects shell metacharacters in secret keys', async
         key: 'SAFE_KEY;echo pwned',
         value: 'secret-value',
       }),
+    });
+
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, 'INVALID_WORKER_SECRET');
+  });
+});
+
+test('worker secret mutation returns structured 400 for an empty body', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/admin/workers/api-gateway/secret`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
+      },
     });
 
     assert.equal(response.status, 400);

--- a/docs/generated/route-governance.snapshot.json
+++ b/docs/generated/route-governance.snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-05T09:22:23.601Z",
+  "generatedAt": "2026-07-01T04:49:42.163Z",
   "counts": {
     "serviceBoundaries": {
       "worker-owned": 27,
@@ -513,8 +513,8 @@
       "wranglerPath": "api-gateway/wrangler.toml",
       "hasProduction": true,
       "requiredSecrets": [
-        "BACKEND_ORIGIN",
         "BACKEND_KEY",
+        "BACKEND_ORIGIN",
         "GATEWAY_SIGNING_SECRET",
         "JWT_SECRET",
         "SECRETS_ENCRYPTION_KEY"


### PR DESCRIPTION
## Summary
- Validate admin worker mutation environments and worker variable/secret keys before writing files or invoking wrangler.
- TOML-escape worker var values and reject no-op var updates instead of silently reporting success.
- Run wrangler through spawn without shell interpretation.
- Add route tests for escaped vars and rejected var/secret keys.

## Verification
- git diff --check
- node --test test/workers-mutations.test.js
- npm test

Note: after installing backend dependencies with npm ci --ignore-scripts, I rebuilt native packages with npm rebuild better-sqlite3 sharp before running the full test suite.