### PR TITLE
fix(rag): require admin for management routes

### DIFF
--- a/backend/src/routes/rag.js
+++ b/backend/src/routes/rag.js
@@ -19,6 +19,7 @@
 import express from 'express';
 import crypto from 'node:crypto';
 import { config } from '../config.js';
+import requireAdmin from '../middleware/adminAuth.js';
 import { requireFeature } from '../middleware/featureFlags.js';
 import { validateBody } from '../middleware/validation.js';
 import {
@@ -500,7 +501,7 @@ router.post('/search', validateBody(ragSearchBodySchema), async (req, res) => {
  *   }
  * }
  */
-router.post('/embed', validateBody(ragEmbedBodySchema), async (req, res) => {
+router.post('/embed', requireAdmin, validateBody(ragEmbedBodySchema), async (req, res) => {
   try {
     const { texts } = req.body;
 
@@ -800,7 +801,7 @@ router.post('/memories/batch-delete', validateBody(memoriesBatchDeleteBodySchema
  *   collection?: string  // Optional custom collection name
  * }
  */
-router.post('/index', validateBody(ragIndexBodySchema), async (req, res) => {
+router.post('/index', requireAdmin, validateBody(ragIndexBodySchema), async (req, res) => {
   try {
     const { documents, collection } = req.body;
     const collectionName = collection || config.rag.chromaCollection;
@@ -836,7 +837,7 @@ router.post('/index', validateBody(ragIndexBodySchema), async (req, res) => {
 /**
  * DELETE /index/:documentId - 인덱스에서 문서 삭제
  */
-router.delete('/index/:documentId', async (req, res) => {
+router.delete('/index/:documentId', requireAdmin, async (req, res) => {
   try {
     const { documentId } = req.params;
     const { collection } = req.query;
@@ -874,7 +875,7 @@ router.delete('/index/:documentId', async (req, res) => {
 /**
  * GET /status - 인덱스 상태 확인
  */
-router.get('/status', async (req, res) => {
+router.get('/status', requireAdmin, async (req, res) => {
   try {
     const { collection } = req.query;
     const collectionName = collection || config.rag.chromaCollection;
@@ -933,7 +934,7 @@ router.get('/status', async (req, res) => {
 /**
  * GET /collections - 모든 컬렉션 목록
  */
-router.get('/collections', async (req, res) => {
+router.get('/collections', requireAdmin, async (req, res) => {
   try {
     const collectionsBase = getChromaCollectionsBase();
     

--- a/backend/test/rag-admin-auth.test.js
+++ b/backend/test/rag-admin-auth.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import express from 'express';
+
+process.env.ADMIN_BEARER_TOKEN = 'rag-admin-token';
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '15m';
+process.env.APP_ENV = 'test';
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || 'gpt-4.1-mini';
+process.env.FEATURE_RAG_ENABLED = 'true';
+
+const { default: ragRouter } = await import('../src/routes/rag.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/rag', ragRouter);
+  return app;
+}
+
+async function withServer(callback) {
+  const server = http.createServer(createApp());
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+    await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+test('rag management endpoints require admin authorization', async () => {
+  await withServer(async (baseUrl) => {
+    const requests = [
+      fetch(`${baseUrl}/api/v1/rag/embed`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ texts: ['hello'] }),
+      }),
+      fetch(`${baseUrl}/api/v1/rag/index`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          documents: [{ id: 'doc-1', content: 'hello world' }],
+        }),
+      }),
+      fetch(`${baseUrl}/api/v1/rag/index/doc-1`, { method: 'DELETE' }),
+      fetch(`${baseUrl}/api/v1/rag/status`),
+      fetch(`${baseUrl}/api/v1/rag/collections`),
+    ];
+
+    const responses = await Promise.all(requests);
+    assert.deepEqual(
+      responses.map((response) => response.status),
+      [401, 401, 401, 401, 401],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add backend `requireAdmin` protection to RAG management endpoints that the Worker gateway already treats as admin-only.
- Protect `/api/v1/rag/embed`, `/status`, `/collections`, `/index`, and `/index/:documentId` before validation or external Chroma/OpenAI calls.
- Add a regression test proving unauthenticated management requests return 401.

## Testing
- `cd backend && node --test test/rag-admin-auth.test.js`
- `cd backend && npm test`
- `npm run routes:check`
- `git diff --check`

## Risks
- Direct backend callers now need admin credentials for RAG embedding and management routes; Worker/admin clients already send admin auth for these paths.

## Follow-ups
- Continue admin-only hardening from latest main after checks pass.