### PR TITLE
fix(config): escape admin export values

### DIFF
--- a/backend/src/routes/config.js
+++ b/backend/src/routes/config.js
@@ -391,6 +391,14 @@ function serializeEnvValue(value) {
   return raw;
 }
 
+function serializeDockerComposeEnvEntry(key, value) {
+  return JSON.stringify(`${key}=${String(value ?? "")}`);
+}
+
+function serializeTomlString(value) {
+  return JSON.stringify(String(value ?? ""));
+}
+
 router.post("/export", requireAdmin, (req, res) => {
   const body = req.body && typeof req.body === "object" ? req.body : {};
   const { format = "env", includeSecrets = false } = body;
@@ -452,7 +460,7 @@ function generateDockerComposeEnv(includeSecrets = false) {
       if (v.isSecret && !includeSecrets) {
         lines.push(`      # - ${v.key}=<secret>`);
       } else if (value) {
-        lines.push(`      - ${v.key}=${value}`);
+        lines.push(`      - ${serializeDockerComposeEnvEntry(v.key, value)}`);
       }
     });
   });
@@ -470,7 +478,7 @@ function generateWranglerVars(includeSecrets = false) {
       if (v.isSecret) {
         secretLines.push(`# wrangler secret put ${v.key}`);
       } else if (value) {
-        lines.push(`${v.key} = "${value}"`);
+        lines.push(`${v.key} = ${serializeTomlString(value)}`);
       }
     });
   });

--- a/backend/test/admin-config.test.js
+++ b/backend/test/admin-config.test.js
@@ -150,3 +150,67 @@ test('save-env rejects unknown targets instead of falling back to backend env', 
     });
   });
 });
+
+test('docker-compose export quotes multiline values without injecting extra entries', async () => {
+  const previous = process.env.SITE_BASE_URL;
+  process.env.SITE_BASE_URL = 'https://safe.example\nJWT_SECRET=hijack';
+
+  try {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/v1/admin/config/export`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({ format: 'docker-compose', includeSecrets: false }),
+      });
+
+      assert.equal(response.status, 200);
+      const payload = await response.json();
+      assert.equal(payload.ok, true);
+
+      const content = payload.data.content;
+      assert.match(
+        content,
+        /^      - "SITE_BASE_URL=https:\/\/safe\.example\\nJWT_SECRET=hijack"$/m,
+      );
+      assert.doesNotMatch(content, /^JWT_SECRET=hijack$/m);
+    });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.SITE_BASE_URL;
+    } else {
+      process.env.SITE_BASE_URL = previous;
+    }
+  }
+});
+
+test('wrangler export escapes quotes and newlines in variable values', async () => {
+  const previous = process.env.SITE_BASE_URL;
+  process.env.SITE_BASE_URL = 'https://safe.example"\nJWT_SECRET="hijack';
+
+  try {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/v1/admin/config/export`, {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({ format: 'wrangler', includeSecrets: false }),
+      });
+
+      assert.equal(response.status, 200);
+      const payload = await response.json();
+      assert.equal(payload.ok, true);
+
+      const content = payload.data.content;
+      assert.match(
+        content,
+        /^SITE_BASE_URL = "https:\/\/safe\.example\\"\\nJWT_SECRET=\\"hijack"$/m,
+      );
+      assert.doesNotMatch(content, /^JWT_SECRET=/m);
+    });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.SITE_BASE_URL;
+    } else {
+      process.env.SITE_BASE_URL = previous;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Quote Docker Compose admin config export entries as YAML strings.
- Serialize Wrangler vars through JSON/TOML-compatible string escaping.
- Add regression tests for newline and quote-containing config values so exports do not create injected entries.

## Testing
- `cd backend && node --test test/admin-config.test.js`
- `cd backend && npm test`
- `npm run routes:check`
- `git diff --check`

## Risks
- Docker Compose export now emits quoted list entries instead of raw `KEY=value` items; Compose accepts quoted scalar entries, but copied snippets will look slightly different.

## Follow-ups
- Continue admin-only review from latest main after checks pass.