### PR TITLE
fix(admin): show rag collection errors

### DIFF
--- a/frontend/src/components/features/admin/rag/RAGManager.test.tsx
+++ b/frontend/src/components/features/admin/rag/RAGManager.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCheckRAGHealth = vi.hoisted(() => vi.fn());
+const mockSemanticSearch = vi.hoisted(() => vi.fn());
+const mockGetCollections = vi.hoisted(() => vi.fn());
+const mockGetCollectionStatus = vi.hoisted(() => vi.fn());
+
+vi.mock('@/services/discovery/rag', () => ({
+  checkRAGHealth: mockCheckRAGHealth,
+  semanticSearch: mockSemanticSearch,
+  getCollections: mockGetCollections,
+  getCollectionStatus: mockGetCollectionStatus,
+}));
+
+import { RAGManager } from './RAGManager';
+
+describe('RAGManager', () => {
+  beforeEach(() => {
+    mockCheckRAGHealth.mockReset();
+    mockSemanticSearch.mockReset();
+    mockGetCollections.mockReset();
+    mockGetCollectionStatus.mockReset();
+    mockCheckRAGHealth.mockResolvedValue({
+      ok: true,
+      data: {
+        status: 'ok',
+        chromadb: true,
+        embedding: true,
+        timestamp: '2026-01-01T00:00:00.000Z',
+      },
+    });
+    mockGetCollections.mockResolvedValue({
+      ok: true,
+      data: {
+        collections: [],
+        total: 0,
+      },
+    });
+    mockGetCollectionStatus.mockResolvedValue({
+      ok: true,
+      data: {
+        collection: 'posts',
+        exists: true,
+        count: 12,
+      },
+    });
+  });
+
+  it('shows collection load errors without also showing the empty state', async () => {
+    mockGetCollections.mockResolvedValue({
+      ok: false,
+      error: 'Collections service unavailable',
+    });
+
+    render(<RAGManager />);
+
+    expect(await screen.findByText('Collections service unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('No collections found.')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/rag/RAGManager.tsx
+++ b/frontend/src/components/features/admin/rag/RAGManager.tsx
@@ -107,18 +107,24 @@ function RAGHealthSection() {
 function CollectionsSection() {
   const [collections, setCollections] = useState<RAGCollection[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [selectedCollection, setSelectedCollection] = useState<string | null>(null);
   const [collectionStats, setCollectionStats] = useState<{ count: number; exists: boolean } | null>(null);
 
   const fetchCollections = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const response = await getCollections();
       if (response.ok && response.data) {
         setCollections(response.data.collections);
+      } else {
+        setCollections([]);
+        setError(response.error || 'Failed to fetch collections');
       }
-    } catch {
+    } catch (err) {
       setCollections([]);
+      setError(err instanceof Error ? err.message : 'Failed to fetch collections');
     } finally {
       setLoading(false);
     }
@@ -162,6 +168,8 @@ function CollectionsSection() {
             <RefreshCw className="h-3 w-3 animate-spin" />
             Loading...
           </div>
+        ) : error ? (
+          <p className="text-xs text-red-600">{error}</p>
         ) : collections.length === 0 ? (
           <p className="text-xs text-zinc-400">No collections found.</p>
         ) : (


### PR DESCRIPTION
## Summary
- preserve and display RAG collection fetch errors in the admin RAG manager
- avoid showing the collections empty state when the fetch failed
- add a RAGManager regression test for the collection error state

## Verification
- npm run test:run -- src/components/features/admin/rag/RAGManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check