### PR TITLE
fix(health): use admin client for provider checks

### DIFF
--- a/frontend/src/components/features/admin/health/SystemHealth.test.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.test.tsx
@@ -1,13 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const mockAdminFetchRaw = vi.hoisted(() => vi.fn());
+
 vi.mock("@/utils/network/apiBase", () => ({
   getApiBaseUrl: vi.fn(() => "https://worker.example.com"),
 }));
 
-import { checkBackendHealth } from "./SystemHealth";
+vi.mock("@/services/admin/apiClient", () => ({
+  adminFetchRaw: mockAdminFetchRaw,
+}));
+
+import { checkBackendHealth, getProviders } from "./SystemHealth";
 
 describe("checkBackendHealth", () => {
   afterEach(() => {
+    mockAdminFetchRaw.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -25,5 +32,44 @@ describe("checkBackendHealth", () => {
         signal: expect.any(AbortSignal),
       })
     );
+  });
+
+  it("loads AI providers through the shared admin API client", async () => {
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          data: {
+            providers: [
+              {
+                id: "openai",
+                name: "openai",
+                displayName: "OpenAI",
+                healthStatus: "healthy",
+                lastHealthCheck: null,
+                isEnabled: true,
+                modelCount: 2,
+                enabledModelCount: 1,
+              },
+            ],
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const providers = await getProviders();
+
+    expect(mockAdminFetchRaw).toHaveBeenCalledWith(
+      "https://worker.example.com/api/v1/admin/ai/providers",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(providers).toHaveLength(1);
+    expect(providers[0].displayName).toBe("OpenAI");
   });
 });

--- a/frontend/src/components/features/admin/health/SystemHealth.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.tsx
@@ -12,8 +12,7 @@ import {
   Bot,
 } from "lucide-react";
 import { getApiBaseUrl } from "@/utils/network/apiBase";
-import { useAuthStore } from "@/stores/session/useAuthStore";
-import { bearerAuth } from "@/lib/auth";
+import { adminFetchRaw } from "@/services/admin/apiClient";
 import {
   useFeatureFlagsStore,
   type FeatureFlags,
@@ -81,11 +80,11 @@ async function checkRAGHealth(): Promise<{
   }
 }
 
-async function getProviders(token: string): Promise<ProviderHealth[]> {
+// eslint-disable-next-line react-refresh/only-export-components
+export async function getProviders(): Promise<ProviderHealth[]> {
   const base = getApiBaseUrl();
   try {
-    const res = await fetch(`${base}/api/v1/admin/ai/providers`, {
-      headers: bearerAuth(token),
+    const res = await adminFetchRaw(`${base}/api/v1/admin/ai/providers`, {
       signal: AbortSignal.timeout(10000),
     });
     if (!res.ok) return [];
@@ -98,15 +97,13 @@ async function getProviders(token: string): Promise<ProviderHealth[]> {
 
 async function checkProviderHealth(
   providerId: string,
-  token: string,
 ): Promise<{ status: string; latencyMs?: number; error?: string }> {
   const base = getApiBaseUrl();
   try {
-    const res = await fetch(
+    const res = await adminFetchRaw(
       `${base}/api/v1/admin/ai/providers/${providerId}/health`,
       {
         method: "PUT",
-        headers: bearerAuth(token),
         signal: AbortSignal.timeout(15000),
       },
     );
@@ -182,8 +179,6 @@ const FEATURE_LABELS: Record<keyof FeatureFlags, string> = {
 };
 
 export function SystemHealth() {
-  const { getValidAccessToken } = useAuthStore();
-
   const [coreServices, setCoreServices] = useState<ServiceStatus[]>([
     { name: "backend", displayName: "Backend API", status: "unknown" },
   ]);
@@ -245,35 +240,29 @@ export function SystemHealth() {
 
   const fetchProviders = useCallback(async () => {
     setProvidersLoading(true);
-    const token = await getValidAccessToken();
-    if (token) {
-      const result = await getProviders(token);
-      setProviders(result);
-    }
+    const result = await getProviders();
+    setProviders(result);
     setProvidersLoading(false);
-  }, [getValidAccessToken]);
+  }, []);
 
   const handleCheckProviderHealth = useCallback(
     async (providerId: string) => {
       setCheckingProvider(providerId);
-      const token = await getValidAccessToken();
-      if (token) {
-        const result = await checkProviderHealth(providerId, token);
-        setProviders((prev) =>
-          prev.map((p) =>
-            p.id === providerId
-              ? {
-                  ...p,
-                  healthStatus: result.status,
-                  lastHealthCheck: new Date().toISOString(),
-                }
-              : p,
-          ),
-        );
-      }
+      const result = await checkProviderHealth(providerId);
+      setProviders((prev) =>
+        prev.map((p) =>
+          p.id === providerId
+            ? {
+                ...p,
+                healthStatus: result.status,
+                lastHealthCheck: new Date().toISOString(),
+              }
+            : p,
+        ),
+      );
       setCheckingProvider(null);
     },
-    [getValidAccessToken],
+    [],
   );
 
   const refreshFlags = useCallback(() => {


### PR DESCRIPTION
## Summary
- Route admin health AI provider listing through the shared `adminFetchRaw` client.
- Route provider health checks through the same client so token refresh/retry behavior matches other admin API calls.
- Remove manual bearer header construction from SystemHealth provider calls.

## Testing
- `cd frontend && npm run test:run -- src/components/features/admin/health/SystemHealth.test.tsx`
- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`
- `git diff --check`

## Risks
- If no admin token is available, provider health now follows the shared admin client path and returns an empty/down state after the server rejects the request.

## Follow-ups
- Continue admin-only connection and hardening review from latest main after checks pass.