### PR TITLE
fix(outbox): validate github branch refs

### DIFF
--- a/backend/src/services/backend-outbox.service.js
+++ b/backend/src/services/backend-outbox.service.js
@@ -34,6 +34,8 @@ const GITHUB_POST_MARKDOWN_PATH_PATTERN =
   /^frontend\/public\/posts\/\d{4}\/[\p{L}\p{N}][\p{L}\p{N}_-]*\.md$/u;
 const COMMENT_ARCHIVE_PATH_PATTERN =
   /^frontend\/src\/data\/comments\/\d{4}\/[\p{L}\p{N}][\p{L}\p{N}_-]*\.json$/u;
+const GITHUB_PR_BRANCH_PATTERN =
+  /^(?:post|propose)\/[\p{L}\p{N}][\p{L}\p{N}._-]{0,199}$/u;
 const collectionUUIDCache = new Map();
 
 function clampLimit(value) {
@@ -62,6 +64,22 @@ function assertAllowedRepoPath(pathValue, pattern, label) {
     throw new Error(`${label} path is not allowed`);
   }
   return pathValue;
+}
+
+function assertAllowedGitHubBranch(branchValue) {
+  if (typeof branchValue !== "string" || branchValue.trim() !== branchValue) {
+    throw new Error("GitHub PR branch is not allowed");
+  }
+  if (
+    !GITHUB_PR_BRANCH_PATTERN.test(branchValue) ||
+    branchValue.includes("..") ||
+    branchValue.includes("@{") ||
+    branchValue.endsWith(".") ||
+    branchValue.endsWith(".lock")
+  ) {
+    throw new Error("GitHub PR branch is not allowed");
+  }
+  return branchValue;
 }
 
 function getGitIdentity() {
@@ -264,6 +282,7 @@ async function processGithubPr(event, { octokitFactory } = {}) {
     GITHUB_POST_MARKDOWN_PATH_PATTERN,
     "GitHub PR",
   );
+  const branch = assertAllowedGitHubBranch(payload.branch);
 
   const { owner, repo } = assertGitHubConfigured();
   const octokit = createOctokit(octokitFactory);
@@ -273,13 +292,13 @@ async function processGithubPr(event, { octokitFactory } = {}) {
     owner,
     repo,
     baseBranch,
-    branch: payload.branch,
+    branch,
   });
   await ensureFile(octokit, {
     owner,
     repo,
     path: filePath,
-    branch: payload.branch,
+    branch,
     message: payload.commitMessage || payload.prTitle,
     content: payload.markdown,
   });
@@ -287,14 +306,14 @@ async function processGithubPr(event, { octokitFactory } = {}) {
     owner,
     repo,
     title: payload.prTitle,
-    head: payload.branch,
+    head: branch,
     base: baseBranch,
     body: payload.prBody || "",
   });
 
   return {
     prUrl: pr.html_url,
-    branch: payload.branch,
+    branch,
     path: filePath,
   };
 }

--- a/backend/test/backend-outbox.service.test.js
+++ b/backend/test/backend-outbox.service.test.js
@@ -170,6 +170,44 @@ test("backend outbox rejects GitHub PR paths outside post content", async () => 
   ]);
 });
 
+test("backend outbox rejects unsafe GitHub PR branch names", async () => {
+  const repository = new FakeRepository([
+    {
+      id: "dout-pr-bad-branch",
+      stream: GITHUB_PR_STREAM,
+      aggregateId: "post:2026:test",
+      eventType: "github.pr.create-post",
+      payload: {
+        branch: "post/2026-test..bad",
+        path: "frontend/public/posts/2026/test.md",
+        markdown: "# Test\n",
+        commitMessage: "feat(post): add test",
+        prTitle: "Add test",
+        prBody: "body",
+      },
+    },
+  ]);
+
+  const result = await flushBackendDomainOutbox({
+    repository,
+    streams: GITHUB_PR_STREAM,
+    octokitFactory: () => {
+      throw new Error("Octokit should not be created for invalid branches");
+    },
+  });
+
+  assert.equal(result.processed, 0);
+  assert.equal(result.failed, 1);
+  assert.match(result.results[0].error, /GitHub PR branch is not allowed/);
+  assert.deepEqual(repository.succeeded, []);
+  assert.deepEqual(repository.failed, [
+    {
+      id: "dout-pr-bad-branch",
+      error: "GitHub PR branch is not allowed",
+    },
+  ]);
+});
+
 test("backend outbox rejects comment archive paths outside archive data", async () => {
   const repository = new FakeRepository([
     {


### PR DESCRIPTION
## Summary
- Validate GitHub PR outbox branch refs before Octokit initialization.
- Allow only expected `post/...` and `propose/...` branch shapes with Unicode letters/numbers and safe punctuation.
- Reject unsafe ref fragments such as `..`, `@{`, trailing dots, and `.lock` suffixes.

## Testing
- `cd backend && node --test test/backend-outbox.service.test.js`
- `cd backend && npm test`
- `npm run routes:check`
- `npm run outbox:check-memory`
- `git diff --check`

## Risks
- Future GitHub PR outbox event types that need a different branch prefix will need to extend the allowlist intentionally.

## Follow-ups
- Continue admin-only hardening from latest main after checks pass.