### PR TITLE
fix(health): use admin client for agent check

### DIFF
--- a/frontend/src/components/features/admin/health/SystemHealth.test.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.test.tsx
@@ -10,7 +10,11 @@ vi.mock("@/services/admin/apiClient", () => ({
   adminFetchRaw: mockAdminFetchRaw,
 }));
 
-import { checkBackendHealth, getProviders } from "./SystemHealth";
+import {
+  checkAgentHealthRequest,
+  checkBackendHealth,
+  getProviders,
+} from "./SystemHealth";
 
 describe("checkBackendHealth", () => {
   afterEach(() => {
@@ -71,5 +75,41 @@ describe("checkBackendHealth", () => {
     );
     expect(providers).toHaveLength(1);
     expect(providers[0].displayName).toBe("OpenAI");
+  });
+
+  it("checks agent health through the shared admin API client", async () => {
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          data: {
+            status: "healthy",
+            llm: { ok: true },
+            tools: { count: 7 },
+            uptime: 120,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const health = await checkAgentHealthRequest();
+
+    expect(mockAdminFetchRaw).toHaveBeenCalledWith(
+      "https://worker.example.com/api/v1/agent/health",
+      expect.objectContaining({
+        method: "GET",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(health).toEqual({
+      status: "healthy",
+      llm: { ok: true },
+      tools: { count: 7 },
+      uptime: 120,
+    });
   });
 });

--- a/frontend/src/components/features/admin/health/SystemHealth.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.tsx
@@ -128,10 +128,11 @@ interface AgentHealth {
   uptime?: number;
 }
 
-async function checkAgentHealthRequest(): Promise<AgentHealth> {
+// eslint-disable-next-line react-refresh/only-export-components
+export async function checkAgentHealthRequest(): Promise<AgentHealth> {
   const base = getApiBaseUrl();
   try {
-    const res = await fetch(`${base}/api/v1/agent/health`, {
+    const res = await adminFetchRaw(`${base}/api/v1/agent/health`, {
       method: "GET",
       signal: AbortSignal.timeout(8000),
     });


### PR DESCRIPTION
## Summary
- Route the admin System Health Agent check through `adminFetchRaw` instead of bare `fetch`.
- Export the request helper for focused coverage and assert the agent health endpoint uses the shared admin API client.

## Testing
- `cd frontend && npm run test:run -- src/components/features/admin/health/SystemHealth.test.tsx`
- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`
- `git diff --check`

## Risks
- Low; the visible UI is unchanged, but the Agent health call now gets the same admin token refresh/retry behavior as other protected admin health calls.

## Follow-ups
- Continue admin-only route/client contract review from latest `main`.