### PR TITLE
fix(analytics): allow trusted gateway stats refresh

### DIFF
--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -9,7 +9,7 @@ import {
   isPgConfigured,
 } from '../repositories/analytics.repository.js';
 import { httpCache, invalidateCacheByPrefix } from '../middleware/httpCache.js';
-import requireAdmin from '../middleware/adminAuth.js';
+import requireAdmin, { isAdminRequest } from '../middleware/adminAuth.js';
 import { createLogger } from '../lib/logger.js';
 import { buildDataOwnershipHeaders } from '../../../shared/src/contracts/data-ownership.js';
 import { runIdempotent } from '../lib/idempotency.js';
@@ -36,6 +36,18 @@ const requireD1 = (req, res, next) => {
     return res.status(503).json({ ok: false, error: 'Editor picks not configured (D1 credentials missing)' });
   }
   next();
+};
+
+const requireAdminOrTrustedGateway = (req, res, next) => {
+  if (
+    isAdminRequest(req) ||
+    req.gatewaySignatureVerified === true ||
+    req.gatewaySignatureBypassedByBackendKey === true
+  ) {
+    return next();
+  }
+
+  return requireAdmin(req, res, next);
 };
 
 router.post('/view', requirePg, async (req, res, next) => {
@@ -150,7 +162,7 @@ router.get('/trending', requirePg, httpCache({ ttl: 300, prefix: 'analytics' }),
   }
 });
 
-router.post('/refresh-stats', requireAdmin, requirePg, async (req, res, next) => {
+router.post('/refresh-stats', requireAdminOrTrustedGateway, requirePg, async (req, res, next) => {
   try {
     applyDataOwnership(res, 'analytics.post_stats');
     const refreshed = await refreshPeriodicStats();

--- a/backend/test/analytics-admin-auth.test.js
+++ b/backend/test/analytics-admin-auth.test.js
@@ -11,15 +11,21 @@ delete process.env.DATABASE_URL;
 
 const { default: analyticsRouter } = await import('../src/routes/analytics.js');
 
-function createApp() {
+function createApp({ trustedGateway = false } = {}) {
   const app = express();
   app.use(express.json());
+  if (trustedGateway) {
+    app.use((req, _res, next) => {
+      req.gatewaySignatureVerified = true;
+      next();
+    });
+  }
   app.use('/api/v1/analytics', analyticsRouter);
   return app;
 }
 
-async function withServer(callback) {
-  const server = http.createServer(createApp());
+async function withServer(callback, options) {
+  const server = http.createServer(createApp(options));
   await new Promise((resolve) => {
     server.listen(0, '127.0.0.1', resolve);
   });
@@ -65,4 +71,18 @@ test('refresh-stats preserves the existing PostgreSQL configuration response for
       error: 'Analytics service not configured (DATABASE_URL missing)',
     });
   });
+});
+
+test('refresh-stats allows already verified gateway requests for scheduled refreshes', async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/v1/analytics/refresh-stats`, {
+      method: 'POST',
+    });
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      error: 'Analytics service not configured (DATABASE_URL missing)',
+    });
+  }, { trustedGateway: true });
 });


### PR DESCRIPTION
## Summary
- Keep `POST /api/v1/analytics/refresh-stats` admin-only for direct/client requests.
- Allow requests that already passed backend gateway verification so Worker cron can continue scheduled stats refreshes after PR #93.
- Extend analytics auth tests to cover unauthenticated, admin-token, and trusted-gateway paths.

## Testing
- `cd backend && node --test test/analytics-admin-auth.test.js`
- `cd backend && npm test`
- `npm run routes:check`
- `git diff --check`

## Risks
- Low; the trusted gateway allowance is scoped to this one refresh route and depends on flags set by the backend gateway-signature middleware, not client-supplied headers.

## Follow-ups
- Continue admin-only route/client contract review from latest `main`.