### PR TITLE
fix(admin): show playground model errors

### DIFF
--- a/frontend/src/components/features/admin/ai/Playground.test.tsx
+++ b/frontend/src/components/features/admin/ai/Playground.test.tsx
@@ -93,4 +93,19 @@ describe('Playground', () => {
       expect(mockFetchHistory).toHaveBeenCalledWith({ limit: 20 });
     });
   });
+
+  it('shows model load errors in the playground panel', async () => {
+    mockUseModels.mockReturnValue(
+      createUseModelsValue({
+        error: 'Model inventory unavailable',
+      }),
+    );
+
+    render(<Playground />);
+
+    expect(screen.getByText('Model inventory unavailable')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockFetchModels).toHaveBeenCalledWith(undefined, true);
+    });
+  });
 });

--- a/frontend/src/components/features/admin/ai/Playground.tsx
+++ b/frontend/src/components/features/admin/ai/Playground.tsx
@@ -358,7 +358,7 @@ function SaveTemplateDialog({
 }
 
 export function Playground() {
-  const { models, fetchModels } = useModels();
+  const { models, error: modelsError, fetchModels } = useModels();
   const {
     history,
     templates,
@@ -461,13 +461,14 @@ export function Playground() {
   };
 
   const isComparing = results.length > 1;
+  const displayError = error || modelsError;
 
   return (
     <div className="space-y-6">
-      {error && (
+      {displayError && (
         <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-md flex items-center gap-2">
           <AlertCircle className="h-4 w-4" />
-          {error}
+          {displayError}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- surface useModels load errors in the admin Playground panel
- reuse the existing Playground error banner while keeping history empty-state behavior scoped to playground errors
- extend Playground coverage for model inventory failures

## Verification
- npm run test:run -- src/components/features/admin/ai/Playground.test.tsx
- npm run type-check
- npm run lint
- git diff --check