### PR TITLE
fix(analytics): require admin for stats refresh

### DIFF
--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -9,6 +9,7 @@ import {
   isPgConfigured,
 } from '../repositories/analytics.repository.js';
 import { httpCache, invalidateCacheByPrefix } from '../middleware/httpCache.js';
+import requireAdmin from '../middleware/adminAuth.js';
 import { createLogger } from '../lib/logger.js';
 import { buildDataOwnershipHeaders } from '../../../shared/src/contracts/data-ownership.js';
 import { runIdempotent } from '../lib/idempotency.js';
@@ -149,7 +150,7 @@ router.get('/trending', requirePg, httpCache({ ttl: 300, prefix: 'analytics' }),
   }
 });
 
-router.post('/refresh-stats', requirePg, async (req, res, next) => {
+router.post('/refresh-stats', requireAdmin, requirePg, async (req, res, next) => {
   try {
     applyDataOwnership(res, 'analytics.post_stats');
     const refreshed = await refreshPeriodicStats();

--- a/backend/test/analytics-admin-auth.test.js
+++ b/backend/test/analytics-admin-auth.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import express from 'express';
+
+process.env.ADMIN_BEARER_TOKEN = 'analytics-admin-token';
+process.env.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '15m';
+process.env.APP_ENV = 'test';
+process.env.AI_DEFAULT_MODEL = process.env.AI_DEFAULT_MODEL || 'gpt-4.1-mini';
+delete process.env.DATABASE_URL;
+
+const { default: analyticsRouter } = await import('../src/routes/analytics.js');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/analytics', analyticsRouter);
+  return app;
+}
+
+async function withServer(callback) {
+  const server = http.createServer(createApp());
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+    await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+test('refresh-stats requires admin authorization before checking PostgreSQL configuration', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/analytics/refresh-stats`, {
+      method: 'POST',
+    });
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      error: 'Unauthorized',
+    });
+  });
+});
+
+test('refresh-stats preserves the existing PostgreSQL configuration response for authorized admins', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/analytics/refresh-stats`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
+      },
+    });
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      error: 'Analytics service not configured (DATABASE_URL missing)',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Require admin authorization on backend `POST /api/v1/analytics/refresh-stats` before PostgreSQL configuration checks or refresh work.
- Add focused auth-order coverage for unauthenticated and authorized-but-unconfigured requests.

## Testing
- `cd backend && node --test test/analytics-admin-auth.test.js`
- `cd backend && npm test`
- `npm run routes:check`
- `git diff --check`

## Risks
- Low; public analytics read/write endpoints are unchanged, and the Worker route already required admin before proxying this refresh endpoint.

## Follow-ups
- `analytics/admin/editor-picks` remains Worker-owned per the canonical owner matrix, so backend duplicate management routes were not added.