### PR TITLE
fix(admin): hide usage empty state on errors

### DIFF
--- a/frontend/src/components/features/admin/ai/UsageMonitor.test.tsx
+++ b/frontend/src/components/features/admin/ai/UsageMonitor.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetchUsage = vi.hoisted(() => vi.fn());
+const mockExportConfig = vi.hoisted(() => vi.fn());
+const mockUseUsage = vi.hoisted(() => vi.fn());
+const mockUseAIConfig = vi.hoisted(() => vi.fn());
+
+vi.mock('./hooks', () => ({
+  useUsage: mockUseUsage,
+  useAIConfig: mockUseAIConfig,
+}));
+
+function createUsageData() {
+  return {
+    period: {
+      start: '2026-01-01',
+      end: '2026-01-07',
+    },
+    summary: {
+      totalRequests: 0,
+      totalTokens: 0,
+      totalCost: 0,
+      avgLatencyMs: 0,
+      successCount: 0,
+      errorCount: 0,
+    },
+    breakdown: [],
+  };
+}
+
+function createUseUsageValue(overrides = {}) {
+  return {
+    usage: createUsageData(),
+    loading: false,
+    error: null,
+    fetchUsage: mockFetchUsage,
+    ...overrides,
+  };
+}
+
+import { UsageMonitor } from './UsageMonitor';
+
+describe('UsageMonitor', () => {
+  beforeEach(() => {
+    mockFetchUsage.mockReset();
+    mockExportConfig.mockReset();
+    mockUseUsage.mockReset();
+    mockUseAIConfig.mockReset();
+    mockFetchUsage.mockResolvedValue(undefined);
+    mockExportConfig.mockResolvedValue({
+      ok: true,
+      data: {
+        exportedAt: '2026-01-01T00:00:00.000Z',
+        providers: [],
+        models: [],
+        routes: [],
+      },
+    });
+    mockUseAIConfig.mockReturnValue({
+      exportConfig: mockExportConfig,
+    });
+    mockUseUsage.mockReturnValue(createUseUsageValue());
+  });
+
+  it('shows usage load errors without also showing the empty breakdown state', async () => {
+    mockUseUsage.mockReturnValue(
+      createUseUsageValue({
+        error: 'Usage service unavailable',
+      }),
+    );
+
+    render(<UsageMonitor />);
+
+    expect(screen.getByText('Usage service unavailable')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No usage data available/i),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockFetchUsage).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/features/admin/ai/UsageMonitor.tsx
+++ b/frontend/src/components/features/admin/ai/UsageMonitor.tsx
@@ -133,6 +133,8 @@ export function UsageMonitor() {
     return 0;
   }, [chartData, groupBy]);
 
+  const showBreakdown = chartData.length > 0 || !error;
+
   const handleExport = async () => {
     const result = await exportConfig();
     if (result.ok && result.data) {
@@ -253,68 +255,69 @@ export function UsageMonitor() {
             </Card>
           </div>
 
-          {/* Breakdown */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">
-                {groupBy === 'day' ? 'Daily Usage' : 'Usage by Model'}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {chartData.length > 0 ? (
-                groupBy === 'model' ? (
-                  <div className="space-y-4">
-                    {chartData.map((item, idx) => (
-                      <UsageBar
-                        key={item.model?.id || idx}
-                        label={item.model?.displayName || 'Unknown'}
-                        value={item.requests}
-                        maxValue={maxRequests}
-                        color={
-                          idx === 0
-                            ? 'bg-blue-500'
-                            : idx === 1
-                            ? 'bg-green-500'
-                            : idx === 2
-                            ? 'bg-yellow-500'
-                            : 'bg-gray-400'
-                        }
-                      />
-                    ))}
-                  </div>
-                ) : (
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="border-b">
-                          <th className="text-left p-2">Date</th>
-                          <th className="text-right p-2">Requests</th>
-                          <th className="text-right p-2">Tokens</th>
-                          <th className="text-right p-2">Cost</th>
-                          <th className="text-right p-2">Avg Latency</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {chartData.map((item, idx) => (
-                          <tr key={item.date || idx} className="border-b">
-                            <td className="p-2">{item.date}</td>
-                            <td className="text-right p-2">{formatNumber(item.requests)}</td>
-                            <td className="text-right p-2">{formatNumber(item.tokens)}</td>
-                            <td className="text-right p-2">${item.cost.toFixed(4)}</td>
-                            <td className="text-right p-2">{item.avgLatencyMs}ms</td>
+          {showBreakdown && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">
+                  {groupBy === 'day' ? 'Daily Usage' : 'Usage by Model'}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {chartData.length > 0 ? (
+                  groupBy === 'model' ? (
+                    <div className="space-y-4">
+                      {chartData.map((item, idx) => (
+                        <UsageBar
+                          key={item.model?.id || idx}
+                          label={item.model?.displayName || 'Unknown'}
+                          value={item.requests}
+                          maxValue={maxRequests}
+                          color={
+                            idx === 0
+                              ? 'bg-blue-500'
+                              : idx === 1
+                              ? 'bg-green-500'
+                              : idx === 2
+                              ? 'bg-yellow-500'
+                              : 'bg-gray-400'
+                          }
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="border-b">
+                            <th className="text-left p-2">Date</th>
+                            <th className="text-right p-2">Requests</th>
+                            <th className="text-right p-2">Tokens</th>
+                            <th className="text-right p-2">Cost</th>
+                            <th className="text-right p-2">Avg Latency</th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )
-              ) : (
-                <p className="text-center text-muted-foreground py-8">
-                  No usage data available for this period.
-                </p>
-              )}
-            </CardContent>
-          </Card>
+                        </thead>
+                        <tbody>
+                          {chartData.map((item, idx) => (
+                            <tr key={item.date || idx} className="border-b">
+                              <td className="p-2">{item.date}</td>
+                              <td className="text-right p-2">{formatNumber(item.requests)}</td>
+                              <td className="text-right p-2">{formatNumber(item.tokens)}</td>
+                              <td className="text-right p-2">${item.cost.toFixed(4)}</td>
+                              <td className="text-right p-2">{item.avgLatencyMs}ms</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )
+                ) : (
+                  <p className="text-center text-muted-foreground py-8">
+                    No usage data available for this period.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
           {/* Config Actions */}
           <Card>


### PR DESCRIPTION
## Summary
- hide the UsageMonitor breakdown empty state while a usage load error is present
- add a UsageMonitor regression test for the error-only empty-breakdown state

## Verification
- npm run test:run -- src/components/features/admin/ai/UsageMonitor.test.tsx
- npm run type-check
- npm run lint
- git diff --check