### PR TITLE
fix(execute): reject path-like file names

### DIFF
--- a/backend/src/middleware/schemas/execute.schema.js
+++ b/backend/src/middleware/schemas/execute.schema.js
@@ -5,6 +5,15 @@
 
 import { z } from 'zod';
 
+const executeFileNameSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(
+    /^[\p{L}\p{N}][\p{L}\p{N}._-]*$/u,
+    'file name must be a basename without path separators',
+  );
+
 /**
  * POST / - Execute code via Piston
  */
@@ -14,7 +23,7 @@ export const executeBodySchema = z.object({
   files: z
     .array(
       z.object({
-        name: z.string().max(256).optional(),
+        name: executeFileNameSchema.optional(),
         content: z.string().max(1_000_000), // 1 MB per file max
       }),
     )

--- a/backend/test/execute-schema.test.js
+++ b/backend/test/execute-schema.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { executeBodySchema } from "../src/middleware/schemas/execute.schema.js";
+
+function parseExecuteFileName(name) {
+  return executeBodySchema.safeParse({
+    language: "python",
+    files: [{ name, content: "print('ok')" }],
+  });
+}
+
+test("execute schema accepts basename file names", () => {
+  assert.equal(parseExecuteFileName("main.py").success, true);
+  assert.equal(parseExecuteFileName("Solution.test.js").success, true);
+  assert.equal(parseExecuteFileName("한글.py").success, true);
+});
+
+test("execute schema rejects path-like file names", () => {
+  for (const name of ["../main.py", "src/main.py", "src\\main.py", ".env"]) {
+    const result = parseExecuteFileName(name);
+    assert.equal(result.success, false, `${name} should be rejected`);
+  }
+});


### PR DESCRIPTION
## Summary
- Add basename validation for optional Piston `files[].name` values
- Reject path-like names such as `../main.py`, `src/main.py`, backslash paths, and hidden dot-start names
- Add schema tests covering accepted basenames and rejected path-like inputs

## Testing
- `node --test test/execute-schema.test.js`
- `node --test test/code-execution.tool.test.js`
- `npm test` from `backend/`
- `npm run routes:check`
- `git diff --check`

## Risks
- Admin execution requests that intentionally relied on nested file paths must now send flat file basenames.