### PR TITLE
fix(admin): hide audit empty state on errors

### DIFF
--- a/frontend/src/components/features/admin/secrets/AuditLogViewer.test.tsx
+++ b/frontend/src/components/features/admin/secrets/AuditLogViewer.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetchLogs = vi.hoisted(() => vi.fn());
+const mockUseAuditLog = vi.hoisted(() => vi.fn());
+
+vi.mock('./hooks', () => ({
+  useAuditLog: mockUseAuditLog,
+}));
+
+function createUseAuditLogValue(overrides = {}) {
+  return {
+    logs: [],
+    loading: false,
+    error: null,
+    pagination: {
+      total: 0,
+      limit: 20,
+      offset: 0,
+    },
+    fetchLogs: mockFetchLogs,
+    ...overrides,
+  };
+}
+
+import { AuditLogViewer } from './AuditLogViewer';
+
+describe('AuditLogViewer', () => {
+  beforeEach(() => {
+    mockFetchLogs.mockReset();
+    mockUseAuditLog.mockReset();
+    mockFetchLogs.mockResolvedValue(undefined);
+    mockUseAuditLog.mockReturnValue(createUseAuditLogValue());
+  });
+
+  it('shows audit log errors without also showing the empty state', async () => {
+    mockUseAuditLog.mockReturnValue(
+      createUseAuditLogValue({
+        error: 'Audit log unavailable',
+      }),
+    );
+
+    render(<AuditLogViewer />);
+
+    expect(screen.getByText('Audit log unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('No audit logs found')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockFetchLogs).toHaveBeenCalledWith({
+        action: undefined,
+        limit: 20,
+        offset: 0,
+      });
+    });
+  });
+});

--- a/frontend/src/components/features/admin/secrets/AuditLogViewer.tsx
+++ b/frontend/src/components/features/admin/secrets/AuditLogViewer.tsx
@@ -117,7 +117,7 @@ export function AuditLogViewer() {
             </div>
           ))}
 
-          {logs.length === 0 && !loading && (
+          {logs.length === 0 && !loading && !error && (
             <p className="text-center text-muted-foreground py-8">No audit logs found</p>
           )}
         </div>


### PR DESCRIPTION
## Summary
- suppress the audit log empty state while an audit log load error is present
- add an AuditLogViewer regression test for the error-only empty-list state

## Verification
- npm run test:run -- src/components/features/admin/secrets/AuditLogViewer.test.tsx
- npm run type-check
- npm run lint
- git diff --check