### PR TITLE
fix(admin): avoid json content type on reads

### DIFF
--- a/frontend/src/services/admin/apiClient.ts
+++ b/frontend/src/services/admin/apiClient.ts
@@ -22,7 +22,8 @@ function buildAdminHeaders(
   const nextHeaders = new Headers(headers);
   const isFormDataBody =
     typeof FormData !== 'undefined' && requestBody instanceof FormData;
-  if (!nextHeaders.has('Content-Type') && !isFormDataBody) {
+  const hasRequestBody = requestBody !== undefined && requestBody !== null;
+  if (hasRequestBody && !nextHeaders.has('Content-Type') && !isFormDataBody) {
     nextHeaders.set('Content-Type', 'application/json');
   }
   if (token) {
@@ -55,10 +56,16 @@ function buildAdminRequestInit(
   token: string | null,
   body?: unknown,
 ): RequestInit {
+  const requestBody = body !== undefined ? body : options.body;
+  const isFormDataBody =
+    typeof FormData !== 'undefined' && requestBody instanceof FormData;
+
   return {
     ...options,
-    headers: buildAdminHeaders(token, options.headers, body ?? options.body),
-    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    headers: buildAdminHeaders(token, options.headers, requestBody),
+    ...(body !== undefined
+      ? { body: isFormDataBody ? (body as BodyInit) : JSON.stringify(body) }
+      : {}),
   };
 }
 

--- a/frontend/src/test/adminApiClient.test.ts
+++ b/frontend/src/test/adminApiClient.test.ts
@@ -70,12 +70,41 @@ describe('admin API client auth retry', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(authorizationHeader(fetchMock, 0)).toBe('Bearer old-access-token');
     expect(authorizationHeader(fetchMock, 1)).toBe('Bearer new-access-token');
+    expect(new Headers(fetchMock.mock.calls[0][1]?.headers).get('Content-Type')).toBe(
+      'application/json',
+    );
+    expect(fetchMock.mock.calls[0][1]?.body).toBe(
+      JSON.stringify({ key: 'OPENAI_API_KEY' }),
+    );
     expect(mockRefreshAccessToken).toHaveBeenCalledWith('refresh-token');
     expect(mockState.setTokens).toHaveBeenCalledWith(
       'new-access-token',
       'new-refresh-token',
     );
     expect(mockState.clearAuth).not.toHaveBeenCalled();
+  });
+
+  it('does not force a JSON content type for bodyless adminApiFetch requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { providers: [] } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adminApiFetch<{ providers: unknown[] }>('/providers', {
+      pathPrefix: '/api/v1/admin/ai',
+    });
+
+    expect(result).toEqual({ ok: true, data: { providers: [] } });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get('Authorization')).toBe('Bearer old-access-token');
+    expect(headers.get('Content-Type')).toBeNull();
+    expect(init?.body).toBeUndefined();
   });
 
   it('retries adminFetchRaw with a refreshed token after a 401', async () => {


### PR DESCRIPTION
## Summary
- stop adding Content-Type: application/json to bodyless admin API requests
- preserve JSON Content-Type for JSON bodies and the existing FormData behavior
- add focused admin API client coverage for bodyless reads and JSON body requests

## Verification
- cd frontend && npm run test:run -- src/test/adminApiClient.test.ts
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check