### PR TITLE
fix(admin): show worker inventory failures

### DIFF
--- a/frontend/src/components/features/admin/WorkersManager.tsx
+++ b/frontend/src/components/features/admin/WorkersManager.tsx
@@ -85,6 +85,15 @@ function getApiErrorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
+async function readAdminJson<T>(res: Response, fallback: string): Promise<T> {
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const error = (json as { error?: unknown }).error;
+    throw new Error(getApiErrorMessage(error, fallback));
+  }
+  return json as T;
+}
+
 function getWorkerSignalClasses(tone: WorkerSignalTone): string {
   switch (tone) {
     case "ready":
@@ -189,12 +198,19 @@ export function WorkersManager({
 
   const API_BASE = getApiBaseUrl();
 
-  const { data: workersData, isLoading: workersLoading } = useQuery({
+  const {
+    data: workersData,
+    error: workersError,
+    isLoading: workersLoading,
+    refetch: refetchWorkers,
+  } = useQuery({
     queryKey: ["workers-list"],
     queryFn: async () => {
       const res = await adminFetchRaw(`${API_BASE}/api/v1/admin/workers/list`);
-      if (!res.ok) throw new Error("Failed to fetch workers");
-      const json = await res.json();
+      const json = await readAdminJson<{ data: { workers: WorkerConfig[] } }>(
+        res,
+        "Failed to fetch workers",
+      );
       return json.data.workers as WorkerConfig[];
     },
   });
@@ -358,6 +374,35 @@ export function WorkersManager({
           aria-hidden="true"
         />
         <span>Loading workers…</span>
+      </div>
+    );
+  }
+
+  if (workersError) {
+    const message =
+      workersError instanceof Error
+        ? workersError.message
+        : "Failed to fetch workers";
+
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-300">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <div className="min-w-0">
+              <p className="font-medium">Unable to load workers</p>
+              <p className="mt-1 text-xs">{message}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => void refetchWorkers()}
+            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 text-xs font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200 dark:hover:bg-red-900/30"
+          >
+            <RefreshCw className="h-3 w-3" aria-hidden="true" />
+            Retry
+          </button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/test/WorkersManager.test.tsx
+++ b/frontend/src/test/WorkersManager.test.tsx
@@ -238,4 +238,79 @@ describe("WorkersManager read-only production mode", () => {
       screen.queryByText("prod-value-should-stay-hidden"),
     ).not.toBeInTheDocument();
   });
+
+  it("shows a load error instead of an empty workers list when worker inventory fails", async () => {
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.endsWith("/api/v1/admin/workers/list")) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: { message: "Workers inventory unavailable" },
+          }),
+          {
+            status: 503,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (url.endsWith("/api/v1/admin/workers/secrets")) {
+        return new Response(
+          JSON.stringify({ ok: true, data: { secrets: [] } }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (
+        url.endsWith("/api/v1/admin/workers/d1/databases") ||
+        url.endsWith("/api/v1/admin/workers/kv/namespaces") ||
+        url.endsWith("/api/v1/admin/workers/r2/buckets")
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: { databases: [], namespaces: [], buckets: [] },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as typeof fetch;
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkersManager subtab="workers" />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unable to load workers/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Workers inventory unavailable/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Retry/i })).toBeInTheDocument();
+    expect(screen.queryByText(/No workers found/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- parse worker inventory load failures into readable admin messages
- render an explicit worker load error state with retry instead of an empty workers list
- add WorkersManager coverage for failed worker inventory loading

## Verification
- cd frontend && npm run test:run -- src/test/WorkersManager.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check