### PR TITLE
fix(admin): show rag index errors

### DIFF
--- a/frontend/src/components/features/admin/rag/RAGManager.test.tsx
+++ b/frontend/src/components/features/admin/rag/RAGManager.test.tsx
@@ -58,4 +58,16 @@ describe('RAGManager', () => {
     expect(await screen.findByText('Collections service unavailable')).toBeInTheDocument();
     expect(screen.queryByText('No collections found.')).not.toBeInTheDocument();
   });
+
+  it('shows index status errors instead of the generic unavailable state', async () => {
+    mockGetCollectionStatus.mockResolvedValue({
+      ok: false,
+      error: 'Index status unavailable',
+    });
+
+    render(<RAGManager />);
+
+    expect(await screen.findByText('Index status unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Unable to fetch index status.')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/features/admin/rag/RAGManager.tsx
+++ b/frontend/src/components/features/admin/rag/RAGManager.tsx
@@ -208,16 +208,22 @@ function CollectionsSection() {
 function IndexStatusSection() {
   const [status, setStatus] = useState<{ count: number; collection: string } | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchStatus = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const response = await getCollectionStatus();
       if (response.ok && response.data) {
         setStatus({ count: response.data.count, collection: response.data.collection });
+      } else {
+        setStatus(null);
+        setError(response.error || 'Failed to fetch index status');
       }
-    } catch {
+    } catch (err) {
       setStatus(null);
+      setError(err instanceof Error ? err.message : 'Failed to fetch index status');
     } finally {
       setLoading(false);
     }
@@ -239,6 +245,8 @@ function IndexStatusSection() {
             <RefreshCw className="h-3 w-3 animate-spin" />
             Loading...
           </div>
+        ) : error ? (
+          <p className="text-xs text-red-600">{error}</p>
         ) : status ? (
           <div className="space-y-2">
             <div className="grid grid-cols-2 gap-px border border-zinc-100 rounded-md overflow-hidden">


### PR DESCRIPTION
## Summary
- preserve and display RAG index status fetch errors in the admin RAG manager
- avoid replacing failed status loads with the generic unavailable message
- add RAGManager regression coverage for index status errors

## Verification
- npm run test:run -- src/components/features/admin/rag/RAGManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check