### PR TITLE
fix(admin): surface post service errors

### DIFF
--- a/frontend/src/services/session/admin.ts
+++ b/frontend/src/services/session/admin.ts
@@ -10,6 +10,19 @@ export type CreatePostPayload = {
   draft?: boolean;
 };
 
+function getAdminErrorMessage(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== 'object') return fallback;
+  const record = payload as { error?: unknown; message?: unknown };
+  if (typeof record.error === 'string' && record.error) return record.error;
+  if (record.error && typeof record.error === 'object') {
+    const nested = record.error as { message?: unknown; code?: unknown };
+    if (typeof nested.message === 'string' && nested.message) return nested.message;
+    if (typeof nested.code === 'string' && nested.code) return nested.code;
+  }
+  if (typeof record.message === 'string' && record.message) return record.message;
+  return fallback;
+}
+
 export async function createPostPR(
   payload: CreatePostPayload,
   _token?: string
@@ -27,7 +40,7 @@ export async function createPostPR(
   });
   const json = await res.json().catch(() => ({}));
   if (!res.ok || !json?.ok) {
-    throw new Error(json?.error || 'Failed to create PR');
+    throw new Error(getAdminErrorMessage(json, 'Failed to create PR'));
   }
   return json.data as {
     prUrl?: string;
@@ -131,7 +144,7 @@ async function uploadPostImagesCompatibility(
   });
   const json = await res.json().catch(() => ({}));
   if (!res.ok || !json?.ok) {
-    throw new Error(json?.error || 'Failed to upload');
+    throw new Error(getAdminErrorMessage(json, 'Failed to upload'));
   }
   return json.data as {
     dir: string;

--- a/frontend/src/test/adminSessionService.test.ts
+++ b/frontend/src/test/adminSessionService.test.ts
@@ -58,6 +58,30 @@ describe('admin session service', () => {
     });
   });
 
+  it('surfaces create post backend error messages', async () => {
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: false,
+          error: { message: 'Title is required' },
+        }),
+        {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    await expect(
+      createPostPR({
+        title: '',
+        slug: 'test-post',
+        year: 2026,
+        content: '# Test',
+      }),
+    ).rejects.toThrow('Title is required');
+  });
+
   it('uploads post images through the shared admin API client', async () => {
     mockAdminFetchRaw
       .mockResolvedValueOnce(
@@ -114,5 +138,39 @@ describe('admin session service', () => {
     const [uploadUrl, uploadOptions] = mockAdminFetchRaw.mock.calls[1];
     expect(uploadUrl).toBe('https://worker.example.com/api/v1/images/upload-direct');
     expect(uploadOptions.body).toBeInstanceOf(FormData);
+  });
+
+  it('surfaces fallback image upload backend error messages', async () => {
+    mockAdminFetchRaw
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: false,
+            error: { message: 'Presign disabled' },
+          }),
+          {
+            status: 503,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: false,
+            error: { message: 'Image upload too large' },
+          }),
+          {
+            status: 413,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+
+    const file = new File(['image'], 'cover.png', { type: 'image/png' });
+
+    await expect(
+      uploadPostImages({ year: 2026, slug: 'test-post' }, [file]),
+    ).rejects.toThrow('Image upload too large');
   });
 });


### PR DESCRIPTION
## Summary
- parse object-shaped backend errors in admin post PR creation and fallback image uploads
- prevent user-facing failures from degrading to [object Object]
- add focused admin session service coverage for create-post and fallback upload error messages

## Verification
- cd frontend && npm run test:run -- src/test/adminSessionService.test.ts
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check