### PR TITLE
fix(admin): escape saved config env values

### DIFF
--- a/backend/src/routes/config.js
+++ b/backend/src/routes/config.js
@@ -430,7 +430,7 @@ function generateEnvFile(includeSecrets = false) {
   CONFIG_CATEGORIES.forEach((cat) => {
     lines.push(`# === ${cat.name} ===`);
     cat.variables.forEach((v) => {
-      const value = process.env[v.key] || v.default || "";
+      const value = process.env[v.key] ?? v.default ?? "";
       if (v.isSecret && !includeSecrets) {
         lines.push(`# ${v.key}=<secret>`);
       } else {
@@ -448,7 +448,7 @@ function generateDockerComposeEnv(includeSecrets = false) {
 
   CONFIG_CATEGORIES.forEach((cat) => {
     cat.variables.forEach((v) => {
-      const value = process.env[v.key] || v.default || "";
+      const value = process.env[v.key] ?? v.default ?? "";
       if (v.isSecret && !includeSecrets) {
         lines.push(`      # - ${v.key}=<secret>`);
       } else if (value) {
@@ -466,7 +466,7 @@ function generateWranglerVars(includeSecrets = false) {
 
   CONFIG_CATEGORIES.forEach((cat) => {
     cat.variables.forEach((v) => {
-      const value = process.env[v.key] || v.default || "";
+      const value = process.env[v.key] ?? v.default ?? "";
       if (v.isSecret) {
         secretLines.push(`# wrangler secret put ${v.key}`);
       } else if (value) {
@@ -511,7 +511,7 @@ router.post("/save-env", requireAdmin, async (req, res) => {
 
     CONFIG_CATEGORIES.forEach((cat) => {
       cat.variables.forEach((v) => {
-        allVars[v.key] = process.env[v.key] || v.default || "";
+        allVars[v.key] = process.env[v.key] ?? v.default ?? "";
       });
     });
 
@@ -527,7 +527,7 @@ router.post("/save-env", requireAdmin, async (req, res) => {
     CONFIG_CATEGORIES.forEach((cat) => {
       lines.push(`# === ${cat.name} ===`);
       cat.variables.forEach((v) => {
-        const val = allVars[v.key] || "";
+        const val = allVars[v.key] ?? "";
         if (val || !v.isSecret) {
           lines.push(`${v.key}=${serializeEnvValue(val)}`);
         }

--- a/backend/src/routes/config.js
+++ b/backend/src/routes/config.js
@@ -333,7 +333,8 @@ router.get("/current", requireAdmin, (req, res) => {
 });
 
 router.post("/validate", requireAdmin, (req, res) => {
-  const { key, value } = req.body;
+  const body = req.body && typeof req.body === "object" ? req.body : {};
+  const { key, value } = body;
 
   const category = CONFIG_CATEGORIES.find((cat) =>
     cat.variables.some((v) => v.key === key),
@@ -381,8 +382,18 @@ function validateVariable(variable, value) {
   return { valid: true };
 }
 
+function serializeEnvValue(value) {
+  const raw = String(value ?? "");
+  if (!raw) return "";
+  if (/[\s#"'\\=]/.test(raw)) {
+    return JSON.stringify(raw);
+  }
+  return raw;
+}
+
 router.post("/export", requireAdmin, (req, res) => {
-  const { format = "env", includeSecrets = false } = req.body;
+  const body = req.body && typeof req.body === "object" ? req.body : {};
+  const { format = "env", includeSecrets = false } = body;
 
   if (includeSecrets && config.security?.protectedEnvironment) {
     return res.status(403).json({
@@ -423,7 +434,7 @@ function generateEnvFile(includeSecrets = false) {
       if (v.isSecret && !includeSecrets) {
         lines.push(`# ${v.key}=<secret>`);
       } else {
-        lines.push(`${v.key}=${value}`);
+        lines.push(`${v.key}=${serializeEnvValue(value)}`);
       }
     });
     lines.push("");
@@ -468,7 +479,8 @@ function generateWranglerVars(includeSecrets = false) {
 }
 
 router.post("/save-env", requireAdmin, async (req, res) => {
-  const { variables, target = "backend" } = req.body;
+  const body = req.body && typeof req.body === "object" ? req.body : {};
+  const { variables, target = "backend" } = body;
 
   if (!configMutationsEnabled) {
     return res.status(403).json(buildConfigMutationsDisabledPayload());
@@ -478,6 +490,12 @@ router.post("/save-env", requireAdmin, async (req, res) => {
     return res
       .status(400)
       .json({ ok: false, error: "variables object required" });
+  }
+
+  if (!["backend", "root"].includes(target)) {
+    return res
+      .status(400)
+      .json({ ok: false, error: "target must be backend or root" });
   }
 
   try {
@@ -511,7 +529,7 @@ router.post("/save-env", requireAdmin, async (req, res) => {
       cat.variables.forEach((v) => {
         const val = allVars[v.key] || "";
         if (val || !v.isSecret) {
-          lines.push(`${v.key}=${val}`);
+          lines.push(`${v.key}=${serializeEnvValue(val)}`);
         }
       });
       lines.push("");

--- a/backend/test/admin-config.test.js
+++ b/backend/test/admin-config.test.js
@@ -92,6 +92,27 @@ test('save-env serializes newline values without injecting extra env keys', asyn
   });
 });
 
+test('save-env preserves valid falsy numeric values', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/admin/config/save-env`, {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        target: 'backend',
+        variables: {
+          PORT: 0,
+          TRUST_PROXY: 0,
+        },
+      }),
+    });
+
+    assert.equal(response.status, 200);
+    const content = await fs.readFile(backendEnvPath, 'utf8');
+    assert.match(content, /^PORT=0$/m);
+    assert.match(content, /^TRUST_PROXY=0$/m);
+  });
+});
+
 test('save-env returns structured 400 for an empty body', async () => {
   await withServer(async (baseUrl) => {
     const response = await fetch(`${baseUrl}/api/v1/admin/config/save-env`, {

--- a/backend/test/admin-config.test.js
+++ b/backend/test/admin-config.test.js
@@ -1,0 +1,131 @@
+import test, { after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+import express from 'express';
+
+const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'blog-admin-config-'));
+const backendDir = path.join(tempRoot, 'backend');
+const backendEnvPath = path.join(backendDir, '.env');
+
+process.env.REPO_ROOT = tempRoot;
+process.env.ADMIN_BEARER_TOKEN = 'admin-config-token';
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '15m';
+process.env.APP_ENV = 'test';
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || 'gpt-4.1-mini';
+
+const { default: configRouter } = await import('../src/routes/config.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/admin/config', configRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err?.status || 500).json({
+      ok: false,
+      error: err?.message || 'Unhandled test error',
+    });
+  });
+  return app;
+}
+
+async function withServer(callback) {
+  const server = http.createServer(createApp());
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+    await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+function adminHeaders() {
+  return {
+    Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+beforeEach(async () => {
+  await fs.rm(backendDir, { recursive: true, force: true });
+  await fs.mkdir(backendDir, { recursive: true });
+});
+
+after(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+test('save-env serializes newline values without injecting extra env keys', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/admin/config/save-env`, {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        target: 'backend',
+        variables: {
+          SITE_BASE_URL: 'https://safe.example\nJWT_SECRET=hijack',
+        },
+      }),
+    });
+
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+
+    const content = await fs.readFile(backendEnvPath, 'utf8');
+    assert.match(
+      content,
+      /^SITE_BASE_URL="https:\/\/safe\.example\\nJWT_SECRET=hijack"$/m
+    );
+    assert.doesNotMatch(content, /^JWT_SECRET=hijack$/m);
+  });
+});
+
+test('save-env returns structured 400 for an empty body', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/admin/config/save-env`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
+      },
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      error: 'variables object required',
+    });
+  });
+});
+
+test('save-env rejects unknown targets instead of falling back to backend env', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/admin/config/save-env`, {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        target: 'elsewhere',
+        variables: {
+          SITE_BASE_URL: 'https://safe.example',
+        },
+      }),
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      error: 'target must be backend or root',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Guard admin config mutation handlers against empty request bodies.
- Validate save-env target values instead of falling back to backend env for unknown targets.
- Quote/escape generated .env values so newline or special-character values cannot inject extra env lines.
- Add admin config route tests for newline injection prevention and structured 400 responses.

## Verification
- git diff --check
- node --test test/admin-config.test.js
- node --test test/workers-mutations.test.js
- npm run routes:check
- npm test