### PR TITLE
fix(admin): hide provider empty state on errors

### DIFF
--- a/frontend/src/components/features/admin/ai/ProvidersManager.test.tsx
+++ b/frontend/src/components/features/admin/ai/ProvidersManager.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProvidersManager } from "./ProvidersManager";
+import { useProviders } from "./hooks";
+
+vi.mock("./hooks", () => ({
+  useProviders: vi.fn(),
+}));
+
+const mockUseProviders = vi.mocked(useProviders);
+
+describe("ProvidersManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseProviders.mockReturnValue({
+      providers: [],
+      loading: false,
+      error: "Provider inventory unavailable",
+      fetchProviders: vi.fn(),
+      createProvider: vi.fn(),
+      updateProvider: vi.fn(),
+      deleteProvider: vi.fn(),
+      checkHealth: vi.fn(),
+      killSwitchProvider: vi.fn(),
+      enableProvider: vi.fn(),
+    });
+  });
+
+  it("shows provider load errors without also showing the empty state", () => {
+    render(<ProvidersManager />);
+
+    expect(
+      screen.getByText("Provider inventory unavailable"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No providers configured/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/ai/ProvidersManager.tsx
+++ b/frontend/src/components/features/admin/ai/ProvidersManager.tsx
@@ -428,7 +428,7 @@ export function ProvidersManager() {
                 </div>
               </div>
             ))}
-            {providers.length === 0 && (
+            {!error && providers.length === 0 && (
               <p className="text-center text-muted-foreground py-8">
                 No providers configured. Add your first provider to get started.
               </p>


### PR DESCRIPTION
## Summary
- avoid showing the providers empty state when the provider list failed to load
- add a ProvidersManager component test for the error-only list state

## Verification
- cd frontend && npm run test:run -- src/components/features/admin/ai/ProvidersManager.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check