### PR TITLE
fix(admin): hide trending empty state on degraded analytics

### DIFF
--- a/frontend/src/components/features/admin/analytics/AnalyticsManager.test.tsx
+++ b/frontend/src/components/features/admin/analytics/AnalyticsManager.test.tsx
@@ -5,6 +5,7 @@ import {
   EditorPicksSection,
   getAllPostStats,
   StatsRefreshSection,
+  TrendingPostsSection,
 } from "./AnalyticsManager";
 
 const { mockAdminApiFetch, mockAdminFetchRaw } = vi.hoisted(() => ({
@@ -133,6 +134,33 @@ describe("getAllPostStats", () => {
     ).toBeInTheDocument();
     expect(
       screen.queryByText(/No editor picks configured/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows trending degraded messages without also showing the empty state", async () => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          degraded: true,
+          error: { message: "Trending analytics unavailable" },
+        }),
+        {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }) as typeof fetch;
+
+    render(<TrendingPostsSection />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Trending analytics unavailable/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/No trending data for this period/i),
     ).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/features/admin/analytics/AnalyticsManager.tsx
+++ b/frontend/src/components/features/admin/analytics/AnalyticsManager.tsx
@@ -556,7 +556,7 @@ export function EditorPicksSection() {
   );
 }
 
-function TrendingPostsSection() {
+export function TrendingPostsSection() {
   const [trending, setTrending] = useState<TrendingPost[]>([]);
   const [loading, setLoading] = useState(true);
   const [days, setDays] = useState(7);
@@ -630,7 +630,7 @@ function TrendingPostsSection() {
           <RefreshCw className="h-3 w-3 animate-spin" />
           Loading...
         </div>
-      ) : trending.length === 0 ? (
+      ) : degradedMessage ? null : trending.length === 0 ? (
         <p className="px-4 py-3 text-xs text-zinc-400">
           No trending data for this period.
         </p>


### PR DESCRIPTION
## Summary
- suppress the Trending Posts empty state while degraded analytics messaging is present
- export TrendingPostsSection for focused component coverage, matching the other analytics sections
- add regression coverage for the degraded trending state

## Verification
- npm run test:run -- src/components/features/admin/analytics/AnalyticsManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check