### PR TITLE
fix(admin): show stats refresh failures

### DIFF
--- a/frontend/src/components/features/admin/analytics/AnalyticsManager.test.tsx
+++ b/frontend/src/components/features/admin/analytics/AnalyticsManager.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AllPostsSection,
   EditorPicksSection,
   getAllPostStats,
+  StatsRefreshSection,
 } from "./AnalyticsManager";
 
 const { mockAdminApiFetch, mockAdminFetchRaw } = vi.hoisted(() => ({
@@ -133,5 +134,35 @@ describe("getAllPostStats", () => {
     expect(
       screen.queryByText(/No editor picks configured/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows the backend message when stats refresh fails", async () => {
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: { message: "Aggregation queue unavailable" },
+        }),
+        {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    render(<StatsRefreshSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Run Refresh/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Aggregation queue unavailable/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockAdminFetchRaw).toHaveBeenCalledWith(
+      "https://admin.example.com/api/v1/analytics/refresh-stats",
+      { method: "POST" },
+    );
+    expect(screen.queryByText(/^Refresh failed\.$/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/features/admin/analytics/AnalyticsManager.tsx
+++ b/frontend/src/components/features/admin/analytics/AnalyticsManager.tsx
@@ -55,6 +55,11 @@ interface EditorPicksResult {
   errorMessage?: string;
 }
 
+interface StatsRefreshResult {
+  success: boolean;
+  message: string;
+}
+
 function getAnalyticsErrorMessage(payload: unknown, fallback: string): string {
   if (!payload || typeof payload !== "object") return fallback;
   const record = payload as { error?: unknown; message?: unknown };
@@ -124,15 +129,28 @@ async function getTrendingPosts(
   }
 }
 
-async function refreshStats(): Promise<boolean> {
+async function refreshStats(): Promise<StatsRefreshResult> {
   const base = getApiBaseUrl();
   try {
     const res = await adminFetchRaw(`${base}/api/v1/analytics/refresh-stats`, {
       method: "POST",
     });
-    return res.ok;
-  } catch {
-    return false;
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return {
+        success: false,
+        message: getAnalyticsErrorMessage(data, "Refresh failed."),
+      };
+    }
+    return {
+      success: true,
+      message: data.data?.message || "Stats refreshed successfully.",
+    };
+  } catch (err) {
+    return {
+      success: false,
+      message: err instanceof Error ? err.message : "Refresh failed.",
+    };
   }
 }
 
@@ -681,7 +699,7 @@ function TrendingPostsSection() {
   );
 }
 
-function StatsRefreshSection() {
+export function StatsRefreshSection() {
   const [refreshing, setRefreshing] = useState(false);
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
   const [result, setResult] = useState<{
@@ -692,12 +710,9 @@ function StatsRefreshSection() {
   const handleRefresh = async () => {
     setRefreshing(true);
     setResult(null);
-    const success = await refreshStats();
-    setResult({
-      success,
-      message: success ? "Stats refreshed successfully." : "Refresh failed.",
-    });
-    if (success) setLastRefresh(new Date());
+    const refreshResult = await refreshStats();
+    setResult(refreshResult);
+    if (refreshResult.success) setLastRefresh(new Date());
     setRefreshing(false);
   };
 


### PR DESCRIPTION
## Summary
- return backend refresh messages from the stats refresh helper
- show specific stats refresh failures instead of the generic refresh failed message
- add AnalyticsManager coverage for failed stats refresh feedback

## Verification
- cd frontend && npm run test:run -- src/components/features/admin/analytics/AnalyticsManager.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check