### PR TITLE
fix(agent): use admin client for blog runs

### DIFF
--- a/frontend/src/services/session/agent.ts
+++ b/frontend/src/services/session/agent.ts
@@ -1,4 +1,4 @@
-import { bearerAuth } from '@/lib/auth';
+import { adminFetchRaw } from '@/services/admin/apiClient';
 import { getApiBaseUrl } from '@/utils/network/apiBase';
 
 export type AgentEditorAction =
@@ -49,15 +49,14 @@ export async function runBlogAgent(
     maxIterations?: number;
     temperature?: number;
   },
-  token: string,
+  _token: string,
 ): Promise<AgentRunResponse> {
   const base = getApiBaseUrl();
-  const response = await fetch(`${base}/api/v1/agent/run`, {
+  const response = await adminFetchRaw(`${base}/api/v1/agent/run`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Idempotency-Key': createIdempotencyKey(),
-      ...bearerAuth(token),
     },
     body: JSON.stringify({
       message: payload.message,

--- a/frontend/src/test/adminAgentService.test.ts
+++ b/frontend/src/test/adminAgentService.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockAdminFetchRaw = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/network/apiBase', () => ({
+  getApiBaseUrl: vi.fn(() => 'https://worker.example.com'),
+}));
+
+vi.mock('@/services/admin/apiClient', () => ({
+  adminFetchRaw: mockAdminFetchRaw,
+}));
+
+import { runBlogAgent } from '@/services/session/agent';
+
+describe('admin agent service', () => {
+  afterEach(() => {
+    mockAdminFetchRaw.mockReset();
+  });
+
+  it('runs the blog agent through the shared admin API client', async () => {
+    const data = {
+      response: 'Draft updated',
+      actions: [{ type: 'set_title', value: 'New title' }],
+      sessionId: 'session-1',
+      toolsUsed: ['blog_ops'],
+      memoryUpdated: false,
+      model: 'test-model',
+    };
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, data }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await runBlogAgent(
+      {
+        message: 'Improve this draft',
+        sessionId: 'session-1',
+      },
+      'expired-access-token',
+    );
+
+    expect(result).toEqual(data);
+    expect(mockAdminFetchRaw).toHaveBeenCalledTimes(1);
+
+    const [url, options] = mockAdminFetchRaw.mock.calls[0];
+    expect(url).toBe('https://worker.example.com/api/v1/agent/run');
+    expect(options).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'Idempotency-Key': expect.stringMatching(/^agent-run:/),
+        }),
+      }),
+    );
+    expect(JSON.parse(String(options.body))).toEqual({
+      message: 'Improve this draft',
+      sessionId: 'session-1',
+      mode: 'blog',
+      maxIterations: 6,
+      temperature: 0.4,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Route admin blog agent runs through `adminFetchRaw` instead of manual bearer fetch.
- Preserve the idempotency header and blog-mode request payload.
- Add focused service coverage for the admin agent request contract.

## Testing
- `cd frontend && npm run test:run -- src/test/adminAgentService.test.ts`
- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`
- `git diff --check`

## Risks
- Low; payload and response parsing are unchanged, and the function signature still accepts the token argument used by current callers.

## Follow-ups
- Continue admin-only route/client contract review from latest `main`.