### PR TITLE
fix(admin): report provider health failures

### DIFF
--- a/frontend/src/components/features/admin/health/SystemHealth.test.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/services/admin/apiClient", () => ({
 import {
   checkAgentHealthRequest,
   checkBackendHealth,
+  checkProviderHealth,
   getProviders,
 } from "./SystemHealth";
 
@@ -110,6 +111,62 @@ describe("checkBackendHealth", () => {
       llm: { ok: true },
       tools: { count: 7 },
       uptime: 120,
+    });
+  });
+
+  it("checks provider health through the shared admin API client", async () => {
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          data: {
+            status: "healthy",
+            latencyMs: 84,
+            error: null,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const health = await checkProviderHealth("openai");
+
+    expect(mockAdminFetchRaw).toHaveBeenCalledWith(
+      "https://worker.example.com/api/v1/admin/ai/providers/openai/health",
+      expect.objectContaining({
+        method: "PUT",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(health).toEqual({
+      status: "healthy",
+      latencyMs: 84,
+      error: null,
+    });
+  });
+
+  it("marks provider health checks down on non-OK admin responses", async () => {
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: false,
+          error: { message: "Provider gateway unavailable" },
+        }),
+        {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const health = await checkProviderHealth("openai");
+
+    expect(health).toEqual({
+      status: "down",
+      error: "Provider gateway unavailable",
     });
   });
 });

--- a/frontend/src/components/features/admin/health/SystemHealth.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.tsx
@@ -35,6 +35,7 @@ interface ProviderHealth {
   isEnabled: boolean;
   modelCount: number;
   enabledModelCount: number;
+  healthError?: string | null;
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -95,7 +96,29 @@ export async function getProviders(): Promise<ProviderHealth[]> {
   }
 }
 
-async function checkProviderHealth(
+function getResponseErrorMessage(payload: unknown, fallback: string): string {
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "error" in payload
+  ) {
+    const error = payload.error;
+    if (typeof error === "string" && error) return error;
+    if (
+      error &&
+      typeof error === "object" &&
+      "message" in error &&
+      typeof error.message === "string" &&
+      error.message
+    ) {
+      return error.message;
+    }
+  }
+  return fallback;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export async function checkProviderHealth(
   providerId: string,
 ): Promise<{ status: string; latencyMs?: number; error?: string }> {
   const base = getApiBaseUrl();
@@ -107,7 +130,16 @@ async function checkProviderHealth(
         signal: AbortSignal.timeout(15000),
       },
     );
-    const data = await res.json();
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return {
+        status: "down",
+        error: getResponseErrorMessage(
+          data,
+          `Provider health check failed (${res.status})`,
+        ),
+      };
+    }
     return {
       status: data.data?.status ?? "unknown",
       latencyMs: data.data?.latencyMs,
@@ -256,6 +288,7 @@ export function SystemHealth() {
             ? {
                 ...p,
                 healthStatus: result.status,
+                healthError: result.error ?? null,
                 lastHealthCheck: new Date().toISOString(),
               }
             : p,
@@ -440,8 +473,12 @@ export function SystemHealth() {
                 >
                   <div className="text-left">
                     <p className="text-sm text-zinc-700">{p.displayName}</p>
-                    <p className="font-mono text-xs text-zinc-400">
-                      {p.enabledModelCount}/{p.modelCount} models
+                    <p
+                      className={`font-mono text-xs max-w-[140px] truncate ${
+                        p.healthError ? "text-red-600" : "text-zinc-400"
+                      }`}
+                    >
+                      {p.healthError ?? `${p.enabledModelCount}/${p.modelCount} models`}
                     </p>
                   </div>
                   <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary
- mark provider health checks as down when the admin API returns a non-OK response
- preserve the backend error message from provider health failures and show it in the health panel row
- add focused SystemHealth coverage for provider health success and non-OK failure responses

## Verification
- cd frontend && npm run test:run -- src/components/features/admin/health/SystemHealth.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check