### PR TITLE
fix(admin): show trace detail failures

### DIFF
--- a/frontend/src/components/features/admin/ai/TraceViewer.test.tsx
+++ b/frontend/src/components/features/admin/ai/TraceViewer.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetchTraces = vi.hoisted(() => vi.fn());
+const mockFetchTraceDetail = vi.hoisted(() => vi.fn());
+const mockFetchTraceStats = vi.hoisted(() => vi.fn());
+
+vi.mock('./hooks', () => ({
+  useTraces: () => ({
+    traces: [
+      {
+        trace_id: 'trace-1',
+        total_spans: 2,
+        total_latency_ms: 120,
+        status: 'success',
+        root_span_type: 'client_request',
+        model_id: null,
+        provider_id: null,
+        user_id: null,
+        request_path: '/api/v1/agent/run',
+        error_message: null,
+        created_at: '2026-01-01T01:02:03.000Z',
+        completed_at: '2026-01-01T01:02:03.120Z',
+      },
+    ],
+    loading: false,
+    error: null,
+    total: 1,
+    fetchTraces: mockFetchTraces,
+    fetchTraceDetail: mockFetchTraceDetail,
+    fetchTraceStats: mockFetchTraceStats,
+  }),
+}));
+
+import { TraceViewer } from './TraceViewer';
+
+describe('TraceViewer', () => {
+  beforeEach(() => {
+    mockFetchTraces.mockReset();
+    mockFetchTraceDetail.mockReset();
+    mockFetchTraceStats.mockReset();
+    mockFetchTraces.mockResolvedValue(undefined);
+    mockFetchTraceStats.mockResolvedValue({
+      ok: true,
+      data: {
+        stats: {
+          total_traces: 1,
+          success_count: 1,
+          error_count: 0,
+          timeout_count: 0,
+          avg_latency_ms: 120,
+          max_latency_ms: 120,
+          min_latency_ms: 120,
+        },
+      },
+    });
+  });
+
+  it('shows trace detail load errors instead of stale or empty detail content', async () => {
+    mockFetchTraceDetail.mockResolvedValue({
+      ok: false,
+      error: 'Trace not found',
+    });
+
+    render(<TraceViewer />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /View trace trace-1/i }));
+
+    await waitFor(() => {
+      expect(mockFetchTraceDetail).toHaveBeenCalledWith('trace-1');
+    });
+
+    expect(await screen.findByText('Trace not found')).toBeInTheDocument();
+    expect(screen.queryByText('No trace data found')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/ai/TraceViewer.tsx
+++ b/frontend/src/components/features/admin/ai/TraceViewer.tsx
@@ -21,6 +21,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -136,16 +137,25 @@ function TraceDetailDialog({
     null
   );
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (traceId && open) {
       setLoading(true);
+      setError(null);
+      setDetail(null);
       fetchTraceDetail(traceId).then((result) => {
         if (result.ok && result.data) {
           setDetail(result.data);
+        } else {
+          setError(result.error || 'Failed to load trace detail');
         }
         setLoading(false);
       });
+    } else if (!open) {
+      setDetail(null);
+      setError(null);
+      setLoading(false);
     }
   }, [traceId, open, fetchTraceDetail]);
 
@@ -157,11 +167,18 @@ function TraceDetailDialog({
             <Activity className="h-5 w-5" />
             Trace Detail
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Inspect timing spans and status for the selected AI trace.
+          </DialogDescription>
         </DialogHeader>
 
         {loading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 className="h-6 w-6 animate-spin" />
+          </div>
+        ) : error ? (
+          <div className="p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-500">
+            {error}
           </div>
         ) : detail ? (
           <div className="space-y-6">
@@ -430,6 +447,7 @@ export function TraceViewer() {
                     <Button
                       variant="ghost"
                       size="sm"
+                      aria-label={`View trace ${trace.trace_id}`}
                       onClick={() => handleViewDetail(trace.trace_id)}
                     >
                       <ChevronRight className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- clear stale trace detail state when opening/closing trace detail dialogs
- show trace detail load failures instead of falling back to stale or empty detail content
- add an accessible label for trace detail buttons and a hidden dialog description
- add focused TraceViewer coverage for failed detail loads

## Verification
- cd frontend && npm run test:run -- src/components/features/admin/ai/TraceViewer.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check