### PR TITLE
fix(posts): reject traversal slugs

### DIFF
--- a/backend/src/routes/posts.js
+++ b/backend/src/routes/posts.js
@@ -92,6 +92,11 @@ function validateFilename(filename) {
   return validFilenamePattern.test(filename);
 }
 
+function buildValidatedPostFilename(slug) {
+  const filename = `${String(slug || '')}.md`;
+  return validateFilename(filename) ? filename : null;
+}
+
 
 function computeItem(year, file, fm, body) {
   const filename = path.basename(file, '.md');
@@ -306,7 +311,9 @@ router.get('/:year/:slug', httpCache({ ttl: 600, prefix: 'posts', skip: hasAutho
     if (!/^\d{4}$/.test(year))
       return res.status(400).json({ ok: false, error: 'Invalid year' });
 
-    const file = `${slug}.md`;
+    const file = buildValidatedPostFilename(slug);
+    if (!file)
+      return res.status(400).json({ ok: false, error: 'Invalid slug' });
     
     // Try filesystem first
     if (await isFilesystemAvailable()) {
@@ -407,7 +414,9 @@ router.put('/:year/:slug', requireAdmin, async (req, res, next) => {
     const { year, slug } = req.params;
     if (!/^\d{4}$/.test(year))
       return res.status(400).json({ ok: false, error: 'Invalid year' });
-    const filename = `${slug}.md`;
+    const filename = buildValidatedPostFilename(slug);
+    if (!filename)
+      return res.status(400).json({ ok: false, error: 'Invalid slug' });
     const abs = path.join(config.content.postsDir, year, filename);
     if (!(await exists(abs)))
       return res.status(404).json({ ok: false, error: 'Not found' });
@@ -442,7 +451,9 @@ router.delete('/:year/:slug', requireAdmin, async (req, res, next) => {
     const { year, slug } = req.params;
     if (!/^\d{4}$/.test(year))
       return res.status(400).json({ ok: false, error: 'Invalid year' });
-    const filename = `${slug}.md`;
+    const filename = buildValidatedPostFilename(slug);
+    if (!filename)
+      return res.status(400).json({ ok: false, error: 'Invalid slug' });
     const abs = path.join(config.content.postsDir, year, filename);
     if (!(await exists(abs)))
       return res.status(404).json({ ok: false, error: 'Not found' });

--- a/backend/test/posts-security.test.js
+++ b/backend/test/posts-security.test.js
@@ -164,3 +164,61 @@ test("admin single-post lookup can read unpublished markdown", async () => {
     assert.match(payload.data.markdown, /Draft body/);
   });
 });
+
+test("single-post lookup rejects encoded traversal slugs", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/posts/2026/..%2Foutside`);
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      error: "Invalid slug",
+    });
+  });
+});
+
+test("admin post update rejects encoded traversal slugs before filesystem writes", async () => {
+  const outsidePath = path.join(postsDir, "outside.md");
+  await fs.writeFile(outsidePath, "keep-update", "utf8");
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/posts/2026/..%2Foutside`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${createAdminToken()}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ markdown: "changed" }),
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      error: "Invalid slug",
+    });
+  });
+
+  assert.equal(await fs.readFile(outsidePath, "utf8"), "keep-update");
+});
+
+test("admin post delete rejects encoded traversal slugs before filesystem deletes", async () => {
+  const outsidePath = path.join(postsDir, "outside.md");
+  await fs.writeFile(outsidePath, "keep-delete", "utf8");
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/posts/2026/..%2Foutside`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${createAdminToken()}`,
+      },
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      error: "Invalid slug",
+    });
+  });
+
+  assert.equal(await fs.readFile(outsidePath, "utf8"), "keep-delete");
+});


### PR DESCRIPTION
## Summary
- Validate post slug route params before filesystem lookup, update, or delete operations
- Reject encoded traversal slugs with `400 Invalid slug` before local file access or remote fallback
- Add regression coverage for public lookup plus admin update/delete traversal attempts

## Testing
- `node --test test/posts-security.test.js`
- `npm test`
- `git diff --check`

## Risks
- Requests for post slugs outside the existing filename contract now fail fast with 400 instead of falling through to filesystem or remote lookup.