### PR TITLE
fix(analytics): bound admin visit pagination

### DIFF
--- a/backend/src/routes/adminAnalytics.js
+++ b/backend/src/routes/adminAnalytics.js
@@ -11,6 +11,9 @@ import { createLogger } from "../lib/logger.js";
 
 const router = Router();
 const logger = createLogger("admin-analytics");
+const DEFAULT_VISIT_LIMIT = 100;
+const MAX_VISIT_LIMIT = 200;
+const MAX_VISIT_OFFSET = 100_000;
 
 router.use(requireAdmin);
 
@@ -23,6 +26,37 @@ const requirePg = (req, res, next) => {
   next();
 };
 
+function firstQueryValue(value) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parseBoundedInteger(value, { defaultValue, min, max }) {
+  const raw = firstQueryValue(value);
+  if (raw === undefined || raw === null || raw === "") return defaultValue;
+
+  const text = String(raw).trim();
+  if (!/^-?\d+$/.test(text)) return defaultValue;
+
+  const parsed = Number.parseInt(text, 10);
+  if (!Number.isFinite(parsed)) return defaultValue;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+export function parseVisitPagination(query = {}) {
+  return {
+    limit: parseBoundedInteger(query.limit, {
+      defaultValue: DEFAULT_VISIT_LIMIT,
+      min: 1,
+      max: MAX_VISIT_LIMIT,
+    }),
+    offset: parseBoundedInteger(query.offset, {
+      defaultValue: 0,
+      min: 0,
+      max: MAX_VISIT_OFFSET,
+    }),
+  };
+}
+
 router.get("/posts", requirePg, getAllPostStatsHandler);
 
 router.get(
@@ -31,8 +65,7 @@ router.get(
   async (req, res, next) => {
     try {
       const { year, slug } = req.params;
-      const limit = parseInt(req.query.limit, 10) || 100;
-      const offset = parseInt(req.query.offset, 10) || 0;
+      const { limit, offset } = parseVisitPagination(req.query);
       const [visits, total] = await Promise.all([
         getPostVisits({ slug, year, limit, offset }),
         getPostVisitCount(slug, year),

--- a/backend/test/admin-analytics.test.js
+++ b/backend/test/admin-analytics.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'admin-analytics-test-secret';
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '15m';
+process.env.APP_ENV = process.env.APP_ENV || 'test';
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || 'gpt-4.1-mini';
+
+const { parseVisitPagination } = await import('../src/routes/adminAnalytics.js');
+
+test('admin analytics visit pagination clamps expensive query inputs', () => {
+  assert.deepEqual(parseVisitPagination({ limit: '999999', offset: '999999999' }), {
+    limit: 200,
+    offset: 100000,
+  });
+});
+
+test('admin analytics visit pagination normalizes invalid and negative inputs', () => {
+  assert.deepEqual(parseVisitPagination({ limit: 'not-a-number', offset: '-20' }), {
+    limit: 100,
+    offset: 0,
+  });
+  assert.deepEqual(parseVisitPagination({ limit: '0', offset: '15.5' }), {
+    limit: 1,
+    offset: 0,
+  });
+});


### PR DESCRIPTION
## Summary
- Clamp admin analytics visit-log `limit` to 1..200.
- Clamp admin analytics visit-log `offset` to 0..100000 and default malformed values safely.
- Add focused pagination parser tests without requiring a PostgreSQL connection.

## Testing
- `cd backend && node --test test/admin-analytics.test.js`
- `cd backend && npm test`
- `npm run routes:check`
- `git diff --check`

## Risks
- Requests beyond offset 100000 are now capped; the admin UI currently pages at 50 rows and is unaffected for normal usage.

## Follow-ups
- Continue admin-only hardening from latest main after checks pass.