### PR TITLE
fix(secrets): prompt for plaintext audit reason

### DIFF
--- a/frontend/src/components/features/admin/secrets/SecretsListManager.tsx
+++ b/frontend/src/components/features/admin/secrets/SecretsListManager.tsx
@@ -54,6 +54,7 @@ import {
   CheckCircle,
   XCircle,
   Key,
+  ShieldAlert,
 } from 'lucide-react';
 import { useSecrets, useCategories } from './hooks';
 import type { SecretCategory, SecretPublic, SecretFormData } from './types';
@@ -61,6 +62,19 @@ import type { SecretCategory, SecretPublic, SecretFormData } from './types';
 interface SecretsListManagerProps {
   categories: SecretCategory[];
   initialCategoryFilter?: string | null;
+}
+
+type PlaintextActionKind = 'reveal' | 'copy';
+
+interface PendingPlaintextAction {
+  kind: PlaintextActionKind;
+  secret: SecretPublic;
+}
+
+const BREAK_GLASS_REASON_REQUIRED = 'break-glass reason is required';
+
+function needsBreakGlassReason(error?: string): boolean {
+  return error?.toLowerCase().includes(BREAK_GLASS_REASON_REQUIRED) ?? false;
 }
 
 export function SecretsListManager({ categories: initialCategories, initialCategoryFilter }: SecretsListManagerProps) {
@@ -93,6 +107,11 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
   const [selectedSecret, setSelectedSecret] = useState<SecretPublic | null>(null);
   const [revealedValues, setRevealedValues] = useState<Record<string, string>>({});
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [pendingPlaintextAction, setPendingPlaintextAction] =
+    useState<PendingPlaintextAction | null>(null);
+  const [plaintextReason, setPlaintextReason] = useState('');
+  const [plaintextError, setPlaintextError] = useState('');
+  const [plaintextLoading, setPlaintextLoading] = useState(false);
 
   // Form state
   const [formData, setFormData] = useState<SecretFormData>({
@@ -139,53 +158,113 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
     {} as Record<string, SecretPublic[]>
   );
 
+  const hideSecretValue = useCallback((secretId: string) => {
+    setRevealedValues((prev) => {
+      const next = { ...prev };
+      delete next[secretId];
+      return next;
+    });
+  }, []);
+
+  const showSecretValue = useCallback((secret: SecretPublic, value: string) => {
+    setRevealedValues((prev) => ({
+      ...prev,
+      [secret.id]: value,
+    }));
+    setTimeout(() => hideSecretValue(secret.id), 30000);
+  }, [hideSecretValue]);
+
+  const copySecretValue = useCallback(async (secret: SecretPublic, value: string) => {
+    await navigator.clipboard.writeText(value);
+    setCopiedId(secret.id);
+    setTimeout(() => setCopiedId(null), 2000);
+  }, []);
+
+  const requestPlaintextValue = useCallback(
+    async (
+      secret: SecretPublic,
+      kind: PlaintextActionKind,
+      reason?: string,
+    ): Promise<boolean> => {
+      const result = await revealSecret(secret.id, reason);
+
+      if (result.ok && result.data) {
+        if (kind === 'copy') {
+          await copySecretValue(secret, result.data.value);
+        } else {
+          showSecretValue(secret, result.data.value);
+        }
+        return true;
+      }
+
+      if (!reason && needsBreakGlassReason(result.error)) {
+        setPendingPlaintextAction({ kind, secret });
+        setPlaintextReason('');
+        setPlaintextError('');
+        return false;
+      }
+
+      setPlaintextError(result.error || 'Failed to retrieve secret value');
+      return false;
+    },
+    [copySecretValue, revealSecret, showSecretValue],
+  );
+
+  const closePlaintextDialog = useCallback(() => {
+    setPendingPlaintextAction(null);
+    setPlaintextReason('');
+    setPlaintextError('');
+    setPlaintextLoading(false);
+  }, []);
+
+  const handlePlaintextReasonSubmit = useCallback(async () => {
+    if (!pendingPlaintextAction) return;
+    const reason = plaintextReason.trim();
+    if (reason.length < 8) {
+      setPlaintextError('Reason must be at least 8 characters.');
+      return;
+    }
+
+    setPlaintextLoading(true);
+    setPlaintextError('');
+    const ok = await requestPlaintextValue(
+      pendingPlaintextAction.secret,
+      pendingPlaintextAction.kind,
+      reason,
+    );
+    setPlaintextLoading(false);
+    if (ok) {
+      closePlaintextDialog();
+    }
+  }, [
+    closePlaintextDialog,
+    pendingPlaintextAction,
+    plaintextReason,
+    requestPlaintextValue,
+  ]);
+
   const handleReveal = useCallback(
     async (secret: SecretPublic) => {
       if (revealedValues[secret.id]) {
-        // Hide
-        setRevealedValues((prev) => {
-          const next = { ...prev };
-          delete next[secret.id];
-          return next;
-        });
+        hideSecretValue(secret.id);
         return;
       }
 
-      const result = await revealSecret(secret.id);
-      if (result.ok && result.data) {
-        setRevealedValues((prev) => ({
-          ...prev,
-          [secret.id]: result.data!.value,
-        }));
-        // Auto-hide after 30 seconds
-        setTimeout(() => {
-          setRevealedValues((prev) => {
-            const next = { ...prev };
-            delete next[secret.id];
-            return next;
-          });
-        }, 30000);
-      }
+      await requestPlaintextValue(secret, 'reveal');
     },
-    [revealSecret, revealedValues]
+    [hideSecretValue, requestPlaintextValue, revealedValues],
   );
 
   const handleCopy = useCallback(async (secret: SecretPublic) => {
-    let value = revealedValues[secret.id];
-
-    if (!value) {
-      const result = await revealSecret(secret.id);
-      if (result.ok && result.data) {
-        value = result.data.value;
-      }
-    }
+    const value = revealedValues[secret.id];
 
     if (value) {
-      await navigator.clipboard.writeText(value);
-      setCopiedId(secret.id);
-      setTimeout(() => setCopiedId(null), 2000);
+      await copySecretValue(secret, value);
+      return;
     }
-  }, [revealSecret, revealedValues]);
+
+    await requestPlaintextValue(secret, 'copy');
+  }, [copySecretValue, requestPlaintextValue, revealedValues]);
 
   const handleCreate = async () => {
     setFormError('');
@@ -374,6 +453,7 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
                             size="icon"
                             onClick={() => handleReveal(secret)}
                             title={revealedValues[secret.id] ? 'Hide' : 'Reveal'}
+                            aria-label={`${revealedValues[secret.id] ? 'Hide' : 'Reveal'} ${secret.key_name}`}
                           >
                             {revealedValues[secret.id] ? (
                               <EyeOff className="h-4 w-4" />
@@ -386,6 +466,7 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
                             size="icon"
                             onClick={() => handleCopy(secret)}
                             title="Copy"
+                            aria-label={`Copy ${secret.key_name}`}
                           >
                             {copiedId === secret.id ? (
                               <CheckCircle className="h-4 w-4 text-green-500" />
@@ -400,6 +481,7 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
                         size="icon"
                         onClick={() => openEdit(secret)}
                         title="Edit"
+                        aria-label={`Edit ${secret.key_name}`}
                       >
                         <Edit className="h-4 w-4" />
                       </Button>
@@ -411,6 +493,7 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
                           setIsDeleteOpen(true);
                         }}
                         title="Delete"
+                        aria-label={`Delete ${secret.key_name}`}
                       >
                         <Trash2 className="h-4 w-4 text-destructive" />
                       </Button>
@@ -635,6 +718,61 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
             </Button>
             <Button onClick={handleUpdate} disabled={formLoading}>
               {formLoading ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Plaintext Reason Dialog */}
+      <Dialog
+        open={!!pendingPlaintextAction}
+        onOpenChange={(open) => {
+          if (!open) closePlaintextDialog();
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <ShieldAlert className="h-5 w-5 text-amber-500" />
+              Audit Reason
+            </DialogTitle>
+            <DialogDescription>
+              {pendingPlaintextAction?.secret.key_name}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="plaintext-reason">Reason</Label>
+              <Textarea
+                id="plaintext-reason"
+                value={plaintextReason}
+                onChange={(e) => {
+                  setPlaintextReason(e.target.value);
+                  if (plaintextError) setPlaintextError('');
+                }}
+                rows={3}
+                autoFocus
+              />
+            </div>
+            {plaintextError && (
+              <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {plaintextError}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={closePlaintextDialog}
+              disabled={plaintextLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handlePlaintextReasonSubmit}
+              disabled={plaintextLoading || plaintextReason.trim().length < 8}
+            >
+              {plaintextLoading ? 'Continuing...' : 'Continue'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/features/admin/secrets/hooks.ts
+++ b/frontend/src/components/features/admin/secrets/hooks.ts
@@ -139,7 +139,8 @@ export function useSecrets() {
     [fetchSecrets],
   );
 
-  const revealSecret = useCallback(async (id: string) => {
+  const revealSecret = useCallback(async (id: string, reason?: string) => {
+    const trimmedReason = reason?.trim();
     const result = await adminApiFetch<{
       id: string;
       keyName: string;
@@ -147,6 +148,7 @@ export function useSecrets() {
     }>(`/${id}/reveal`, {
       pathPrefix: "/api/v1/admin/secrets",
       method: "POST",
+      ...(trimmedReason ? { body: { reason: trimmedReason } } : {}),
     });
     return result;
   }, []);
@@ -295,13 +297,19 @@ export function useSecretsOverview() {
 export function useSecretsExport() {
   const [loading, setLoading] = useState(false);
 
-  const exportSecrets = useCallback(async (includeValues = false) => {
+  const exportSecrets = useCallback(async (includeValues = false, reason?: string) => {
     const query = includeValues ? "?includeValues=true" : "";
+    const trimmedReason = reason?.trim();
     const result = await adminApiFetch<{
       exportedAt: string;
       categories: SecretCategory[];
       secrets: SecretPublic[];
-    }>(`/export${query}`, { pathPrefix: "/api/v1/admin/secrets" });
+    }>(`/export${query}`, {
+      pathPrefix: "/api/v1/admin/secrets",
+      ...(trimmedReason
+        ? { headers: { "X-Break-Glass-Reason": trimmedReason } }
+        : {}),
+    });
     return result;
   }, []);
 

--- a/frontend/src/test/SecretsListManager.breakglass.test.tsx
+++ b/frontend/src/test/SecretsListManager.breakglass.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const hookMocks = vi.hoisted(() => ({
+  createSecret: vi.fn(),
+  deleteSecret: vi.fn(),
+  fetchCategories: vi.fn(),
+  fetchSecrets: vi.fn(),
+  generateValue: vi.fn(),
+  revealSecret: vi.fn(),
+  updateSecret: vi.fn(),
+}));
+
+vi.mock('@/components/features/admin/secrets/hooks', () => ({
+  useCategories: () => ({
+    categories: [],
+    loading: false,
+    error: null,
+    fetchCategories: hookMocks.fetchCategories,
+    createCategory: vi.fn(),
+  }),
+  useSecrets: () => ({
+    secrets: [
+      {
+        id: 'sec_1',
+        category_id: 'cat_ai',
+        key_name: 'OPENAI_API_KEY',
+        display_name: 'OpenAI API Key',
+        description: null,
+        is_required: 1,
+        is_sensitive: 1,
+        value_type: 'string',
+        validation_pattern: null,
+        default_value: null,
+        env_fallback: 'OPENAI_API_KEY',
+        last_rotated_at: null,
+        expires_at: null,
+        created_at: '2026-07-01T00:00:00.000Z',
+        updated_at: '2026-07-01T00:00:00.000Z',
+        created_by: 'admin',
+        updated_by: 'admin',
+        has_value: true,
+        category_name: 'AI',
+      },
+    ],
+    loading: false,
+    error: null,
+    fetchSecrets: hookMocks.fetchSecrets,
+    createSecret: hookMocks.createSecret,
+    updateSecret: hookMocks.updateSecret,
+    deleteSecret: hookMocks.deleteSecret,
+    revealSecret: hookMocks.revealSecret,
+    generateValue: hookMocks.generateValue,
+  }),
+}));
+
+import { SecretsListManager } from '@/components/features/admin/secrets/SecretsListManager';
+import type { SecretCategory } from '@/components/features/admin/secrets/types';
+
+const categories: SecretCategory[] = [
+  {
+    id: 'cat_ai',
+    name: 'ai',
+    display_name: 'AI',
+    description: null,
+    icon: null,
+    sort_order: 1,
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+  },
+];
+
+describe('SecretsListManager plaintext break-glass flow', () => {
+  afterEach(() => {
+    Object.values(hookMocks).forEach((mock) => mock.mockReset());
+  });
+
+  it('prompts for a reason and retries reveal when the API requires one', async () => {
+    hookMocks.revealSecret
+      .mockResolvedValueOnce({
+        ok: false,
+        error: 'break-glass reason is required',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          id: 'sec_1',
+          keyName: 'OPENAI_API_KEY',
+          value: 'secret-value',
+        },
+      });
+
+    render(<SecretsListManager categories={categories} />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Reveal OPENAI_API_KEY' }),
+    );
+
+    expect(await screen.findByText('Audit Reason')).toBeInTheDocument();
+    expect(hookMocks.revealSecret).toHaveBeenCalledWith('sec_1', undefined);
+
+    fireEvent.change(screen.getByLabelText('Reason'), {
+      target: { value: 'Rotating production provider key' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(hookMocks.revealSecret).toHaveBeenLastCalledWith(
+        'sec_1',
+        'Rotating production provider key',
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('secret-value')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/test/adminSecretsHooks.test.tsx
+++ b/frontend/src/test/adminSecretsHooks.test.tsx
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockAdminApiFetch = vi.hoisted(() => vi.fn());
+
+vi.mock('@/services/admin/apiClient', () => ({
+  adminApiFetch: mockAdminApiFetch,
+}));
+
+import {
+  useSecrets,
+  useSecretsExport,
+} from '@/components/features/admin/secrets/hooks';
+
+describe('admin secrets hooks', () => {
+  afterEach(() => {
+    mockAdminApiFetch.mockReset();
+  });
+
+  it('sends a break-glass reason when revealing a plaintext secret', async () => {
+    mockAdminApiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'sec_1',
+        keyName: 'OPENAI_API_KEY',
+        value: 'secret-value',
+      },
+    });
+
+    const { result } = renderHook(() => useSecrets());
+    const response = await result.current.revealSecret(
+      'sec_1',
+      'Rotating production provider key',
+    );
+
+    expect(response.ok).toBe(true);
+    expect(mockAdminApiFetch).toHaveBeenCalledWith('/sec_1/reveal', {
+      pathPrefix: '/api/v1/admin/secrets',
+      method: 'POST',
+      body: { reason: 'Rotating production provider key' },
+    });
+  });
+
+  it('sends a break-glass reason header when exporting plaintext values', async () => {
+    mockAdminApiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        exportedAt: '2026-07-01T00:00:00.000Z',
+        categories: [],
+        secrets: [],
+      },
+    });
+
+    const { result } = renderHook(() => useSecretsExport());
+    const response = await result.current.exportSecrets(
+      true,
+      'Emergency migration backup',
+    );
+
+    expect(response.ok).toBe(true);
+    expect(mockAdminApiFetch).toHaveBeenCalledWith('/export?includeValues=true', {
+      pathPrefix: '/api/v1/admin/secrets',
+      headers: { 'X-Break-Glass-Reason': 'Emergency migration backup' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- pass break-glass reasons through admin secrets reveal/export API calls
- prompt for an audit reason when plaintext reveal/copy is rejected for missing reason
- add focused hook and component coverage for the reason retry flow

## Testing
- cd frontend && npm run test:run -- src/test/adminSecretsHooks.test.tsx src/test/SecretsListManager.breakglass.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check

## Risks
- plaintext export UI still needs a caller-level prompt before includeValues exports are exposed in the UI; this PR only adds the hook contract.

## Follow-ups
- continue admin-only route/client contract review from latest main after this PR merges.