### PR TITLE
refactor(admin): stop passing ai panel tokens

### DIFF
--- a/frontend/src/components/features/admin/AiImageGeneratorPanel.tsx
+++ b/frontend/src/components/features/admin/AiImageGeneratorPanel.tsx
@@ -51,7 +51,6 @@ type AiImageGeneratorPanelProps = {
   content: string;
   year: string;
   slug: string;
-  getAccessToken: () => Promise<string | null>;
   onInsertMarkdown: (markdown: string) => void;
   onSetCoverImage: (url: string) => void;
 };
@@ -71,7 +70,6 @@ export default function AiImageGeneratorPanel({
   content,
   year,
   slug,
-  getAccessToken,
   onInsertMarkdown,
   onSetCoverImage,
 }: AiImageGeneratorPanelProps) {
@@ -94,8 +92,6 @@ export default function AiImageGeneratorPanel({
 
   const handleGenerate = async () => {
     try {
-      const token = await getAccessToken();
-      if (!token) throw new Error('먼저 로그인하세요');
       if (!/^[0-9]{4}$/.test(year)) throw new Error('연도(YYYY)를 입력하세요');
       if (!slug.trim()) throw new Error('슬러그(slug)를 먼저 입력하세요');
 
@@ -112,7 +108,6 @@ export default function AiImageGeneratorPanel({
           outputFormat: 'png',
           alt: alt.trim() || title.trim() || `${slug.trim()} cover image`,
         },
-        token,
       );
       setItems((previous) => [...response.items, ...previous]);
       toast({

--- a/frontend/src/components/features/admin/BotChatPanel.tsx
+++ b/frontend/src/components/features/admin/BotChatPanel.tsx
@@ -22,7 +22,6 @@ interface BotChatPanelProps {
     setCategory: (category: string) => void;
     setCoverImage: (url: string) => void;
     onInsertMarkdown: (markdown: string) => void;
-    getAccessToken: () => Promise<string | null>;
 }
 
 interface Message {
@@ -45,7 +44,6 @@ export default function BotChatPanel({
     setCategory,
     setCoverImage,
     onInsertMarkdown,
-    getAccessToken,
 }: BotChatPanelProps) {
     const [messages, setMessages] = useState<Message[]>([
         { role: "assistant", content: "안녕하세요. 현재 글 상태를 읽고 초안, 메타데이터, 커버/본문 이미지 생성을 도울 수 있습니다." },
@@ -177,9 +175,6 @@ export default function BotChatPanel({
         setIsTyping(true);
 
         try {
-            const token = await getAccessToken();
-            if (!token) throw new Error("먼저 로그인하세요");
-
             const result = await runBlogAgent(
                 {
                     message: buildAgentMessage(userMessage),
@@ -187,7 +182,6 @@ export default function BotChatPanel({
                     maxIterations: 6,
                     temperature: 0.4,
                 },
-                token,
             );
             const applied = applyActions(result.actions);
             const toolSuffix =

--- a/frontend/src/components/features/admin/content/PostEditorWorkspace.tsx
+++ b/frontend/src/components/features/admin/content/PostEditorWorkspace.tsx
@@ -152,7 +152,7 @@ function getImageFilesFromClipboard(
 
 export function PostEditorWorkspace() {
   const { toast } = useToast();
-  const { logout: storeLogout, getValidAccessToken } = useAuthStore();
+  const { logout: storeLogout } = useAuthStore();
 
   const [title, setTitle] = useState('');
   const [slug, setSlug] = useState('');
@@ -978,7 +978,6 @@ export function PostEditorWorkspace() {
                   setCategory={setCategory}
                   setCoverImage={setCoverImage}
                   onInsertMarkdown={insertAtCursor}
-                  getAccessToken={getValidAccessToken}
                 />
               </TabsContent>
 
@@ -990,7 +989,6 @@ export function PostEditorWorkspace() {
                   content={content}
                   year={year}
                   slug={slug}
-                  getAccessToken={getValidAccessToken}
                   onInsertMarkdown={handleGeneratedMarkdownInsert}
                   onSetCoverImage={setCoverImage}
                 />

--- a/frontend/src/services/session/adminImages.ts
+++ b/frontend/src/services/session/adminImages.ts
@@ -87,7 +87,7 @@ function getErrorMessage(payload: unknown, fallback: string): string {
 
 export async function generatePostImages(
   payload: GeneratePostImagesPayload,
-  _token: string,
+  _token?: string,
 ): Promise<GeneratePostImagesResponse> {
   const base = getApiBaseUrl();
   const response = await adminFetchRaw(`${base}/api/v1/admin/ai-images/generate`, {
@@ -113,7 +113,7 @@ export async function generatePostImages(
 }
 
 export async function getAdminAiImagesHealth(
-  _token: string,
+  _token?: string,
 ): Promise<AdminAiImagesHealth> {
   const base = getApiBaseUrl();
   const response = await adminFetchRaw(`${base}/api/v1/admin/ai-images/health`);

--- a/frontend/src/services/session/agent.ts
+++ b/frontend/src/services/session/agent.ts
@@ -49,7 +49,7 @@ export async function runBlogAgent(
     maxIterations?: number;
     temperature?: number;
   },
-  _token: string,
+  _token?: string,
 ): Promise<AgentRunResponse> {
   const base = getApiBaseUrl();
   const response = await adminFetchRaw(`${base}/api/v1/agent/run`, {

--- a/frontend/src/test/PostEditorWorkspace.test.tsx
+++ b/frontend/src/test/PostEditorWorkspace.test.tsx
@@ -6,7 +6,6 @@ import { PostEditorWorkspace } from '@/components/features/admin/content/PostEdi
 
 const mocks = vi.hoisted(() => ({
   createPostPR: vi.fn(),
-  getValidAccessToken: vi.fn(async () => 'access-token'),
   logout: vi.fn(async () => undefined),
   uploadPostImages: vi.fn(),
 }));
@@ -18,7 +17,6 @@ vi.mock('@/services/session/admin', () => ({
 
 vi.mock('@/stores/session/useAuthStore', () => ({
   useAuthStore: () => ({
-    getValidAccessToken: mocks.getValidAccessToken,
     logout: mocks.logout,
   }),
 }));

--- a/frontend/src/test/adminAgentService.test.ts
+++ b/frontend/src/test/adminAgentService.test.ts
@@ -38,7 +38,6 @@ describe('admin agent service', () => {
         message: 'Improve this draft',
         sessionId: 'session-1',
       },
-      'expired-access-token',
     );
 
     expect(result).toEqual(data);

--- a/frontend/src/test/adminImages.test.ts
+++ b/frontend/src/test/adminImages.test.ts
@@ -43,7 +43,6 @@ describe('admin image service', () => {
         slug: 'test-post',
         prompt: 'generate a cover image',
       },
-      'expired-access-token',
     );
 
     expect(result).toEqual(data);
@@ -88,7 +87,7 @@ describe('admin image service', () => {
       }),
     );
 
-    const result = await getAdminAiImagesHealth('expired-access-token');
+    const result = await getAdminAiImagesHealth();
 
     expect(result).toEqual(data);
     expect(mockAdminFetchRaw).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- remove getAccessToken props from the admin bot and AI image panels
- make the blog agent and admin image service token arguments optional while relying on adminFetchRaw for auth and refresh/retry
- update focused service/editor tests for token-free calls

## Testing
- cd frontend && npm run test:run -- src/test/adminImages.test.ts src/test/adminAgentService.test.ts src/test/PostEditorWorkspace.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check

## Risks
- missing auth now surfaces through the shared admin client/service errors instead of panel-level prechecks.

## Follow-ups
- continue admin-only route/client contract review from latest main after this PR merges.