### PR TITLE
fix(admin): hide model empty state on errors

### DIFF
--- a/frontend/src/components/features/admin/ai/ModelsManager.test.tsx
+++ b/frontend/src/components/features/admin/ai/ModelsManager.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ModelsManager } from "./ModelsManager";
+import { useModels, useProviders } from "./hooks";
+
+vi.mock("./hooks", () => ({
+  useModels: vi.fn(),
+  useProviders: vi.fn(),
+}));
+
+const mockUseModels = vi.mocked(useModels);
+const mockUseProviders = vi.mocked(useProviders);
+
+describe("ModelsManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseModels.mockReturnValue({
+      models: [],
+      loading: false,
+      error: "Model inventory unavailable",
+      fetchModels: vi.fn(),
+      createModel: vi.fn(),
+      updateModel: vi.fn(),
+      deleteModel: vi.fn(),
+      testModel: vi.fn(),
+    });
+    mockUseProviders.mockReturnValue({
+      providers: [],
+      loading: false,
+      error: null,
+      fetchProviders: vi.fn(),
+      createProvider: vi.fn(),
+      updateProvider: vi.fn(),
+      deleteProvider: vi.fn(),
+      checkHealth: vi.fn(),
+      killSwitchProvider: vi.fn(),
+      enableProvider: vi.fn(),
+    });
+  });
+
+  it("shows model load errors without also showing the empty state", () => {
+    render(<ModelsManager />);
+
+    expect(
+      screen.getByText("Model inventory unavailable"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/No models found/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/ai/ModelsManager.tsx
+++ b/frontend/src/components/features/admin/ai/ModelsManager.tsx
@@ -64,6 +64,8 @@ import {
 import { useModels, useProviders } from './hooks';
 import type { AIModel, ModelFormData, AIProvider } from './types';
 
+const ALL_FILTER_VALUE = 'all';
+
 interface ModelFormProps {
   model?: AIModel;
   providers: AIProvider[];
@@ -332,8 +334,10 @@ export function ModelsManager() {
   const [testingModel, setTestingModel] = useState<string | null>(null);
   const [testResult, setTestResult] = useState<TestResultProps['result'] | null>(null);
   const [showTestDialog, setShowTestDialog] = useState(false);
-  const [filterProvider, setFilterProvider] = useState<string>('');
-  const [filterEnabled, setFilterEnabled] = useState<string>('');
+  const [filterProvider, setFilterProvider] =
+    useState<string>(ALL_FILTER_VALUE);
+  const [filterEnabled, setFilterEnabled] =
+    useState<string>(ALL_FILTER_VALUE);
   const [searchQuery, setSearchQuery] = useState('');
   const [deleteTarget, setDeleteTarget] = useState<AIModel | null>(null);
 
@@ -389,7 +393,9 @@ export function ModelsManager() {
   };
 
   const filteredModels = models.filter((m) => {
-    if (filterProvider && m.provider.id !== filterProvider) return false;
+    if (filterProvider !== ALL_FILTER_VALUE && m.provider.id !== filterProvider) {
+      return false;
+    }
     if (filterEnabled === 'true' && !m.isEnabled) return false;
     if (filterEnabled === 'false' && m.isEnabled) return false;
     if (searchQuery) {
@@ -431,7 +437,7 @@ export function ModelsManager() {
               <SelectValue placeholder="All Providers" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">All Providers</SelectItem>
+              <SelectItem value={ALL_FILTER_VALUE}>All Providers</SelectItem>
               {providers.map((p) => (
                 <SelectItem key={p.id} value={p.id}>
                   {p.displayName}
@@ -444,7 +450,7 @@ export function ModelsManager() {
               <SelectValue placeholder="All Status" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">All Status</SelectItem>
+              <SelectItem value={ALL_FILTER_VALUE}>All Status</SelectItem>
               <SelectItem value="true">Enabled Only</SelectItem>
               <SelectItem value="false">Disabled Only</SelectItem>
             </SelectContent>
@@ -555,7 +561,7 @@ export function ModelsManager() {
                 </div>
               </div>
             ))}
-            {filteredModels.length === 0 && (
+            {!error && filteredModels.length === 0 && (
               <p className="text-center text-muted-foreground py-8">
                 No models found. Add your first model to get started.
               </p>


### PR DESCRIPTION
## Summary
- avoid showing the models empty state when the model list failed to load
- replace empty Select item values with an explicit all-filter sentinel
- add a ModelsManager component test for the error-only list state

## Verification
- cd frontend && npm run test:run -- src/components/features/admin/ai/ModelsManager.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check