### PR TITLE
fix(admin): hide trace empty state on errors

### DIFF
--- a/frontend/src/components/features/admin/ai/TraceViewer.test.tsx
+++ b/frontend/src/components/features/admin/ai/TraceViewer.test.tsx
@@ -4,9 +4,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockFetchTraces = vi.hoisted(() => vi.fn());
 const mockFetchTraceDetail = vi.hoisted(() => vi.fn());
 const mockFetchTraceStats = vi.hoisted(() => vi.fn());
+const mockUseTraces = vi.hoisted(() => vi.fn());
 
 vi.mock('./hooks', () => ({
-  useTraces: () => ({
+  useTraces: mockUseTraces,
+}));
+
+function createUseTracesValue(overrides = {}) {
+  return {
     traces: [
       {
         trace_id: 'trace-1',
@@ -29,8 +34,9 @@ vi.mock('./hooks', () => ({
     fetchTraces: mockFetchTraces,
     fetchTraceDetail: mockFetchTraceDetail,
     fetchTraceStats: mockFetchTraceStats,
-  }),
-}));
+    ...overrides,
+  };
+}
 
 import { TraceViewer } from './TraceViewer';
 
@@ -54,6 +60,7 @@ describe('TraceViewer', () => {
         },
       },
     });
+    mockUseTraces.mockReturnValue(createUseTracesValue());
   });
 
   it('shows trace detail load errors instead of stale or empty detail content', async () => {
@@ -72,5 +79,23 @@ describe('TraceViewer', () => {
 
     expect(await screen.findByText('Trace not found')).toBeInTheDocument();
     expect(screen.queryByText('No trace data found')).not.toBeInTheDocument();
+  });
+
+  it('shows trace list errors without also showing the empty state', async () => {
+    mockUseTraces.mockReturnValue(
+      createUseTracesValue({
+        traces: [],
+        error: 'Trace service unavailable',
+        total: 0,
+      }),
+    );
+
+    render(<TraceViewer />);
+
+    expect(screen.getByText('Trace service unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('No traces found')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockFetchTraceStats).toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/components/features/admin/ai/TraceViewer.tsx
+++ b/frontend/src/components/features/admin/ai/TraceViewer.tsx
@@ -455,7 +455,7 @@ export function TraceViewer() {
                   </TableCell>
                 </TableRow>
               ))}
-              {!loading && traces.length === 0 && (
+              {!loading && !error && traces.length === 0 && (
                 <TableRow>
                   <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
                     No traces found


### PR DESCRIPTION
## Summary
- avoid showing the trace empty-state row when the trace list failed to load
- make TraceViewer hook mocks configurable per test
- add coverage for the trace-list error-only state

## Verification
- cd frontend && npm run test:run -- src/components/features/admin/ai/TraceViewer.test.tsx
- cd frontend && npm run type-check
- cd frontend && npm run lint
- git diff --check