### PR TITLE
fix(admin): show post metrics load errors

### DIFF
--- a/frontend/src/components/features/admin/analytics/PostMetricsDetail.test.tsx
+++ b/frontend/src/components/features/admin/analytics/PostMetricsDetail.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockAdminApiFetch = vi.hoisted(() => vi.fn());
+
+vi.mock('@/services/admin/apiClient', () => ({
+  adminApiFetch: mockAdminApiFetch,
+}));
+
+import { PostMetricsDetail } from './PostMetricsDetail';
+
+describe('PostMetricsDetail', () => {
+  afterEach(() => {
+    mockAdminApiFetch.mockReset();
+  });
+
+  it('loads visits and metrics through the shared admin API client', async () => {
+    mockAdminApiFetch.mockImplementation(async (endpoint: string) => {
+      if (endpoint === '/posts/2026/hello-world/visits?limit=50&offset=0') {
+        return {
+          ok: true,
+          data: {
+            visits: [
+              {
+                id: 1,
+                ip_address: '127.0.0.1',
+                user_agent: 'Mozilla/5.0 Chrome/120.0',
+                referer: 'https://example.com/ref',
+                path: '/blog/2026/hello-world',
+                session_id: 'session-1',
+                visited_at: '2026-01-01T01:02:03.000Z',
+              },
+            ],
+            total: 1,
+          },
+        };
+      }
+
+      if (endpoint === '/posts/2026/hello-world/metrics') {
+        return {
+          ok: true,
+          data: {
+            hourly: [{ hour: '2026-01-01T01:00:00.000Z', visits: 1 }],
+          },
+        };
+      }
+
+      return { ok: false, error: `Unexpected request: ${endpoint}` };
+    });
+
+    render(<PostMetricsDetail slug="hello-world" year="2026" onBack={vi.fn()} />);
+
+    expect(await screen.findByText('127.0.0.1')).toBeInTheDocument();
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+    expect(screen.getByText('example.com')).toBeInTheDocument();
+    expect(mockAdminApiFetch).toHaveBeenCalledWith(
+      '/posts/2026/hello-world/visits?limit=50&offset=0',
+      { pathPrefix: '/api/v1/admin/analytics' },
+    );
+    expect(mockAdminApiFetch).toHaveBeenCalledWith(
+      '/posts/2026/hello-world/metrics',
+      { pathPrefix: '/api/v1/admin/analytics' },
+    );
+  });
+
+  it('shows the admin API error instead of an empty visitor log on visit failures', async () => {
+    mockAdminApiFetch.mockImplementation(async (endpoint: string) => {
+      if (endpoint.endsWith('/visits?limit=50&offset=0')) {
+        return {
+          ok: false,
+          error: 'Session expired. Please log in again.',
+        };
+      }
+
+      if (endpoint.endsWith('/metrics')) {
+        return {
+          ok: true,
+          data: { hourly: [] },
+        };
+      }
+
+      return { ok: false, error: `Unexpected request: ${endpoint}` };
+    });
+
+    render(<PostMetricsDetail slug="hello-world" year="2026" onBack={vi.fn()} />);
+
+    expect(
+      await screen.findByText('Session expired. Please log in again.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Unable to load visitor log.')).toBeInTheDocument();
+    expect(screen.queryByText('No visits recorded yet.')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/analytics/PostMetricsDetail.tsx
+++ b/frontend/src/components/features/admin/analytics/PostMetricsDetail.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { RefreshCw, ArrowLeft, Eye, Clock, Globe, Monitor } from 'lucide-react';
-import { getApiBaseUrl } from '@/utils/network/apiBase';
-import { adminFetchRaw } from '@/services/admin/apiClient';
+import { adminApiFetch } from '@/services/admin/apiClient';
 
 interface Visit {
   id: number;
@@ -16,6 +15,15 @@ interface Visit {
 interface HourlyPoint {
   hour: string;
   visits: number;
+}
+
+interface VisitsData {
+  visits: Visit[];
+  total: number;
+}
+
+interface MetricsData {
+  hourly: HourlyPoint[];
 }
 
 interface PostMetricsDetailProps {
@@ -34,6 +42,11 @@ function parseBrowserName(ua: string | null): string {
   if (ua.includes('curl')) return 'curl';
   if (ua.includes('bot') || ua.includes('Bot') || ua.includes('spider')) return 'Bot';
   return 'Other';
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
 }
 
 function HourlyChart({ data }: { data: HourlyPoint[] }) {
@@ -71,34 +84,47 @@ export function PostMetricsDetail({ slug, year, onBack }: PostMetricsDetailProps
   const [total, setTotal] = useState(0);
   const [hourly, setHourly] = useState<HourlyPoint[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(0);
 
   const PAGE_SIZE = 50;
 
   const fetchData = useCallback(async (pageNum: number) => {
     setLoading(true);
-    const base = getApiBaseUrl();
+    setError(null);
     const offset = pageNum * PAGE_SIZE;
+    const postPath = `/posts/${encodeURIComponent(year)}/${encodeURIComponent(slug)}`;
 
     try {
-      const [visitsRes, metricsRes] = await Promise.all([
-        adminFetchRaw(`${base}/api/v1/admin/analytics/posts/${year}/${slug}/visits?limit=${PAGE_SIZE}&offset=${offset}`),
+      const [visitsResult, metricsResult] = await Promise.all([
+        adminApiFetch<VisitsData>(
+          `${postPath}/visits?limit=${PAGE_SIZE}&offset=${offset}`,
+          { pathPrefix: '/api/v1/admin/analytics' },
+        ),
         pageNum === 0
-          ? adminFetchRaw(`${base}/api/v1/admin/analytics/posts/${year}/${slug}/metrics`)
+          ? adminApiFetch<MetricsData>(
+              `${postPath}/metrics`,
+              { pathPrefix: '/api/v1/admin/analytics' },
+            )
           : Promise.resolve(null),
       ]);
 
-      if (visitsRes.ok) {
-        const data = await visitsRes.json();
-        setVisits(data.data?.visits ?? []);
-        setTotal(data.data?.total ?? 0);
+      if (!visitsResult.ok || !visitsResult.data) {
+        throw new Error(visitsResult.error || 'Failed to load visit logs');
       }
 
-      if (metricsRes?.ok) {
-        const data = await metricsRes.json();
-        setHourly(data.data?.hourly ?? []);
+      setVisits(visitsResult.data.visits ?? []);
+      setTotal(visitsResult.data.total ?? 0);
+
+      if (metricsResult) {
+        setHourly(metricsResult.ok && metricsResult.data ? metricsResult.data.hourly ?? [] : []);
       }
-    } catch { void 0; } finally {
+    } catch (err) {
+      setVisits([]);
+      setTotal(0);
+      if (pageNum === 0) setHourly([]);
+      setError(getErrorMessage(err, 'Failed to load visit logs'));
+    } finally {
       setLoading(false);
     }
   }, [slug, year]);
@@ -154,6 +180,11 @@ export function PostMetricsDetail({ slug, year, onBack }: PostMetricsDetailProps
           <div className="flex items-center gap-2 px-4 py-3 text-xs text-zinc-400">
             <RefreshCw className="h-3 w-3 animate-spin" />
             Loading...
+          </div>
+        ) : error ? (
+          <div className="px-4 py-3 space-y-1">
+            <p className="text-xs font-medium text-red-600">{error}</p>
+            <p className="text-xs text-zinc-400">Unable to load visitor log.</p>
           </div>
         ) : visits.length === 0 ? (
           <p className="px-4 py-3 text-xs text-zinc-400">No visits recorded yet.</p>


### PR DESCRIPTION
## Summary
- move post metrics detail visits/metrics reads onto adminApiFetch with the /api/v1/admin/analytics prefix
- clear stale visitor data and show the admin API error when visit-log loading fails
- add focused PostMetricsDetail coverage for successful reads and failed visit-log responses

## Verification
- cd frontend && npm run test:run -- src/components/features/admin/analytics/PostMetricsDetail.test.tsx src/components/features/admin/analytics/AnalyticsManager.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check