### PR TITLE
fix(admin): block CTA saves after load failures

### DIFF
--- a/frontend/src/components/features/admin/content/ContentManager.tsx
+++ b/frontend/src/components/features/admin/content/ContentManager.tsx
@@ -1,7 +1,7 @@
 import type { SiteContentBlock } from '@/services/content/site-content';
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { FileText, Megaphone, RefreshCw, Save } from 'lucide-react';
+import { AlertCircle, FileText, Megaphone, RefreshCw, Save } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
@@ -66,6 +66,11 @@ export function ContentManager({
   });
 
   const block = query.data ?? DEFAULT_HOME_AI_CTA_BLOCK;
+  const homeCtaLoadError = query.error instanceof Error ? query.error : null;
+  const hasLoadedHomeCta = query.data !== undefined;
+  const homeCtaUnavailable = Boolean(homeCtaLoadError && !hasLoadedHomeCta);
+  const homeCtaFormDisabled =
+    homeCtaUnavailable || (query.isLoading && !hasLoadedHomeCta);
 
   useEffect(() => {
     setMarkdown(block.markdown);
@@ -91,6 +96,7 @@ export function ContentManager({
   });
 
   const handleSave = () => {
+    if (homeCtaFormDisabled) return;
     saveMutation.mutate({
       markdown,
       ctaLabel: ctaLabel || null,
@@ -138,9 +144,28 @@ export function ContentManager({
         </div>
 
         <div className='space-y-4 p-4'>
-          {query.error instanceof Error && (
+          {homeCtaLoadError && (
             <div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-300'>
-              {query.error.message}
+              <div className='flex items-start justify-between gap-3'>
+                <div className='flex min-w-0 items-start gap-2'>
+                  <AlertCircle className='mt-0.5 h-3.5 w-3.5 shrink-0' />
+                  <div className='min-w-0'>
+                    <p className='font-medium'>Unable to load Home CTA</p>
+                    <p className='mt-1'>{homeCtaLoadError.message}</p>
+                  </div>
+                </div>
+                <button
+                  type='button'
+                  onClick={() => void query.refetch()}
+                  disabled={query.isFetching}
+                  className='inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-amber-200 bg-white px-2 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-100 disabled:opacity-50 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-200 dark:hover:bg-amber-900/40'
+                >
+                  <RefreshCw
+                    className={`h-3 w-3 ${query.isFetching ? 'animate-spin' : ''}`}
+                  />
+                  Retry
+                </button>
+              </div>
             </div>
           )}
 
@@ -153,6 +178,7 @@ export function ContentManager({
               value={markdown}
               onChange={event => setMarkdown(event.target.value)}
               rows={12}
+              disabled={homeCtaFormDisabled}
               className='min-h-72 resize-y rounded-lg font-mono text-sm'
             />
           </div>
@@ -166,6 +192,7 @@ export function ContentManager({
                 id='home-ai-cta-label'
                 value={ctaLabel}
                 onChange={event => setCtaLabel(event.target.value)}
+                disabled={homeCtaFormDisabled}
                 className='h-9 rounded-lg text-sm'
               />
             </div>
@@ -177,6 +204,7 @@ export function ContentManager({
                 id='home-ai-cta-href'
                 value={ctaHref}
                 onChange={event => setCtaHref(event.target.value)}
+                disabled={homeCtaFormDisabled}
                 className='h-9 rounded-lg font-mono text-sm'
               />
             </div>
@@ -193,13 +221,14 @@ export function ContentManager({
               id='home-ai-cta-enabled'
               checked={enabled}
               onCheckedChange={setEnabled}
+              disabled={homeCtaFormDisabled}
             />
           </div>
 
           <button
             type='button'
             onClick={handleSave}
-            disabled={saveMutation.isPending}
+            disabled={homeCtaFormDisabled || saveMutation.isPending}
             className='inline-flex h-9 items-center gap-2 rounded-lg bg-zinc-900 px-3 text-xs font-semibold text-white transition-colors hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200'
           >
             <Save className='h-3.5 w-3.5' />

--- a/frontend/src/test/ContentManager.test.tsx
+++ b/frontend/src/test/ContentManager.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ContentManager } from '@/components/features/admin/content/ContentManager';
+
+const mocks = vi.hoisted(() => ({
+  getAdminSiteContentBlock: vi.fn(),
+  saveSiteContentBlock: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock('@/components/features/blog/SafeDescriptionMarkdown', () => ({
+  SafeDescriptionMarkdown: ({ text }: { text: string }) => (
+    <div data-testid='markdown-preview'>{text}</div>
+  ),
+}));
+
+vi.mock('@/components/features/admin/content/PostEditorWorkspace', () => ({
+  PostEditorWorkspace: () => <div>Mock post editor</div>,
+}));
+
+vi.mock('@/services/content/site-content', () => ({
+  HOME_AI_CTA_BLOCK_KEY: 'home_ai_cta',
+  DEFAULT_HOME_AI_CTA_BLOCK: {
+    key: 'home_ai_cta',
+    markdown: 'Default CTA markdown',
+    ctaLabel: 'Open AI tools',
+    ctaHref: '/?ai=chat',
+    enabled: true,
+    updatedAt: null,
+  },
+  getAdminSiteContentBlock: mocks.getAdminSiteContentBlock,
+  saveSiteContentBlock: mocks.saveSiteContentBlock,
+}));
+
+function renderContentManager() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ContentManager subtab='home-cta' />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ContentManager', () => {
+  beforeEach(() => {
+    mocks.getAdminSiteContentBlock.mockRejectedValue(
+      new Error('Home CTA store unavailable'),
+    );
+    mocks.saveSiteContentBlock.mockResolvedValue({
+      key: 'home_ai_cta',
+      markdown: 'Saved CTA',
+      ctaLabel: null,
+      ctaHref: null,
+      enabled: true,
+      updatedAt: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables Home CTA editing and saving when the initial content load fails', async () => {
+    renderContentManager();
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to load Home CTA')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Home CTA store unavailable')).toBeInTheDocument();
+    expect(mocks.getAdminSiteContentBlock).toHaveBeenCalledWith('home_ai_cta');
+
+    expect(screen.getByLabelText('Markdown')).toBeDisabled();
+    expect(screen.getByLabelText('CTA label')).toBeDisabled();
+    expect(screen.getByLabelText('CTA href')).toBeDisabled();
+    expect(screen.getByRole('switch', { name: /Enabled/i })).toBeDisabled();
+
+    const saveButton = screen.getByRole('button', { name: /^Save$/i });
+    expect(saveButton).toBeDisabled();
+    fireEvent.click(saveButton);
+
+    expect(mocks.saveSiteContentBlock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- disable Home CTA editing and saving while the initial admin content read is unavailable
- replace the bare load error text with a clear Home CTA load error and retry action
- add focused ContentManager coverage to prevent saving fallback CTA defaults after read failures

## Testing
- npm run test:run -- src/test/ContentManager.test.tsx
- npm run type-check
- npm run lint
- git diff --cached --check

## Risks
- Home CTA controls remain disabled until a successful content read or seeded initial block is available

## Follow-ups
- Continue admin-only route/client contract review from latest main.