### PR TITLE
fix(admin): show rag health errors

### DIFF
--- a/frontend/src/components/features/admin/rag/RAGManager.test.tsx
+++ b/frontend/src/components/features/admin/rag/RAGManager.test.tsx
@@ -59,6 +59,20 @@ describe('RAGManager', () => {
     expect(screen.queryByText('No collections found.')).not.toBeInTheDocument();
   });
 
+  it('shows health load errors instead of only the unreachable fallback', async () => {
+    mockCheckRAGHealth.mockResolvedValue({
+      ok: false,
+      error: {
+        message: 'Health service unavailable',
+      },
+    });
+
+    render(<RAGManager />);
+
+    expect(await screen.findByText('Health service unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Unreachable')).not.toBeInTheDocument();
+  });
+
   it('shows index status errors instead of the generic unavailable state', async () => {
     mockGetCollectionStatus.mockResolvedValue({
       ok: false,

--- a/frontend/src/components/features/admin/rag/RAGManager.tsx
+++ b/frontend/src/components/features/admin/rag/RAGManager.tsx
@@ -26,9 +26,11 @@ interface HealthStatus {
 function RAGHealthSection() {
   const [health, setHealth] = useState<HealthStatus | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchHealth = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const response = await checkRAGHealth();
       if (response.ok && response.data) {
@@ -43,10 +45,14 @@ function RAGHealthSection() {
             embedding: raw.services.embedding,
             chroma: raw.services.chroma,
           });
+        } else {
+          setHealth(null);
+          setError(response.error?.message || 'Failed to fetch RAG health');
         }
       }
-    } catch {
+    } catch (err) {
       setHealth(null);
+      setError(err instanceof Error ? err.message : 'Failed to fetch RAG health');
     } finally {
       setLoading(false);
     }
@@ -85,6 +91,11 @@ function RAGHealthSection() {
               </span>
             </span>
           </>
+        ) : error ? (
+          <span className="flex items-center gap-1 text-xs text-red-600">
+            <AlertCircle className="h-3 w-3" />
+            {error}
+          </span>
         ) : (
           <span className="flex items-center gap-1 text-xs text-red-600">
             <AlertCircle className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- preserve and display RAG health check failures in the admin RAG manager
- keep the existing Unreachable fallback only when no specific error is available
- add RAGManager regression coverage for health check errors

## Verification
- npm run test:run -- src/components/features/admin/rag/RAGManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check