### PR TITLE
fix(workers): bound wrangler command execution

### DIFF
--- a/backend/src/routes/workers.js
+++ b/backend/src/routes/workers.js
@@ -12,6 +12,8 @@ const WORKERS_ROOT = config.paths?.workersDir || path.join(config.content.repoRo
 const workerMutationsEnabled = process.env.ADMIN_WORKER_MUTATIONS === 'true';
 const WORKER_MUTATION_ENVS = new Set(['development', 'production']);
 const WORKER_VAR_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const DEFAULT_WRANGLER_TIMEOUT_MS = 120_000;
+const DEFAULT_WRANGLER_MAX_OUTPUT_BYTES = 256 * 1024;
 
 
 const WORKERS_CONFIG = WORKER_DEPLOYMENTS.map((worker) => ({
@@ -437,9 +439,16 @@ function parseWranglerToml(content) {
   return result;
 }
 
-function runWranglerCommand(args, cwd, stdin = null) {
+export function runWranglerCommand(args, cwd, stdin = null, options = {}) {
   return new Promise((resolve, reject) => {
-    const proc = spawn('npx', ['wrangler', ...args], {
+    const spawnImpl = options.spawnImpl || spawn;
+    const timeoutMs = Number.isFinite(options.timeoutMs)
+      ? options.timeoutMs
+      : DEFAULT_WRANGLER_TIMEOUT_MS;
+    const maxOutputBytes = Number.isFinite(options.maxOutputBytes)
+      ? options.maxOutputBytes
+      : DEFAULT_WRANGLER_MAX_OUTPUT_BYTES;
+    const proc = spawnImpl('npx', ['wrangler', ...args], {
       cwd,
       shell: false,
       env: { ...process.env },
@@ -447,13 +456,38 @@ function runWranglerCommand(args, cwd, stdin = null) {
 
     let stdout = '';
     let stderr = '';
+    let settled = false;
+
+    const finish = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      fn(value);
+    };
+
+    const appendOutput = (target, data) => {
+      if (settled) return target;
+      const next = target + data.toString();
+      if (Buffer.byteLength(stdout) + Buffer.byteLength(stderr) + Buffer.byteLength(data) > maxOutputBytes) {
+        proc.kill?.('SIGTERM');
+        finish(reject, new Error(`Wrangler command output exceeded ${maxOutputBytes} bytes`));
+      }
+      return next;
+    };
+
+    const timeout = timeoutMs > 0
+      ? setTimeout(() => {
+          proc.kill?.('SIGTERM');
+          finish(reject, new Error(`Wrangler command timed out after ${timeoutMs}ms`));
+        }, timeoutMs)
+      : null;
 
     proc.stdout.on('data', (data) => {
-      stdout += data.toString();
+      stdout = appendOutput(stdout, data);
     });
 
     proc.stderr.on('data', (data) => {
-      stderr += data.toString();
+      stderr = appendOutput(stderr, data);
     });
 
     if (stdin) {
@@ -463,14 +497,14 @@ function runWranglerCommand(args, cwd, stdin = null) {
 
     proc.on('close', (code) => {
       if (code === 0) {
-        resolve(stdout || stderr);
+        finish(resolve, stdout || stderr);
       } else {
-        reject(new Error(stderr || stdout || `Command failed with code ${code}`));
+        finish(reject, new Error(stderr || stdout || `Command failed with code ${code}`));
       }
     });
 
     proc.on('error', (err) => {
-      reject(err);
+      finish(reject, err);
     });
   });
 }

--- a/backend/test/workers-mutations.test.js
+++ b/backend/test/workers-mutations.test.js
@@ -1,5 +1,6 @@
 import test, { after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import fs from 'node:fs/promises';
 import http from 'node:http';
 import os from 'node:os';
@@ -18,7 +19,21 @@ process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '15m';
 process.env.APP_ENV = 'test';
 process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || 'gpt-4.1-mini';
 
-const { default: workersRouter } = await import('../src/routes/workers.js');
+const { default: workersRouter, runWranglerCommand } = await import('../src/routes/workers.js');
+
+function createFakeProcess() {
+  const proc = new EventEmitter();
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = {
+    write() {},
+    end() {},
+  };
+  proc.kill = (signal) => {
+    proc.killedSignal = signal;
+  };
+  return proc;
+}
 
 async function writeWranglerToml() {
   await fs.mkdir(workerDir, { recursive: true });
@@ -222,4 +237,35 @@ test('worker secret mutation returns structured 400 for an empty body', async ()
     assert.equal(payload.ok, false);
     assert.equal(payload.error.code, 'INVALID_WORKER_SECRET');
   });
+});
+
+test('wrangler command rejects oversized output and terminates the process', async () => {
+  let proc;
+  const promise = runWranglerCommand(['d1', 'list'], tempRoot, null, {
+    maxOutputBytes: 4,
+    timeoutMs: 1000,
+    spawnImpl: () => {
+      proc = createFakeProcess();
+      return proc;
+    },
+  });
+
+  proc.stdout.emit('data', Buffer.from('12345'));
+
+  await assert.rejects(promise, /Wrangler command output exceeded 4 bytes/);
+  assert.equal(proc.killedSignal, 'SIGTERM');
+});
+
+test('wrangler command rejects timed out processes and terminates them', async () => {
+  let proc;
+  const promise = runWranglerCommand(['deploy'], tempRoot, null, {
+    timeoutMs: 1,
+    spawnImpl: () => {
+      proc = createFakeProcess();
+      return proc;
+    },
+  });
+
+  await assert.rejects(promise, /Wrangler command timed out after 1ms/);
+  assert.equal(proc.killedSignal, 'SIGTERM');
 });


### PR DESCRIPTION
## Summary
- Add a 120s timeout and 256 KiB combined output cap to admin Worker Wrangler command execution.
- Terminate over-limit or timed-out Wrangler child processes with SIGTERM and settle the promise once.
- Export the helper for focused unit coverage with injected fake spawn processes.

## Testing
- `cd backend && node --test test/workers-mutations.test.js`
- `cd backend && npm test`
- `npm run routes:check`
- `git diff --check`

## Risks
- Wrangler operations that legitimately need more than 120 seconds will now fail fast and require an intentional limit adjustment.

## Follow-ups
- Continue admin-only hardening loop after checks pass.