### PR TITLE
fix(admin): label log toolbar controls

### DIFF
--- a/frontend/src/components/features/admin/logs/LogViewer.test.tsx
+++ b/frontend/src/components/features/admin/logs/LogViewer.test.tsx
@@ -1,9 +1,12 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  mockAdminFetchRaw,
   mockGetApiBaseUrl,
   mockGetValidAccessToken,
 } = vi.hoisted(() => ({
+  mockAdminFetchRaw: vi.fn(),
   mockGetApiBaseUrl: vi.fn(() => "https://admin.example.com"),
   mockGetValidAccessToken: vi.fn(),
 }));
@@ -18,8 +21,13 @@ vi.mock("@/stores/session/useAuthStore", () => ({
   }),
 }));
 
+vi.mock("@/services/admin/apiClient", () => ({
+  adminFetchRaw: mockAdminFetchRaw,
+}));
+
 import {
   connectLogStream,
+  LogViewer,
   type LogEntry,
 } from "./LogViewer";
 
@@ -92,6 +100,34 @@ describe("LogViewer stream controller", () => {
   afterEach(() => {
     vi.clearAllTimers();
     vi.useRealTimers();
+  });
+
+  it("labels icon-only log toolbar controls and updates pause state", async () => {
+    mockGetValidAccessToken.mockResolvedValue("stream-token");
+    mockAdminFetchRaw.mockResolvedValue(createResponse([]));
+
+    render(<LogViewer />);
+
+    await waitFor(() => {
+      expect(mockAdminFetchRaw).toHaveBeenCalled();
+    });
+
+    const pauseButton = screen.getByRole("button", {
+      name: "Pause log stream",
+    });
+    expect(pauseButton).toHaveAttribute("title", "Pause log stream");
+    expect(
+      screen.getByRole("button", { name: "Clear logs" }),
+    ).toHaveAttribute("title", "Clear logs");
+    expect(
+      screen.getByRole("button", { name: "Reconnect log stream" }),
+    ).toHaveAttribute("title", "Reconnect log stream");
+
+    fireEvent.click(pauseButton);
+
+    expect(
+      screen.getByRole("button", { name: "Resume log stream" }),
+    ).toHaveAttribute("title", "Resume log stream");
   });
 
   it("uses the shared admin stream fetcher after resolving a token", async () => {

--- a/frontend/src/components/features/admin/logs/LogViewer.tsx
+++ b/frontend/src/components/features/admin/logs/LogViewer.tsx
@@ -319,6 +319,7 @@ export function LogViewer() {
     if (serviceFilter && !l.service) return false;
     return true;
   });
+  const pauseToggleLabel = paused ? "Resume log stream" : "Pause log stream";
 
   return (
     <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden">
@@ -361,28 +362,35 @@ export function LogViewer() {
           <button
             type="button"
             onClick={() => setPaused((v) => !v)}
+            aria-label={pauseToggleLabel}
+            title={pauseToggleLabel}
             className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors"
           >
             {paused ? (
-              <Play className="h-3 w-3" />
+              <Play className="h-3 w-3" aria-hidden="true" />
             ) : (
-              <Pause className="h-3 w-3" />
+              <Pause className="h-3 w-3" aria-hidden="true" />
             )}
           </button>
           <button
             type="button"
             onClick={handleClear}
+            aria-label="Clear logs"
+            title="Clear logs"
             className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-red-600 hover:bg-red-50 transition-colors"
           >
-            <Trash2 className="h-3 w-3" />
+            <Trash2 className="h-3 w-3" aria-hidden="true" />
           </button>
           <button
             type="button"
             onClick={connect}
+            aria-label="Reconnect log stream"
+            title="Reconnect log stream"
             className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors"
           >
             <RefreshCw
               className={`h-3 w-3 ${!connected ? "animate-spin" : ""}`}
+              aria-hidden="true"
             />
           </button>
         </div>


### PR DESCRIPTION
## Summary
- add accessible names and native tooltips to the log pause, clear, and reconnect icon buttons
- mark toolbar icons as decorative so screen readers use the action labels
- add focused LogViewer coverage for toolbar labels and pause/resume state

## Testing
- npm run test:run -- src/components/features/admin/logs/LogViewer.test.tsx
- npm run type-check
- npm run lint
- git diff --cached --check

## Risks
- visual UI is unchanged except browser-native title tooltips on the icon controls

## Follow-ups
- Continue admin-only route/client contract review from latest main.