### PR TITLE
fix(admin): show log stream errors

### DIFF
--- a/frontend/src/components/features/admin/logs/LogViewer.test.tsx
+++ b/frontend/src/components/features/admin/logs/LogViewer.test.tsx
@@ -100,6 +100,7 @@ describe("LogViewer stream controller", () => {
 
     const state = createLogState();
     const setConnected = vi.fn();
+    const setConnectionError = vi.fn();
 
     await connectLogStream({
       abortRef: { current: null },
@@ -108,6 +109,7 @@ describe("LogViewer stream controller", () => {
       pausedRef: { current: false },
       reconnect: vi.fn(),
       setConnected,
+      setConnectionError,
       setLogs: state.setLogs,
     });
 
@@ -121,6 +123,7 @@ describe("LogViewer stream controller", () => {
         }),
       }),
     );
+    expect(setConnectionError).toHaveBeenCalledWith(null);
   });
 
   it("retries on non-ok responses without entering the stream parser", async () => {
@@ -143,6 +146,7 @@ describe("LogViewer stream controller", () => {
 
     const state = createLogState();
     const setConnected = vi.fn();
+    const setConnectionError = vi.fn();
     const abortRef = { current: null as AbortController | null };
 
     async function connect() {
@@ -157,6 +161,7 @@ describe("LogViewer stream controller", () => {
           }, 3000);
         },
         setConnected,
+        setConnectionError,
         setLogs: state.setLogs,
       });
     }
@@ -166,6 +171,9 @@ describe("LogViewer stream controller", () => {
     expect(firstGetReader).not.toHaveBeenCalled();
     expect(state.getLogs()).toEqual([]);
     expect(setConnected).toHaveBeenCalledWith(false);
+    expect(setConnectionError).toHaveBeenCalledWith(
+      "Log stream request failed with HTTP 401",
+    );
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(3000);

--- a/frontend/src/components/features/admin/logs/LogViewer.tsx
+++ b/frontend/src/components/features/admin/logs/LogViewer.tsx
@@ -111,6 +111,7 @@ export async function connectLogStream({
   pausedRef,
   reconnect,
   setConnected,
+  setConnectionError,
   setLogs,
 }: {
   abortRef: AbortControllerRef;
@@ -119,15 +120,18 @@ export async function connectLogStream({
   pausedRef: BooleanRef;
   reconnect: () => void;
   setConnected: (connected: boolean) => void;
+  setConnectionError?: (error: string | null) => void;
   setLogs: LogStateSetter;
 }) {
   if (abortRef.current) {
     abortRef.current.abort();
   }
 
+  setConnectionError?.(null);
   const token = await getValidAccessToken();
   if (!token) {
     setConnected(false);
+    setConnectionError?.("Not authenticated. Please log in again.");
     reconnect();
     return;
   }
@@ -148,17 +152,20 @@ export async function connectLogStream({
 
     if (!response.ok) {
       setConnected(false);
+      setConnectionError?.(`Log stream request failed with HTTP ${response.status}`);
       reconnect();
       return;
     }
 
     if (!response.body) {
       setConnected(false);
+      setConnectionError?.("Log stream response did not include a body.");
       reconnect();
       return;
     }
 
     setConnected(true);
+    setConnectionError?.(null);
     const reader = response.body.getReader();
     await parseLogStream(reader, { pausedRef, setLogs });
 
@@ -171,6 +178,9 @@ export async function connectLogStream({
       return;
     }
     setConnected(false);
+    setConnectionError?.(
+      err instanceof Error ? err.message : "Failed to connect to log stream",
+    );
     reconnect();
   }
 }
@@ -245,6 +255,7 @@ export function LogViewer() {
   const [levelFilter, setLevelFilter] = useState<string>("all");
   const [serviceFilter, setServiceFilter] = useState("");
   const [connected, setConnected] = useState(false);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const pausedRef = useRef(false);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -275,6 +286,7 @@ export function LogViewer() {
       pausedRef,
       reconnect: scheduleReconnect,
       setConnected,
+      setConnectionError,
       setLogs,
     });
   }, [getValidAccessToken, scheduleReconnect]);
@@ -377,8 +389,12 @@ export function LogViewer() {
       </div>
       <div className="h-[500px] overflow-y-auto font-mono bg-white">
         {filtered.length === 0 ? (
-          <div className="flex items-center justify-center h-full text-xs text-zinc-400">
-            {connected ? "Waiting for logs..." : "Connecting..."}
+          <div
+            className={`flex items-center justify-center h-full text-xs ${
+              connectionError ? "text-red-600" : "text-zinc-400"
+            }`}
+          >
+            {connectionError || (connected ? "Waiting for logs..." : "Connecting...")}
           </div>
         ) : (
           filtered.map((entry, i) => (


### PR DESCRIPTION
## Summary
- surface log stream connection failures in the admin LogViewer instead of only showing Connecting
- keep reconnect behavior unchanged while clearing the message on successful connection
- extend LogViewer stream controller coverage for connection error reporting

## Verification
- npm run test:run -- src/components/features/admin/logs/LogViewer.test.tsx
- npm run type-check
- npm run lint
- git diff --check