### PR TITLE
fix(admin): normalize api client errors

### DIFF
--- a/frontend/src/services/admin/apiClient.ts
+++ b/frontend/src/services/admin/apiClient.ts
@@ -32,6 +32,19 @@ function buildAdminHeaders(
   return nextHeaders;
 }
 
+function getAdminApiErrorMessage(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== 'object') return fallback;
+  const record = payload as { error?: unknown; message?: unknown };
+  if (typeof record.error === 'string' && record.error) return record.error;
+  if (record.error && typeof record.error === 'object') {
+    const nested = record.error as { message?: unknown; code?: unknown };
+    if (typeof nested.message === 'string' && nested.message) return nested.message;
+    if (typeof nested.code === 'string' && nested.code) return nested.code;
+  }
+  if (typeof record.message === 'string' && record.message) return record.message;
+  return fallback;
+}
+
 async function forceRefreshAdminAccessToken(): Promise<string | null> {
   const { refreshToken, clearAuth } = useAuthStore.getState();
   if (!refreshToken) {
@@ -100,7 +113,7 @@ export async function adminApiFetch<T>(
     if (!res.ok) {
       return {
         ok: false,
-        error: json?.error?.message || json?.error || `Request failed (${res.status})`,
+        error: getAdminApiErrorMessage(json, `Request failed (${res.status})`),
       };
     }
 

--- a/frontend/src/test/adminApiClient.test.ts
+++ b/frontend/src/test/adminApiClient.test.ts
@@ -107,6 +107,27 @@ describe('admin API client auth retry', () => {
     expect(init?.body).toBeUndefined();
   });
 
+  it('normalizes object-shaped adminApiFetch error responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: { code: 'RATE_LIMITED' },
+        }),
+        {
+          status: 429,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adminApiFetch<{ saved: boolean }>('/secrets', {
+      pathPrefix: '/api/v1/admin',
+    });
+
+    expect(result).toEqual({ ok: false, error: 'RATE_LIMITED' });
+  });
+
   it('retries adminFetchRaw with a refreshed token after a 401', async () => {
     const fetchMock = vi
       .fn()


### PR DESCRIPTION
## Summary
- normalize object-shaped adminApiFetch error responses into strings
- preserve nested message/code values before falling back to HTTP status text
- add focused admin API client coverage for object-shaped failure responses

## Verification
- cd frontend && npm run test:run -- src/test/adminApiClient.test.ts
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check