### PR TITLE
fix(logs): use admin client for stream connection

### DIFF
--- a/frontend/src/components/features/admin/logs/LogViewer.test.tsx
+++ b/frontend/src/components/features/admin/logs/LogViewer.test.tsx
@@ -1,17 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  mockBearerAuth,
   mockGetApiBaseUrl,
   mockGetValidAccessToken,
 } = vi.hoisted(() => ({
-  mockBearerAuth: vi.fn((token: string) => ({ Authorization: `Bearer ${token}` })),
   mockGetApiBaseUrl: vi.fn(() => "https://admin.example.com"),
   mockGetValidAccessToken: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  bearerAuth: mockBearerAuth,
 }));
 
 vi.mock("@/utils/network/apiBase", () => ({
@@ -92,20 +86,15 @@ describe("LogViewer stream controller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
-    vi.stubGlobal("fetch", mockFetch);
     mockGetApiBaseUrl.mockReturnValue("https://admin.example.com");
-    mockBearerAuth.mockImplementation((token: string) => ({
-      Authorization: `Bearer ${token}`,
-    }));
   });
 
   afterEach(() => {
     vi.clearAllTimers();
     vi.useRealTimers();
-    vi.unstubAllGlobals();
   });
 
-  it("sends the bearer token in the stream request", async () => {
+  it("uses the shared admin stream fetcher after resolving a token", async () => {
     mockGetValidAccessToken.mockResolvedValue("test-token");
     mockFetch.mockResolvedValue(createResponse([]));
 
@@ -114,6 +103,7 @@ describe("LogViewer stream controller", () => {
 
     await connectLogStream({
       abortRef: { current: null },
+      fetchStream: mockFetch,
       getValidAccessToken: mockGetValidAccessToken,
       pausedRef: { current: false },
       reconnect: vi.fn(),
@@ -121,14 +111,13 @@ describe("LogViewer stream controller", () => {
       setLogs: state.setLogs,
     });
 
-    expect(mockBearerAuth).toHaveBeenCalledWith("test-token");
+    expect(mockGetValidAccessToken).toHaveBeenCalled();
     expect(mockFetch).toHaveBeenCalledWith(
       "https://admin.example.com/api/v1/admin/logs/stream",
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
           "Content-Type": "text/event-stream",
-          Authorization: "Bearer test-token",
         }),
       }),
     );
@@ -159,6 +148,7 @@ describe("LogViewer stream controller", () => {
     async function connect() {
       await connectLogStream({
         abortRef,
+        fetchStream: mockFetch,
         getValidAccessToken: mockGetValidAccessToken,
         pausedRef: { current: false },
         reconnect: () => {
@@ -208,6 +198,7 @@ describe("LogViewer stream controller", () => {
 
     await connectLogStream({
       abortRef,
+      fetchStream: mockFetch,
       getValidAccessToken: mockGetValidAccessToken,
       pausedRef,
       reconnect,
@@ -224,6 +215,7 @@ describe("LogViewer stream controller", () => {
 
     await connectLogStream({
       abortRef,
+      fetchStream: mockFetch,
       getValidAccessToken: mockGetValidAccessToken,
       pausedRef,
       reconnect,

--- a/frontend/src/components/features/admin/logs/LogViewer.tsx
+++ b/frontend/src/components/features/admin/logs/LogViewer.tsx
@@ -16,7 +16,7 @@ import {
 } from "lucide-react";
 import { getApiBaseUrl } from "@/utils/network/apiBase";
 import { useAuthStore } from "@/stores/session/useAuthStore";
-import { bearerAuth } from "@/lib/auth";
+import { adminFetchRaw } from "@/services/admin/apiClient";
 import {
   findSSEFrameBoundary,
   parseSSEFrame,
@@ -106,7 +106,7 @@ export async function parseLogStream(
 // eslint-disable-next-line react-refresh/only-export-components
 export async function connectLogStream({
   abortRef,
-  fetchImpl = fetch,
+  fetchStream = adminFetchRaw,
   getValidAccessToken,
   pausedRef,
   reconnect,
@@ -114,7 +114,7 @@ export async function connectLogStream({
   setLogs,
 }: {
   abortRef: AbortControllerRef;
-  fetchImpl?: typeof fetch;
+  fetchStream?: typeof adminFetchRaw;
   getValidAccessToken: () => Promise<string | null>;
   pausedRef: BooleanRef;
   reconnect: () => void;
@@ -138,11 +138,10 @@ export async function connectLogStream({
   abortRef.current = controller;
 
   try {
-    const response = await fetchImpl(url, {
+    const response = await fetchStream(url, {
       method: "GET",
       headers: {
         "Content-Type": "text/event-stream",
-        ...bearerAuth(token),
       },
       signal: controller.signal,
     });


### PR DESCRIPTION
## Summary
- Route the admin log stream connection through `adminFetchRaw` while preserving SSE parsing and reconnect behavior.
- Keep the preflight `getValidAccessToken()` check, then let the shared admin client handle Authorization and 401 refresh/retry.
- Update LogViewer stream tests to inject the admin stream fetcher contract.

## Testing
- `cd frontend && npm run test:run -- src/components/features/admin/logs/LogViewer.test.tsx`
- `cd frontend && npm run type-check`
- `cd frontend && npm run lint`
- `git diff --check`

## Risks
- Low; stream body handling is unchanged and the response reader path still receives a normal `Response`.

## Follow-ups
- Continue admin-only route/client contract review from latest `main`.