### PR TITLE
fix(outbox): restrict GitHub write paths

### DIFF
--- a/backend/src/routes/posts.js
+++ b/backend/src/routes/posts.js
@@ -88,7 +88,7 @@ async function isFilesystemAvailable() {
 
 
 function validateFilename(filename) {
-  const validFilenamePattern = /^[a-zA-Z0-9][a-zA-Z0-9\-_]*\.md$/;
+  const validFilenamePattern = /^[\p{L}\p{N}][\p{L}\p{N}\-_]*\.md$/u;
   return validFilenamePattern.test(filename);
 }
 

--- a/backend/src/services/backend-outbox.service.js
+++ b/backend/src/services/backend-outbox.service.js
@@ -30,6 +30,10 @@ const MAX_LIMIT = 50;
 const DEFAULT_CONSUMER_ID = `backend-outbox-${process.pid}`;
 const CHROMA_TENANT = "default_tenant";
 const CHROMA_DATABASE = "default_database";
+const GITHUB_POST_MARKDOWN_PATH_PATTERN =
+  /^frontend\/public\/posts\/\d{4}\/[\p{L}\p{N}][\p{L}\p{N}_-]*\.md$/u;
+const COMMENT_ARCHIVE_PATH_PATTERN =
+  /^frontend\/src\/data\/comments\/\d{4}\/[\p{L}\p{N}][\p{L}\p{N}_-]*\.json$/u;
 const collectionUUIDCache = new Map();
 
 function clampLimit(value) {
@@ -51,6 +55,13 @@ function assertGitHubConfigured() {
     throw new Error("Server not configured for GitHub (owner/repo/token missing)");
   }
   return { owner, repo, token };
+}
+
+function assertAllowedRepoPath(pathValue, pattern, label) {
+  if (typeof pathValue !== "string" || !pattern.test(pathValue)) {
+    throw new Error(`${label} path is not allowed`);
+  }
+  return pathValue;
 }
 
 function getGitIdentity() {
@@ -244,13 +255,19 @@ async function processGithubPr(event, { octokitFactory } = {}) {
   }
 
   const payload = event.payload || {};
-  const { owner, repo } = assertGitHubConfigured();
-  const octokit = createOctokit(octokitFactory);
-  const baseBranch = payload.baseBranch || await getDefaultBranch(octokit, owner, repo);
 
   if (!payload.branch || !payload.path || !payload.markdown || !payload.prTitle) {
     throw new Error("GitHub PR outbox payload is incomplete");
   }
+  const filePath = assertAllowedRepoPath(
+    payload.path,
+    GITHUB_POST_MARKDOWN_PATH_PATTERN,
+    "GitHub PR",
+  );
+
+  const { owner, repo } = assertGitHubConfigured();
+  const octokit = createOctokit(octokitFactory);
+  const baseBranch = payload.baseBranch || await getDefaultBranch(octokit, owner, repo);
 
   await ensureBranch(octokit, {
     owner,
@@ -261,7 +278,7 @@ async function processGithubPr(event, { octokitFactory } = {}) {
   await ensureFile(octokit, {
     owner,
     repo,
-    path: payload.path,
+    path: filePath,
     branch: payload.branch,
     message: payload.commitMessage || payload.prTitle,
     content: payload.markdown,
@@ -278,27 +295,37 @@ async function processGithubPr(event, { octokitFactory } = {}) {
   return {
     prUrl: pr.html_url,
     branch: payload.branch,
-    path: payload.path,
+    path: filePath,
   };
 }
 
 async function processGithubCommentsArchive(event, { octokitFactory } = {}) {
   const payload = event.payload || {};
-  const { owner, repo } = assertGitHubConfigured();
   const archives = Array.isArray(payload.archives) ? payload.archives : [];
   if (!archives.length) return { archivedPosts: [], totalComments: 0 };
 
+  const normalizedArchives = archives.map((archive) => {
+    if (!archive.path || !archive.content || !Array.isArray(archive.commentIds)) {
+      throw new Error("Comment archive payload is incomplete");
+    }
+    return {
+      ...archive,
+      path: assertAllowedRepoPath(
+        archive.path,
+        COMMENT_ARCHIVE_PATH_PATTERN,
+        "Comment archive",
+      ),
+    };
+  });
+
+  const { owner, repo } = assertGitHubConfigured();
   const octokit = createOctokit(octokitFactory);
   const baseBranch = payload.baseBranch || await getDefaultBranch(octokit, owner, repo);
   const identity = getGitIdentity();
   const archivedPosts = [];
   let totalComments = 0;
 
-  for (const archive of archives) {
-    if (!archive.path || !archive.content || !Array.isArray(archive.commentIds)) {
-      throw new Error("Comment archive payload is incomplete");
-    }
-
+  for (const archive of normalizedArchives) {
     let sha;
     try {
       const existing = await octokit.rest.repos.getContent({

--- a/backend/test/backend-outbox.service.test.js
+++ b/backend/test/backend-outbox.service.test.js
@@ -78,7 +78,7 @@ test("backend outbox creates GitHub PRs with idempotent branch/file/PR operation
       eventType: "github.pr.create-post",
       payload: {
         branch: "post/2026-test-202604270101",
-        path: "frontend/public/posts/2026/test.md",
+        path: "frontend/public/posts/2026/한글-post.md",
         markdown: "# Test\n",
         commitMessage: "feat(post): add test",
         prTitle: "Add test",
@@ -129,6 +129,85 @@ test("backend outbox creates GitHub PRs with idempotent branch/file/PR operation
   assert.equal(result.processed, 1);
   assert.equal(result.results[0].result.prUrl, "https://github.example/pr/1");
   assert.deepEqual(calls.map(([kind]) => kind), ["branch", "file", "pr"]);
+  assert.equal(calls[1][1].path, "frontend/public/posts/2026/한글-post.md");
+});
+
+test("backend outbox rejects GitHub PR paths outside post content", async () => {
+  const repository = new FakeRepository([
+    {
+      id: "dout-pr-bad-path",
+      stream: GITHUB_PR_STREAM,
+      aggregateId: "post:2026:test",
+      eventType: "github.pr.create-post",
+      payload: {
+        branch: "post/2026-test-202604270101",
+        path: "package.json",
+        markdown: "# Test\n",
+        commitMessage: "feat(post): add test",
+        prTitle: "Add test",
+        prBody: "body",
+      },
+    },
+  ]);
+
+  const result = await flushBackendDomainOutbox({
+    repository,
+    streams: GITHUB_PR_STREAM,
+    octokitFactory: () => {
+      throw new Error("Octokit should not be created for invalid paths");
+    },
+  });
+
+  assert.equal(result.processed, 0);
+  assert.equal(result.failed, 1);
+  assert.match(result.results[0].error, /GitHub PR path is not allowed/);
+  assert.deepEqual(repository.succeeded, []);
+  assert.deepEqual(repository.failed, [
+    {
+      id: "dout-pr-bad-path",
+      error: "GitHub PR path is not allowed",
+    },
+  ]);
+});
+
+test("backend outbox rejects comment archive paths outside archive data", async () => {
+  const repository = new FakeRepository([
+    {
+      id: "dout-comments-bad-path",
+      stream: GITHUB_PR_STREAM,
+      aggregateId: "comments-archive:test",
+      eventType: "github.comments.archive",
+      payload: {
+        archives: [
+          {
+            postId: "2026/test",
+            path: "frontend/src/data/comments/../../package.json",
+            content: "{}\n",
+            commentIds: ["comment-1"],
+          },
+        ],
+      },
+    },
+  ]);
+
+  const result = await flushBackendDomainOutbox({
+    repository,
+    streams: GITHUB_PR_STREAM,
+    octokitFactory: () => {
+      throw new Error("Octokit should not be created for invalid archive paths");
+    },
+  });
+
+  assert.equal(result.processed, 0);
+  assert.equal(result.failed, 1);
+  assert.match(result.results[0].error, /Comment archive path is not allowed/);
+  assert.deepEqual(repository.succeeded, []);
+  assert.deepEqual(repository.failed, [
+    {
+      id: "dout-comments-bad-path",
+      error: "Comment archive path is not allowed",
+    },
+  ]);
 });
 
 test("backend outbox broadcasts notifications and marks the notification outbox row", async () => {

--- a/backend/test/posts-security.test.js
+++ b/backend/test/posts-security.test.js
@@ -42,6 +42,17 @@ date: 2026-01-02
 Draft body
 `,
 );
+await fs.writeFile(
+  path.join(postsDir, "2026", "한글-post.md"),
+  `---
+title: Korean Slug Post
+published: true
+date: 2026-01-03
+---
+
+Korean slug body
+`,
+);
 
 const [{ default: postsRouter }, { signJwt }, { closeRedis }] = await Promise.all([
   import("../src/routes/posts.js"),
@@ -106,7 +117,7 @@ test("public post list never includes drafts by default", async () => {
     assert.equal(payload.ok, true);
     assert.deepEqual(
       payload.data.items.map((item) => item.slug).sort(),
-      ["public-post"],
+      ["public-post", "한글-post"],
     );
   });
 });
@@ -135,7 +146,7 @@ test("admin post list can include drafts", async () => {
     assert.equal(payload.ok, true);
     assert.deepEqual(
       payload.data.items.map((item) => item.slug).sort(),
-      ["draft-post", "public-post"],
+      ["draft-post", "public-post", "한글-post"],
     );
   });
 });
@@ -162,6 +173,19 @@ test("admin single-post lookup can read unpublished markdown", async () => {
     assert.equal(payload.data.item.slug, "draft-post");
     assert.equal(payload.data.item.published, false);
     assert.match(payload.data.markdown, /Draft body/);
+  });
+});
+
+test("single-post lookup allows existing unicode slugs without path separators", async () => {
+  await withServer(async (baseUrl) => {
+    const slug = encodeURIComponent("한글-post");
+    const response = await fetch(`${baseUrl}/api/v1/posts/2026/${slug}`);
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.equal(payload.data.item.slug, "한글-post");
+    assert.match(payload.data.markdown, /Korean slug body/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Restrict backend GitHub outbox writes to expected post markdown and archived-comment JSON paths before Octokit is created
- Reject invalid PR/archive paths as failed outbox events instead of reaching GitHub file writes
- Broaden post filename validation to allow existing Unicode slugs while still blocking path separators and traversal

## Testing
- `node --test test/backend-outbox.service.test.js`
- `node --test test/posts-security.test.js`
- `npm test` from `backend/`
- `npm run routes:check`
- `npm run outbox:check-memory`
- `git diff --check`

## Risks
- GitHub outbox events for paths outside `frontend/public/posts/YYYY/*.md` or `frontend/src/data/comments/YYYY/*.json` now fail fast and need a new explicit allowlist if another repo-write use case is added.