### PR TITLE
fix(admin): label rag refresh controls

### DIFF
--- a/frontend/src/components/features/admin/rag/RAGManager.test.tsx
+++ b/frontend/src/components/features/admin/rag/RAGManager.test.tsx
@@ -59,6 +59,20 @@ describe('RAGManager', () => {
     expect(screen.queryByText('No collections found.')).not.toBeInTheDocument();
   });
 
+  it('labels RAG refresh icon controls', async () => {
+    render(<RAGManager />);
+
+    expect(
+      screen.getByRole('button', { name: 'Refresh RAG health' }),
+    ).toHaveAttribute('title', 'Refresh RAG health');
+    expect(
+      screen.getByRole('button', { name: 'Refresh RAG collections' }),
+    ).toHaveAttribute('title', 'Refresh RAG collections');
+    expect(await screen.findByText('Embedding')).toBeInTheDocument();
+    expect(await screen.findByText('No collections found.')).toBeInTheDocument();
+    expect(await screen.findByText('Documents')).toBeInTheDocument();
+  });
+
   it('shows health load errors instead of only the unreachable fallback', async () => {
     mockCheckRAGHealth.mockResolvedValue({
       ok: false,

--- a/frontend/src/components/features/admin/rag/RAGManager.tsx
+++ b/frontend/src/components/features/admin/rag/RAGManager.tsx
@@ -106,9 +106,14 @@ function RAGHealthSection() {
           type="button"
           onClick={fetchHealth}
           disabled={loading}
+          aria-label="Refresh RAG health"
+          title="Refresh RAG health"
           className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors disabled:opacity-50"
         >
-          <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
+          <RefreshCw
+            className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`}
+            aria-hidden="true"
+          />
         </button>
       </div>
     </div>
@@ -168,9 +173,14 @@ function CollectionsSection() {
           type="button"
           onClick={fetchCollections}
           disabled={loading}
+          aria-label="Refresh RAG collections"
+          title="Refresh RAG collections"
           className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors disabled:opacity-50"
         >
-          <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
+          <RefreshCw
+            className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`}
+            aria-hidden="true"
+          />
         </button>
       </div>
       <div className="px-4 py-3">


### PR DESCRIPTION
## Summary
- add accessible names and native tooltips to the RAG health and collections refresh icon buttons
- mark the refresh icons as decorative so assistive tech uses the action labels
- add focused RAGManager coverage for the refresh control labels

## Testing
- npm run test:run -- src/components/features/admin/rag/RAGManager.test.tsx
- npm run type-check
- npm run lint
- git diff --cached --check

## Risks
- visual UI is unchanged except browser-native title tooltips on the refresh controls

## Follow-ups
- Continue admin-only route/client contract review from latest main.