### PR TITLE
fix(admin): hide route empty state on errors

### DIFF
--- a/frontend/src/components/features/admin/ai/RoutesManager.test.tsx
+++ b/frontend/src/components/features/admin/ai/RoutesManager.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RoutesManager } from "./RoutesManager";
+import { useModels, useRoutes } from "./hooks";
+
+vi.mock("./hooks", () => ({
+  useModels: vi.fn(),
+  useRoutes: vi.fn(),
+}));
+
+const mockUseModels = vi.mocked(useModels);
+const mockUseRoutes = vi.mocked(useRoutes);
+
+describe("RoutesManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseRoutes.mockReturnValue({
+      routes: [],
+      loading: false,
+      error: "Route inventory unavailable",
+      fetchRoutes: vi.fn(),
+      createRoute: vi.fn(),
+      updateRoute: vi.fn(),
+      deleteRoute: vi.fn(),
+    });
+    mockUseModels.mockReturnValue({
+      models: [],
+      loading: false,
+      error: null,
+      fetchModels: vi.fn(),
+      createModel: vi.fn(),
+      updateModel: vi.fn(),
+      deleteModel: vi.fn(),
+      testModel: vi.fn(),
+    });
+  });
+
+  it("shows route load errors without also showing the empty state", () => {
+    render(<RoutesManager />);
+
+    expect(
+      screen.getByText("Route inventory unavailable"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No routes configured/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/ai/RoutesManager.tsx
+++ b/frontend/src/components/features/admin/ai/RoutesManager.tsx
@@ -476,7 +476,7 @@ export function RoutesManager() {
                 </div>
               </div>
             ))}
-            {routes.length === 0 && (
+            {!error && routes.length === 0 && (
               <p className="text-center text-muted-foreground py-8">
                 No routes configured. Add your first routing rule to get started.
               </p>


### PR DESCRIPTION
## Summary
- avoid showing the routes empty state when the route list failed to load
- add a RoutesManager component test for the error-only list state

## Verification
- cd frontend && npm run test:run -- src/components/features/admin/ai/RoutesManager.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check