### PR TITLE
fix(images): use admin client for ai image requests

### DIFF
--- a/frontend/src/services/session/adminImages.ts
+++ b/frontend/src/services/session/adminImages.ts
@@ -1,4 +1,4 @@
-import { bearerAuth } from '@/lib/auth';
+import { adminFetchRaw } from '@/services/admin/apiClient';
 import { getApiBaseUrl } from '@/utils/network/apiBase';
 
 export type AdminAiImageQuality = 'low' | 'medium' | 'high' | 'standard' | 'hd' | 'auto';
@@ -87,15 +87,14 @@ function getErrorMessage(payload: unknown, fallback: string): string {
 
 export async function generatePostImages(
   payload: GeneratePostImagesPayload,
-  token: string,
+  _token: string,
 ): Promise<GeneratePostImagesResponse> {
   const base = getApiBaseUrl();
-  const response = await fetch(`${base}/api/v1/admin/ai-images/generate`, {
+  const response = await adminFetchRaw(`${base}/api/v1/admin/ai-images/generate`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Idempotency-Key': createIdempotencyKey(),
-      ...bearerAuth(token),
     },
     body: JSON.stringify({
       ...payload,
@@ -114,12 +113,10 @@ export async function generatePostImages(
 }
 
 export async function getAdminAiImagesHealth(
-  token: string,
+  _token: string,
 ): Promise<AdminAiImagesHealth> {
   const base = getApiBaseUrl();
-  const response = await fetch(`${base}/api/v1/admin/ai-images/health`, {
-    headers: bearerAuth(token),
-  });
+  const response = await adminFetchRaw(`${base}/api/v1/admin/ai-images/health`);
   const json = await response.json().catch(() => ({}));
   if (!response.ok || !json?.ok) {
     throw new Error(getErrorMessage(json, 'Failed to load AI image health'));

--- a/frontend/src/test/adminImages.test.ts
+++ b/frontend/src/test/adminImages.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockAdminFetchRaw = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/network/apiBase', () => ({
+  getApiBaseUrl: vi.fn(() => 'https://worker.example.com'),
+}));
+
+vi.mock('@/services/admin/apiClient', () => ({
+  adminFetchRaw: mockAdminFetchRaw,
+}));
+
+import {
+  generatePostImages,
+  getAdminAiImagesHealth,
+} from '@/services/session/adminImages';
+
+describe('admin image service', () => {
+  afterEach(() => {
+    mockAdminFetchRaw.mockReset();
+  });
+
+  it('generates images through the shared admin API client', async () => {
+    const data = {
+      dir: '/images/2026/test-post/ai',
+      model: 'test-image-model',
+      created: 1,
+      durationMs: 25,
+      usage: null,
+      metadata: null,
+      items: [],
+    };
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, data }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await generatePostImages(
+      {
+        year: 2026,
+        slug: 'test-post',
+        prompt: 'generate a cover image',
+      },
+      'expired-access-token',
+    );
+
+    expect(result).toEqual(data);
+    expect(mockAdminFetchRaw).toHaveBeenCalledTimes(1);
+
+    const [url, options] = mockAdminFetchRaw.mock.calls[0];
+    expect(url).toBe('https://worker.example.com/api/v1/admin/ai-images/generate');
+    expect(options).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'Idempotency-Key': expect.stringMatching(/^admin-ai-image:/),
+        }),
+      }),
+    );
+    expect(JSON.parse(String(options.body))).toEqual({
+      year: '2026',
+      slug: 'test-post',
+      prompt: 'generate a cover image',
+      n: 1,
+      size: '1024x1024',
+      quality: 'medium',
+      outputFormat: 'png',
+    });
+  });
+
+  it('loads AI image health through the shared admin API client', async () => {
+    const data = {
+      enabled: true,
+      configured: true,
+      baseUrlConfigured: true,
+      apiKeyConfigured: true,
+      model: 'test-image-model',
+      maxCount: 2,
+      timeoutMs: 10000,
+    };
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, data }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await getAdminAiImagesHealth('expired-access-token');
+
+    expect(result).toEqual(data);
+    expect(mockAdminFetchRaw).toHaveBeenCalledWith(
+      'https://worker.example.com/api/v1/admin/ai-images/health',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Route admin AI image generate/health requests through `adminFetchRaw` so they get shared admin token refresh/retry behavior.
- Remove manual bearer header construction from the JSON admin image service calls.
- Add focused service tests for generate and health request routing.

## Testing
- `cd frontend && npm run test:run -- src/test/adminImages.test.ts`
- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`
- `git diff --check`

## Risks
- Low; the request payloads and response parsing are unchanged. Function signatures still accept the token argument for current callers.

## Follow-ups
- Review FormData admin image upload paths separately because they need content-type handling in the shared admin client.