### PR TITLE
fix(config): expose wrangler export in admin

### DIFF
--- a/frontend/src/components/features/admin/ConfigManager.tsx
+++ b/frontend/src/components/features/admin/ConfigManager.tsx
@@ -347,7 +347,7 @@ export function ConfigManager() {
             <span className='text-xs text-zinc-400 dark:text-zinc-500'>Environment config</span>
           )}
         </div>
-        <div className='flex items-center gap-1.5 shrink-0'>
+        <div className='flex flex-wrap items-center justify-end gap-1.5 shrink-0'>
           <button
             type='button'
             onClick={() => exportMutation.mutate('env')}
@@ -365,6 +365,15 @@ export function ConfigManager() {
           >
             <Download className='h-3 w-3' aria-hidden='true' />
             Docker
+          </button>
+          <button
+            type='button'
+            onClick={() => exportMutation.mutate('wrangler')}
+            disabled={exportMutation.isPending}
+            className='flex items-center gap-1.5 h-8 px-3 text-xs font-medium rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-zinc-900 dark:focus-visible:ring-zinc-400 outline-none'
+          >
+            <Download className='h-3 w-3' aria-hidden='true' />
+            Wrangler
           </button>
           {mutationsEnabled ? (
             <button

--- a/frontend/src/test/ConfigManager.test.tsx
+++ b/frontend/src/test/ConfigManager.test.tsx
@@ -109,6 +109,7 @@ describe("ConfigManager protected-environment mode", () => {
 
     expect(screen.getByText(/GitOps only/i)).toBeInTheDocument();
     expect(screen.getByText(/ConfigMap and redeploy/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Wrangler/i })).toBeInTheDocument();
     expect(screen.queryByText("Save")).not.toBeInTheDocument();
 
     const input = screen.getByDisplayValue("https://noblog.nodove.com");


### PR DESCRIPTION
## Summary
- Add a Wrangler export button to the admin ConfigManager toolbar.
- Reuse the existing config export mutation with `format: wrangler` and existing `wrangler-vars.toml` download handling.
- Allow the export button group to wrap so the extra button does not force horizontal overflow.

## Testing
- `cd frontend && npm run test:run -- ConfigManager.test.tsx`
- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`
- `git diff --check`

## Risks
- The admin config toolbar now has one more action; wrapping is enabled to keep compact layouts usable.

## Follow-ups
- Continue admin-only connection and hardening review from latest main after checks pass.