### PR TITLE
refactor(admin): stop passing unused post editor tokens

### DIFF
--- a/frontend/src/components/features/admin/content/PostEditorWorkspace.tsx
+++ b/frontend/src/components/features/admin/content/PostEditorWorkspace.tsx
@@ -354,9 +354,6 @@ export function PostEditorWorkspace() {
 
   const createPr = useMutation({
     mutationFn: async (mode: SubmitMode) => {
-      const token = await getValidAccessToken();
-      if (!token) throw new Error('먼저 로그인하세요');
-
       const publishNow = mode === 'publish' && published;
       const payload: CreatePostPayload = {
         title: title.trim() || slug.trim() || 'New Post',
@@ -375,7 +372,7 @@ export function PostEditorWorkspace() {
         },
       };
 
-      return createPostPR(payload, token);
+      return createPostPR(payload);
     },
     onSuccess: data => {
       if (data.prUrl) {
@@ -439,8 +436,6 @@ export function PostEditorWorkspace() {
       }
 
       try {
-        const token = await getValidAccessToken();
-        if (!token) throw new Error('먼저 로그인하세요');
         if (!/^[0-9]{4}$/.test(year)) throw new Error('연도(YYYY)를 입력하세요');
         if (!slug.trim()) {
           throw new Error('슬러그를 먼저 입력하세요. 이미지 저장 경로에 필요합니다.');
@@ -451,7 +446,6 @@ export function PostEditorWorkspace() {
         const result = await uploadPostImages(
           { year, slug: slug.trim() },
           imageFiles,
-          token,
         );
 
         result.items.forEach((item, index) => {
@@ -483,7 +477,6 @@ export function PostEditorWorkspace() {
     },
     [
       appendAttachedImage,
-      getValidAccessToken,
       insertAtCursor,
       slug,
       toast,

--- a/frontend/src/services/session/admin.ts
+++ b/frontend/src/services/session/admin.ts
@@ -12,7 +12,7 @@ export type CreatePostPayload = {
 
 export async function createPostPR(
   payload: CreatePostPayload,
-  _token: string
+  _token?: string
 ): Promise<{
   prUrl?: string;
   status?: 'pending' | 'succeeded';
@@ -41,7 +41,7 @@ export async function createPostPR(
 export async function uploadPostImages(
   params: { year: string | number; slug: string },
   files: File[],
-  _token: string
+  _token?: string
 ): Promise<{
   dir: string;
   items: Array<{ url: string; variantWebp?: { url: string } | null }>;

--- a/frontend/src/test/PostEditorWorkspace.test.tsx
+++ b/frontend/src/test/PostEditorWorkspace.test.tsx
@@ -74,6 +74,12 @@ function renderEditor() {
 describe('PostEditorWorkspace', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    mocks.createPostPR.mockResolvedValue({
+      status: 'pending',
+      outboxId: 'outbox-1',
+      branch: 'post/draft-title',
+      path: 'frontend/public/posts/2026/draft-title.md',
+    });
     mocks.uploadPostImages.mockResolvedValue({
       dir: '/images/2026/drag-hero',
       items: [
@@ -117,6 +123,36 @@ describe('PostEditorWorkspace', () => {
     );
   });
 
+  it('creates draft PRs through the admin session service without token plumbing', async () => {
+    renderEditor();
+
+    fireEvent.change(screen.getByLabelText('제목'), {
+      target: { value: 'Draft Title' },
+    });
+    fireEvent.change(screen.getByLabelText('슬러그'), {
+      target: { value: 'draft-title' },
+    });
+    fireEvent.change(screen.getByLabelText('Markdown content editor'), {
+      target: { value: '# Draft Title\n\nBody' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Draft PR/i }));
+
+    await waitFor(() => {
+      expect(mocks.createPostPR).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mocks.createPostPR.mock.calls[0]).toHaveLength(1);
+    expect(mocks.createPostPR).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Draft Title',
+        slug: 'draft-title',
+        content: '# Draft Title\n\nBody',
+        draft: true,
+      }),
+    );
+  });
+
   it('uploads a dropped image and inserts the returned markdown into content', async () => {
     renderEditor();
 
@@ -146,9 +182,9 @@ describe('PostEditorWorkspace', () => {
       expect(mocks.uploadPostImages).toHaveBeenCalledWith(
         { year: expect.any(String), slug: 'drag-hero' },
         [file],
-        'access-token',
       );
     });
+    expect(mocks.uploadPostImages.mock.calls[0]).toHaveLength(2);
 
     expect(
       (screen.getByLabelText('Markdown content editor') as HTMLTextAreaElement)


### PR DESCRIPTION
## Summary
- stop prefetching access tokens in the admin post editor before creating post PRs or uploading images
- make the legacy token parameters optional in the admin session service while keeping compatibility with existing callers
- extend PostEditorWorkspace coverage to assert post PR/image upload calls no longer pass token arguments

## Testing
- cd frontend && npm run test:run -- src/test/PostEditorWorkspace.test.tsx src/test/adminSessionService.test.ts
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check

## Risks
- unauthenticated failures now surface from the shared admin client/service response instead of the component-level Korean precheck.

## Follow-ups
- continue admin-only route/client contract review from latest main after this PR merges.