### PR TITLE
fix(admin): show realtime visitor outages

### DIFF
--- a/frontend/src/components/features/admin/analytics/AnalyticsManager.test.tsx
+++ b/frontend/src/components/features/admin/analytics/AnalyticsManager.test.tsx
@@ -4,13 +4,19 @@ import {
   AllPostsSection,
   EditorPicksSection,
   getAllPostStats,
+  RealtimeVisitorsSection,
   StatsRefreshSection,
   TrendingPostsSection,
 } from "./AnalyticsManager";
 
-const { mockAdminApiFetch, mockAdminFetchRaw } = vi.hoisted(() => ({
+const {
+  mockAdminApiFetch,
+  mockAdminFetchRaw,
+  mockGetRealtimeVisitorsSnapshot,
+} = vi.hoisted(() => ({
   mockAdminApiFetch: vi.fn(),
   mockAdminFetchRaw: vi.fn(),
+  mockGetRealtimeVisitorsSnapshot: vi.fn(),
 }));
 
 vi.mock("@/services/admin/apiClient", () => ({
@@ -20,6 +26,10 @@ vi.mock("@/services/admin/apiClient", () => ({
 
 vi.mock("@/utils/network/apiBase", () => ({
   getApiBaseUrl: () => "https://admin.example.com",
+}));
+
+vi.mock("@/services/content/analytics", () => ({
+  getRealtimeVisitorsSnapshot: mockGetRealtimeVisitorsSnapshot,
 }));
 
 describe("getAllPostStats", () => {
@@ -161,6 +171,28 @@ describe("getAllPostStats", () => {
 
     expect(
       screen.queryByText(/No trending data for this period/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows realtime visitor degraded messages without reporting zero visitors", async () => {
+    mockGetRealtimeVisitorsSnapshot.mockResolvedValue({
+      data: { activeVisitors: 0, timestamp: null },
+      degraded: true,
+      errorMessage: "Realtime KV unavailable",
+    });
+
+    render(<RealtimeVisitorsSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Realtime KV unavailable/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(screen.getByText(/visitor count unavailable/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^0$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Last updated:/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Best-effort signal backed by heartbeat writes/i),
     ).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/features/admin/analytics/AnalyticsManager.tsx
+++ b/frontend/src/components/features/admin/analytics/AnalyticsManager.tsx
@@ -154,7 +154,7 @@ async function refreshStats(): Promise<StatsRefreshResult> {
   }
 }
 
-function RealtimeVisitorsSection() {
+export function RealtimeVisitorsSection() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [activeVisitors, setActiveVisitors] = useState(0);
@@ -170,10 +170,13 @@ function RealtimeVisitorsSection() {
       }
 
       const result = await getRealtimeVisitorsSnapshot();
+      const realtimeUnavailable = Boolean(result.degraded);
       setActiveVisitors(result.data.activeVisitors);
-      setLastUpdated(result.data.timestamp ?? Date.now());
+      setLastUpdated(
+        realtimeUnavailable ? null : result.data.timestamp ?? Date.now(),
+      );
       setDegradedMessage(
-        result.degraded
+        realtimeUnavailable
           ? result.errorMessage || "Realtime visitor analytics unavailable"
           : null
       );
@@ -262,17 +265,27 @@ function RealtimeVisitorsSection() {
         ) : (
           <>
             <div className="flex items-end gap-2">
-              <span className="font-mono text-2xl font-semibold text-zinc-900">
-                {activeVisitors.toLocaleString()}
+              <span
+                className={`font-mono text-2xl font-semibold ${
+                  degradedMessage ? "text-zinc-500" : "text-zinc-900"
+                }`}
+              >
+                {degradedMessage
+                  ? "Unavailable"
+                  : activeVisitors.toLocaleString()}
               </span>
               <span className="pb-0.5 text-xs text-zinc-400">
-                active within 60s
+                {degradedMessage
+                  ? "visitor count unavailable"
+                  : "active within 60s"}
               </span>
             </div>
-            <p className="text-xs text-zinc-400">
-              Best-effort signal backed by heartbeat writes and KV-based reads.
-            </p>
-            {lastUpdated && (
+            {!degradedMessage && (
+              <p className="text-xs text-zinc-400">
+                Best-effort signal backed by heartbeat writes and KV-based reads.
+              </p>
+            )}
+            {!degradedMessage && lastUpdated && (
               <p className="text-xs text-zinc-400">
                 Last updated:{" "}
                 <span className="font-mono">


### PR DESCRIPTION
## Summary
- show an explicit unavailable state for realtime visitor degraded responses
- avoid rendering outage fallback counts as real zero-visitor data
- add focused analytics manager coverage for realtime degraded responses

## Testing
- npm run test:run -- src/components/features/admin/analytics/AnalyticsManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check -- frontend/src/components/features/admin/analytics/AnalyticsManager.tsx frontend/src/components/features/admin/analytics/AnalyticsManager.test.tsx

## Risks
- realtime visitor degraded responses now suppress stale last-updated/supporting copy until a healthy response is available

## Follow-ups
- Continue admin-only route/client contract review from latest main.