### PR TITLE
fix(admin): show playground template errors

### DIFF
--- a/frontend/src/components/features/admin/ai/Playground.test.tsx
+++ b/frontend/src/components/features/admin/ai/Playground.test.tsx
@@ -39,6 +39,7 @@ function createUsePlaygroundValue(overrides = {}) {
     loading: false,
     running: false,
     error: null,
+    templatesError: null,
     total: 0,
     runPlayground: mockRunPlayground,
     fetchHistory: mockFetchHistory,
@@ -106,6 +107,26 @@ describe('Playground', () => {
     expect(screen.getByText('Model inventory unavailable')).toBeInTheDocument();
     await waitFor(() => {
       expect(mockFetchModels).toHaveBeenCalledWith(undefined, true);
+    });
+  });
+
+  it('shows template load errors without also showing the template empty state', async () => {
+    mockUsePlayground.mockReturnValue(
+      createUsePlaygroundValue({
+        templatesError: 'Prompt templates unavailable',
+      }),
+    );
+
+    render(<Playground />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /Templates/i }));
+
+    expect(screen.getByText('Prompt templates unavailable')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No templates yet/i),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockFetchTemplates).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/features/admin/ai/Playground.tsx
+++ b/frontend/src/components/features/admin/ai/Playground.tsx
@@ -364,6 +364,7 @@ export function Playground() {
     templates,
     running,
     error,
+    templatesError,
     total: historyTotal,
     runPlayground,
     fetchHistory,
@@ -461,7 +462,7 @@ export function Playground() {
   };
 
   const isComparing = results.length > 1;
-  const displayError = error || modelsError;
+  const displayError = error || modelsError || templatesError;
 
   return (
     <div className="space-y-6">
@@ -786,7 +787,7 @@ export function Playground() {
                     </CardContent>
                   </Card>
                 ))}
-                {templates.length === 0 && (
+                {!templatesError && templates.length === 0 && (
                   <div className="col-span-full text-center text-muted-foreground py-8">
                     No templates yet. Save a prompt as a template to get started.
                   </div>

--- a/frontend/src/components/features/admin/ai/hooks.ts
+++ b/frontend/src/components/features/admin/ai/hooks.ts
@@ -575,6 +575,7 @@ export function usePlayground() {
   const [loading, setLoading] = useState(false);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [templatesError, setTemplatesError] = useState<string | null>(null);
   const [total, setTotal] = useState(0);
 
   const runPlayground = useCallback(
@@ -672,12 +673,15 @@ export function usePlayground() {
   );
 
   const fetchTemplates = useCallback(async (category?: string) => {
+    setTemplatesError(null);
     const query = category ? `?category=${category}` : '';
     const result = await adminApiFetch<{ templates: PromptTemplate[]; total: number }>(
       `/prompt-templates${query}`
     , { pathPrefix: '/api/v1/admin/ai' });
     if (result.ok && result.data) {
       setTemplates(result.data.templates);
+    } else {
+      setTemplatesError(result.error || 'Failed to fetch templates');
     }
     return result;
   }, []);
@@ -762,6 +766,7 @@ export function usePlayground() {
     loading,
     running,
     error,
+    templatesError,
     total,
     runPlayground,
     fetchHistory,


### PR DESCRIPTION
## Summary
- track prompt-template load failures separately in usePlayground
- surface template load errors in the Playground error banner
- suppress the templates empty state while a template load error is present

## Verification
- npm run test:run -- src/components/features/admin/ai/Playground.test.tsx
- npm run type-check
- npm run lint
- git diff --check