### PR TITLE
fix(admin): use shared client for post image uploads

### DIFF
--- a/frontend/src/services/admin/apiClient.ts
+++ b/frontend/src/services/admin/apiClient.ts
@@ -17,9 +17,12 @@ interface AdminApiFetchOptions extends Omit<RequestInit, 'body'> {
 function buildAdminHeaders(
   token: string | null,
   headers?: HeadersInit,
+  requestBody?: unknown,
 ): Headers {
   const nextHeaders = new Headers(headers);
-  if (!nextHeaders.has('Content-Type')) {
+  const isFormDataBody =
+    typeof FormData !== 'undefined' && requestBody instanceof FormData;
+  if (!nextHeaders.has('Content-Type') && !isFormDataBody) {
     nextHeaders.set('Content-Type', 'application/json');
   }
   if (token) {
@@ -54,7 +57,7 @@ function buildAdminRequestInit(
 ): RequestInit {
   return {
     ...options,
-    headers: buildAdminHeaders(token, options.headers),
+    headers: buildAdminHeaders(token, options.headers, body ?? options.body),
     ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
   };
 }

--- a/frontend/src/services/session/admin.ts
+++ b/frontend/src/services/session/admin.ts
@@ -1,5 +1,5 @@
 import { getApiBaseUrl } from '@/utils/network/apiBase';
-import { bearerAuth } from '@/lib/auth';
+import { adminFetchRaw } from '@/services/admin/apiClient';
 
 export type CreatePostPayload = {
   title: string;
@@ -12,7 +12,7 @@ export type CreatePostPayload = {
 
 export async function createPostPR(
   payload: CreatePostPayload,
-  token: string
+  _token: string
 ): Promise<{
   prUrl?: string;
   status?: 'pending' | 'succeeded';
@@ -21,12 +21,8 @@ export async function createPostPR(
   path: string;
 }> {
   const base = getApiBaseUrl();
-  const res = await fetch(`${base}/api/v1/admin/create-post-pr`, {
+  const res = await adminFetchRaw(`${base}/api/v1/admin/create-post-pr`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...bearerAuth(token),
-    },
     body: JSON.stringify(payload),
   });
   const json = await res.json().catch(() => ({}));
@@ -45,7 +41,7 @@ export async function createPostPR(
 export async function uploadPostImages(
   params: { year: string | number; slug: string },
   files: File[],
-  token: string
+  _token: string
 ): Promise<{
   dir: string;
   items: Array<{ url: string; variantWebp?: { url: string } | null }>;
@@ -56,7 +52,7 @@ export async function uploadPostImages(
   const uploadedItems: Array<{ url: string; variantWebp?: { url: string } | null }> = [];
 
   for (const file of files) {
-    const directResult = await uploadPostImageDirect(normalizedBase, postId, file, token);
+    const directResult = await uploadPostImageDirect(normalizedBase, postId, file);
     if (directResult) {
       uploadedItems.push(directResult);
       continue;
@@ -64,7 +60,7 @@ export async function uploadPostImages(
     if (uploadedItems.length > 0) {
       throw new Error('Direct image upload failed after partial completion');
     }
-    return uploadPostImagesCompatibility(params, files, token);
+    return uploadPostImagesCompatibility(params, files);
   }
 
   return {
@@ -76,15 +72,10 @@ export async function uploadPostImages(
 async function uploadPostImageDirect(
   baseUrl: string,
   postId: string,
-  file: File,
-  token: string
+  file: File
 ): Promise<{ url: string; variantWebp?: { url: string } | null } | null> {
-  const presign = await fetch(`${baseUrl}/api/v1/images/presign`, {
+  const presign = await adminFetchRaw(`${baseUrl}/api/v1/images/presign`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...bearerAuth(token),
-    },
     body: JSON.stringify({
       filename: file.name,
       contentType: file.type,
@@ -105,9 +96,8 @@ async function uploadPostImageDirect(
   formData.append('file', file, file.name);
   formData.append('postId', postId);
 
-  const uploadResponse = await fetch(uploadUrl, {
+  const uploadResponse = await adminFetchRaw(uploadUrl, {
     method: 'POST',
-    headers: bearerAuth(token),
     body: formData,
   });
 
@@ -124,8 +114,7 @@ async function uploadPostImageDirect(
 
 async function uploadPostImagesCompatibility(
   params: { year: string | number; slug: string },
-  files: File[],
-  token: string
+  files: File[]
 ): Promise<{
   dir: string;
   items: Array<{ url: string; variantWebp?: { url: string } | null }>;
@@ -136,9 +125,8 @@ async function uploadPostImagesCompatibility(
   fd.append('slug', params.slug);
   for (const f of files) fd.append('files', f, f.name);
 
-  const res = await fetch(`${base}/api/v1/images/upload`, {
+  const res = await adminFetchRaw(`${base}/api/v1/images/upload`, {
     method: 'POST',
-    headers: bearerAuth(token),
     body: fd,
   });
   const json = await res.json().catch(() => ({}));

--- a/frontend/src/test/adminApiClient.test.ts
+++ b/frontend/src/test/adminApiClient.test.ts
@@ -95,4 +95,29 @@ describe('admin API client auth retry', () => {
     expect(authorizationHeader(fetchMock, 1)).toBe('Bearer new-access-token');
     expect(mockRefreshAccessToken).toHaveBeenCalledWith('refresh-token');
   });
+
+  it('does not force a JSON content type for FormData adminFetchRaw requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const formData = new FormData();
+    formData.append('file', new Blob(['image']), 'cover.png');
+
+    const response = await adminFetchRaw(
+      'https://api.example.com/api/v1/images/upload-direct',
+      {
+        method: 'POST',
+        body: formData,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get('Authorization')).toBe('Bearer old-access-token');
+    expect(headers.get('Content-Type')).toBeNull();
+    expect(init?.body).toBe(formData);
+  });
 });

--- a/frontend/src/test/adminSessionService.test.ts
+++ b/frontend/src/test/adminSessionService.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockAdminFetchRaw = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/network/apiBase', () => ({
+  getApiBaseUrl: vi.fn(() => 'https://worker.example.com'),
+}));
+
+vi.mock('@/services/admin/apiClient', () => ({
+  adminFetchRaw: mockAdminFetchRaw,
+}));
+
+import {
+  createPostPR,
+  uploadPostImages,
+} from '@/services/session/admin';
+
+describe('admin session service', () => {
+  afterEach(() => {
+    mockAdminFetchRaw.mockReset();
+  });
+
+  it('creates post PRs through the shared admin API client', async () => {
+    const data = {
+      prUrl: 'https://github.com/example/blog/pull/1',
+      status: 'succeeded',
+      branch: 'post/test-post',
+      path: 'frontend/public/posts/2026/test-post.md',
+    };
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, data }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await createPostPR(
+      {
+        title: 'Test Post',
+        slug: 'test-post',
+        year: 2026,
+        content: '# Test',
+      },
+      'expired-access-token',
+    );
+
+    expect(result).toEqual(data);
+    expect(mockAdminFetchRaw).toHaveBeenCalledTimes(1);
+
+    const [url, options] = mockAdminFetchRaw.mock.calls[0];
+    expect(url).toBe('https://worker.example.com/api/v1/admin/create-post-pr');
+    expect(options).toEqual(expect.objectContaining({ method: 'POST' }));
+    expect(JSON.parse(String(options.body))).toEqual({
+      title: 'Test Post',
+      slug: 'test-post',
+      year: 2026,
+      content: '# Test',
+    });
+  });
+
+  it('uploads post images through the shared admin API client', async () => {
+    mockAdminFetchRaw
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            data: { uploadUrl: '/images/upload-direct' },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            data: { url: '/images/2026/test-post/cover.png' },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+
+    const file = new File(['image'], 'cover.png', { type: 'image/png' });
+    const result = await uploadPostImages(
+      { year: 2026, slug: 'test-post' },
+      [file],
+      'expired-access-token',
+    );
+
+    expect(result).toEqual({
+      dir: '/images/2026/test-post',
+      items: [
+        {
+          url: '/images/2026/test-post/cover.png',
+          variantWebp: null,
+        },
+      ],
+    });
+    expect(mockAdminFetchRaw).toHaveBeenCalledTimes(2);
+
+    const [presignUrl, presignOptions] = mockAdminFetchRaw.mock.calls[0];
+    expect(presignUrl).toBe('https://worker.example.com/api/v1/images/presign');
+    expect(JSON.parse(String(presignOptions.body))).toEqual({
+      filename: 'cover.png',
+      contentType: 'image/png',
+      postId: '2026/test-post',
+    });
+
+    const [uploadUrl, uploadOptions] = mockAdminFetchRaw.mock.calls[1];
+    expect(uploadUrl).toBe('https://worker.example.com/api/v1/images/upload-direct');
+    expect(uploadOptions.body).toBeInstanceOf(FormData);
+  });
+});


### PR DESCRIPTION
## Summary
- Make `adminFetchRaw` preserve browser-managed FormData content type instead of forcing JSON.
- Route admin post PR creation, image presign/direct upload, and compatibility image upload through the shared admin client.
- Add focused tests for FormData header behavior and admin post/image service routing.

## Testing
- `cd frontend && npm run test:run -- src/test/adminApiClient.test.ts src/test/adminSessionService.test.ts`
- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`
- `git diff --check`

## Risks
- Moderate-low; FormData upload requests now rely on `adminFetchRaw` for Authorization and retry, while leaving multipart boundaries to the browser. Existing function signatures are preserved for callers.

## Follow-ups
- Continue admin-only route/client contract review from latest `main`.