### PR TITLE
fix(admin): show provider load failures

### DIFF
--- a/frontend/src/components/features/admin/health/SystemHealth.test.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.test.tsx
@@ -15,6 +15,7 @@ import {
   checkBackendHealth,
   checkProviderHealth,
   getProviders,
+  getProvidersResult,
 } from "./SystemHealth";
 
 describe("checkBackendHealth", () => {
@@ -76,6 +77,28 @@ describe("checkBackendHealth", () => {
     );
     expect(providers).toHaveLength(1);
     expect(providers[0].displayName).toBe("OpenAI");
+  });
+
+  it("returns provider load errors from non-OK admin responses", async () => {
+    mockAdminFetchRaw.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: false,
+          error: { message: "Provider inventory unavailable" },
+        }),
+        {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const result = await getProvidersResult();
+
+    expect(result).toEqual({
+      providers: [],
+      errorMessage: "Provider inventory unavailable",
+    });
   });
 
   it("checks agent health through the shared admin API client", async () => {

--- a/frontend/src/components/features/admin/health/SystemHealth.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.tsx
@@ -38,6 +38,11 @@ interface ProviderHealth {
   healthError?: string | null;
 }
 
+interface ProvidersResult {
+  providers: ProviderHealth[];
+  errorMessage?: string;
+}
+
 // eslint-disable-next-line react-refresh/only-export-components
 export async function checkBackendHealth(): Promise<{
   ok: boolean;
@@ -82,18 +87,35 @@ async function checkRAGHealth(): Promise<{
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export async function getProviders(): Promise<ProviderHealth[]> {
+export async function getProvidersResult(): Promise<ProvidersResult> {
   const base = getApiBaseUrl();
   try {
     const res = await adminFetchRaw(`${base}/api/v1/admin/ai/providers`, {
       signal: AbortSignal.timeout(10000),
     });
-    if (!res.ok) return [];
-    const data = await res.json();
-    return data.data?.providers ?? [];
-  } catch {
-    return [];
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return {
+        providers: [],
+        errorMessage: getResponseErrorMessage(
+          data,
+          `Failed to load providers (${res.status})`,
+        ),
+      };
+    }
+    return { providers: data.data?.providers ?? [] };
+  } catch (err) {
+    return {
+      providers: [],
+      errorMessage:
+        err instanceof Error ? err.message : "Failed to load providers",
+    };
   }
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export async function getProviders(): Promise<ProviderHealth[]> {
+  return (await getProvidersResult()).providers;
 }
 
 function getResponseErrorMessage(payload: unknown, fallback: string): string {
@@ -224,6 +246,7 @@ export function SystemHealth() {
   const [ragLoading, setRagLoading] = useState(false);
 
   const [providers, setProviders] = useState<ProviderHealth[]>([]);
+  const [providersError, setProvidersError] = useState<string | null>(null);
   const [providersLoading, setProvidersLoading] = useState(false);
   const [checkingProvider, setCheckingProvider] = useState<string | null>(null);
 
@@ -273,8 +296,10 @@ export function SystemHealth() {
 
   const fetchProviders = useCallback(async () => {
     setProvidersLoading(true);
-    const result = await getProviders();
-    setProviders(result);
+    setProvidersError(null);
+    const result = await getProvidersResult();
+    setProviders(result.providers);
+    setProvidersError(result.errorMessage ?? null);
     setProvidersLoading(false);
   }, []);
 
@@ -458,7 +483,20 @@ export function SystemHealth() {
             </button>
           </div>
           <div className="divide-y divide-zinc-100">
-            {providers.length === 0 ? (
+            {providersError ? (
+              <div className="px-4 py-2.5 text-xs text-red-700 bg-red-50">
+                <p className="font-medium">Unable to load providers</p>
+                <p>{providersError}</p>
+                <button
+                  type="button"
+                  onClick={fetchProviders}
+                  className="mt-2 inline-flex h-7 items-center gap-1.5 rounded-md border border-red-200 bg-white px-2 text-xs font-semibold text-red-700 hover:bg-red-100"
+                >
+                  <RefreshCw className="h-3 w-3" />
+                  Retry
+                </button>
+              </div>
+            ) : providers.length === 0 ? (
               <p className="px-4 py-2.5 text-xs text-zinc-400">
                 {providersLoading ? "Loading..." : "No providers"}
               </p>


### PR DESCRIPTION
## Summary
- return readable AI provider load errors from the SystemHealth provider helper
- show an explicit provider load error with retry instead of an empty provider list
- add SystemHealth coverage for non-OK provider inventory responses

## Verification
- cd frontend && npm run test:run -- src/components/features/admin/health/SystemHealth.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check