### PR TITLE
fix(admin): show playground load errors

### DIFF
--- a/frontend/src/components/features/admin/ai/Playground.test.tsx
+++ b/frontend/src/components/features/admin/ai/Playground.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetchModels = vi.hoisted(() => vi.fn());
+const mockFetchHistory = vi.hoisted(() => vi.fn());
+const mockDeleteHistory = vi.hoisted(() => vi.fn());
+const mockClearHistory = vi.hoisted(() => vi.fn());
+const mockFetchTemplates = vi.hoisted(() => vi.fn());
+const mockCreateTemplate = vi.hoisted(() => vi.fn());
+const mockDeleteTemplate = vi.hoisted(() => vi.fn());
+const mockApplyTemplate = vi.hoisted(() => vi.fn());
+const mockRunPlayground = vi.hoisted(() => vi.fn());
+const mockUseModels = vi.hoisted(() => vi.fn());
+const mockUsePlayground = vi.hoisted(() => vi.fn());
+
+vi.mock('./hooks', () => ({
+  useModels: mockUseModels,
+  usePlayground: mockUsePlayground,
+}));
+
+function createUseModelsValue(overrides = {}) {
+  return {
+    models: [],
+    loading: false,
+    error: null,
+    fetchModels: mockFetchModels,
+    createModel: vi.fn(),
+    updateModel: vi.fn(),
+    deleteModel: vi.fn(),
+    testModel: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createUsePlaygroundValue(overrides = {}) {
+  return {
+    history: [],
+    templates: [],
+    loading: false,
+    running: false,
+    error: null,
+    total: 0,
+    runPlayground: mockRunPlayground,
+    fetchHistory: mockFetchHistory,
+    deleteHistory: mockDeleteHistory,
+    clearHistory: mockClearHistory,
+    fetchTemplates: mockFetchTemplates,
+    createTemplate: mockCreateTemplate,
+    deleteTemplate: mockDeleteTemplate,
+    applyTemplate: mockApplyTemplate,
+    ...overrides,
+  };
+}
+
+import { Playground } from './Playground';
+
+describe('Playground', () => {
+  beforeEach(() => {
+    mockFetchModels.mockReset();
+    mockFetchHistory.mockReset();
+    mockDeleteHistory.mockReset();
+    mockClearHistory.mockReset();
+    mockFetchTemplates.mockReset();
+    mockCreateTemplate.mockReset();
+    mockDeleteTemplate.mockReset();
+    mockApplyTemplate.mockReset();
+    mockRunPlayground.mockReset();
+    mockUseModels.mockReset();
+    mockUsePlayground.mockReset();
+    mockFetchModels.mockResolvedValue(undefined);
+    mockFetchHistory.mockResolvedValue(undefined);
+    mockFetchTemplates.mockResolvedValue(undefined);
+    mockUseModels.mockReturnValue(createUseModelsValue());
+    mockUsePlayground.mockReturnValue(createUsePlaygroundValue());
+  });
+
+  it('shows playground load errors without also showing history empty state', async () => {
+    mockUsePlayground.mockReturnValue(
+      createUsePlaygroundValue({
+        error: 'Playground history unavailable',
+      }),
+    );
+
+    render(<Playground />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /History/i }));
+
+    expect(screen.getByText('Playground history unavailable')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No history yet/i),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockFetchHistory).toHaveBeenCalledWith({ limit: 20 });
+    });
+  });
+});

--- a/frontend/src/components/features/admin/ai/Playground.tsx
+++ b/frontend/src/components/features/admin/ai/Playground.tsx
@@ -57,6 +57,7 @@ import {
   Bot,
   Save,
   ChevronRight,
+  AlertCircle,
 } from 'lucide-react';
 import {
   usePlayground,
@@ -362,6 +363,7 @@ export function Playground() {
     history,
     templates,
     running,
+    error,
     total: historyTotal,
     runPlayground,
     fetchHistory,
@@ -462,6 +464,13 @@ export function Playground() {
 
   return (
     <div className="space-y-6">
+      {error && (
+        <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-md flex items-center gap-2">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      )}
+
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>
           <TabsTrigger value="playground" className="flex items-center gap-2">
@@ -717,7 +726,7 @@ export function Playground() {
                       </TableCell>
                     </TableRow>
                   ))}
-                  {history.length === 0 && (
+                  {!error && history.length === 0 && (
                     <TableRow>
                       <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
                         No history yet. Run a prompt to get started.


### PR DESCRIPTION
## Summary
- render usePlayground load errors in the admin Playground panel
- suppress the history empty state while a playground load error is present
- add focused Playground coverage for the history error-only state

## Verification
- npm run test:run -- src/components/features/admin/ai/Playground.test.tsx
- npm run type-check
- npm run lint
- git diff --check