### PR TITLE
fix(admin): hide secrets empty state on errors

### DIFF
--- a/frontend/src/components/features/admin/secrets/SecretsListManager.test.tsx
+++ b/frontend/src/components/features/admin/secrets/SecretsListManager.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetchSecrets = vi.hoisted(() => vi.fn());
+const mockCreateSecret = vi.hoisted(() => vi.fn());
+const mockUpdateSecret = vi.hoisted(() => vi.fn());
+const mockDeleteSecret = vi.hoisted(() => vi.fn());
+const mockRevealSecret = vi.hoisted(() => vi.fn());
+const mockGenerateValue = vi.hoisted(() => vi.fn());
+const mockFetchCategories = vi.hoisted(() => vi.fn());
+const mockCreateCategory = vi.hoisted(() => vi.fn());
+const mockUseSecrets = vi.hoisted(() => vi.fn());
+const mockUseCategories = vi.hoisted(() => vi.fn());
+
+vi.mock('./hooks', () => ({
+  useSecrets: mockUseSecrets,
+  useCategories: mockUseCategories,
+}));
+
+function createUseSecretsValue(overrides = {}) {
+  return {
+    secrets: [],
+    loading: false,
+    error: null,
+    fetchSecrets: mockFetchSecrets,
+    createSecret: mockCreateSecret,
+    updateSecret: mockUpdateSecret,
+    deleteSecret: mockDeleteSecret,
+    revealSecret: mockRevealSecret,
+    generateValue: mockGenerateValue,
+    ...overrides,
+  };
+}
+
+function createUseCategoriesValue(overrides = {}) {
+  return {
+    categories: [],
+    loading: false,
+    error: null,
+    fetchCategories: mockFetchCategories,
+    createCategory: mockCreateCategory,
+    ...overrides,
+  };
+}
+
+import { SecretsListManager } from './SecretsListManager';
+
+describe('SecretsListManager', () => {
+  beforeEach(() => {
+    mockFetchSecrets.mockReset();
+    mockCreateSecret.mockReset();
+    mockUpdateSecret.mockReset();
+    mockDeleteSecret.mockReset();
+    mockRevealSecret.mockReset();
+    mockGenerateValue.mockReset();
+    mockFetchCategories.mockReset();
+    mockCreateCategory.mockReset();
+    mockUseSecrets.mockReset();
+    mockUseCategories.mockReset();
+    mockFetchSecrets.mockResolvedValue(undefined);
+    mockUseSecrets.mockReturnValue(createUseSecretsValue());
+    mockUseCategories.mockReturnValue(createUseCategoriesValue());
+  });
+
+  it('shows secret load errors without also showing the empty state', async () => {
+    mockUseSecrets.mockReturnValue(
+      createUseSecretsValue({
+        error: 'Secrets inventory unavailable',
+      }),
+    );
+
+    render(<SecretsListManager categories={[]} />);
+
+    expect(screen.getByText('Secrets inventory unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('No secrets found')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockFetchSecrets).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/features/admin/secrets/SecretsListManager.tsx
+++ b/frontend/src/components/features/admin/secrets/SecretsListManager.tsx
@@ -505,7 +505,7 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
           </Card>
         ))}
 
-        {filteredSecrets.length === 0 && !loading && (
+        {filteredSecrets.length === 0 && !loading && !error && (
           <Card>
             <CardContent className="py-12 text-center">
               <Key className="h-12 w-12 mx-auto text-muted-foreground mb-4" />


### PR DESCRIPTION
## Summary
- suppress the secrets empty state while a secrets load error is present
- add a SecretsListManager regression test for the error-only empty-list state

## Verification
- npm run test:run -- src/components/features/admin/secrets/SecretsListManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check