### PR TITLE
fix(admin): label health refresh controls

### DIFF
--- a/frontend/src/components/features/admin/health/SystemHealth.test.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.test.tsx
@@ -1,6 +1,35 @@
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const mockAdminFetchRaw = vi.hoisted(() => vi.fn());
+const {
+  mockAdminFetchRaw,
+  mockFetchFlags,
+  mockUseFeatureFlagsStore,
+} = vi.hoisted(() => {
+  const mockFetchFlags = vi.fn();
+  const flags = {
+    aiEnabled: true,
+    ragEnabled: true,
+    terminalEnabled: false,
+    aiInline: true,
+    codeExecutionEnabled: false,
+    commentsEnabled: true,
+  };
+  const mockUseFeatureFlagsStore = Object.assign(
+    vi.fn(() => ({
+      flags,
+      isLoading: false,
+      fetchFlags: mockFetchFlags,
+    })),
+    { setState: vi.fn() },
+  );
+
+  return {
+    mockAdminFetchRaw: vi.fn(),
+    mockFetchFlags,
+    mockUseFeatureFlagsStore,
+  };
+});
 
 vi.mock("@/utils/network/apiBase", () => ({
   getApiBaseUrl: vi.fn(() => "https://worker.example.com"),
@@ -10,6 +39,10 @@ vi.mock("@/services/admin/apiClient", () => ({
   adminFetchRaw: mockAdminFetchRaw,
 }));
 
+vi.mock("@/stores/runtime/useFeatureFlagsStore", () => ({
+  useFeatureFlagsStore: mockUseFeatureFlagsStore,
+}));
+
 import {
   checkAgentHealthRequest,
   checkBackendHealth,
@@ -17,12 +50,98 @@ import {
   checkRAGHealth,
   getProviders,
   getProvidersResult,
+  SystemHealth,
 } from "./SystemHealth";
 
 describe("checkBackendHealth", () => {
   afterEach(() => {
     mockAdminFetchRaw.mockReset();
+    mockFetchFlags.mockReset();
+    mockUseFeatureFlagsStore.mockClear();
+    mockUseFeatureFlagsStore.setState.mockClear();
     vi.restoreAllMocks();
+  });
+
+  it("labels section refresh icon controls", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.endsWith("/api/v1/rag/health")) {
+        return new Response(
+          JSON.stringify({
+            services: {
+              embedding: { ok: true },
+              chroma: { ok: true },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(null, { status: 200 });
+    });
+    mockAdminFetchRaw.mockImplementation(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.endsWith("/api/v1/admin/ai/providers")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: { providers: [] },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          data: {
+            status: "healthy",
+            llm: { ok: true },
+            tools: { count: 7 },
+            uptime: 120,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+
+    render(<SystemHealth />);
+
+    expect(screen.getByRole("button", { name: "Refresh core health" }))
+      .toHaveAttribute("title", "Refresh core health");
+    expect(screen.getByRole("button", { name: "Refresh RAG health" }))
+      .toHaveAttribute("title", "Refresh RAG health");
+    expect(screen.getByRole("button", { name: "Refresh AI providers" }))
+      .toHaveAttribute("title", "Refresh AI providers");
+    expect(screen.getByRole("button", { name: "Refresh feature flags" }))
+      .toHaveAttribute("title", "Refresh feature flags");
+    expect(screen.getByRole("button", { name: "Refresh agent health" }))
+      .toHaveAttribute("title", "Refresh agent health");
+
+    await waitFor(() => {
+      expect(screen.getByText("All systems operational")).toBeInTheDocument();
+    });
   });
 
   it("calls the backend healthz endpoint through the worker proxy", async () => {

--- a/frontend/src/components/features/admin/health/SystemHealth.tsx
+++ b/frontend/src/components/features/admin/health/SystemHealth.tsx
@@ -425,10 +425,13 @@ export function SystemHealth() {
               type="button"
               onClick={checkCoreServices}
               disabled={coreLoading}
+              aria-label="Refresh core health"
+              title="Refresh core health"
               className="h-6 w-6 flex items-center justify-center rounded hover:bg-zinc-100 transition-colors disabled:opacity-50"
             >
               <RefreshCw
                 className={`h-3 w-3 text-zinc-400 ${coreLoading ? "animate-spin" : ""}`}
+                aria-hidden="true"
               />
             </button>
           </div>
@@ -467,10 +470,13 @@ export function SystemHealth() {
               type="button"
               onClick={checkRagServices}
               disabled={ragLoading}
+              aria-label="Refresh RAG health"
+              title="Refresh RAG health"
               className="h-6 w-6 flex items-center justify-center rounded hover:bg-zinc-100 transition-colors disabled:opacity-50"
             >
               <RefreshCw
                 className={`h-3 w-3 text-zinc-400 ${ragLoading ? "animate-spin" : ""}`}
+                aria-hidden="true"
               />
             </button>
           </div>
@@ -511,10 +517,13 @@ export function SystemHealth() {
               type="button"
               onClick={fetchProviders}
               disabled={providersLoading}
+              aria-label="Refresh AI providers"
+              title="Refresh AI providers"
               className="h-6 w-6 flex items-center justify-center rounded hover:bg-zinc-100 transition-colors disabled:opacity-50"
             >
               <RefreshCw
                 className={`h-3 w-3 text-zinc-400 ${providersLoading ? "animate-spin" : ""}`}
+                aria-hidden="true"
               />
             </button>
           </div>
@@ -588,10 +597,13 @@ export function SystemHealth() {
               type="button"
               onClick={refreshFlags}
               disabled={flagsLoading}
+              aria-label="Refresh feature flags"
+              title="Refresh feature flags"
               className="h-6 w-6 flex items-center justify-center rounded hover:bg-zinc-100 transition-colors disabled:opacity-50"
             >
               <RefreshCw
                 className={`h-3 w-3 text-zinc-400 ${flagsLoading ? "animate-spin" : ""}`}
+                aria-hidden="true"
               />
             </button>
           </div>
@@ -626,10 +638,13 @@ export function SystemHealth() {
               type="button"
               onClick={checkAgentHealth}
               disabled={agentLoading}
+              aria-label="Refresh agent health"
+              title="Refresh agent health"
               className="h-6 w-6 flex items-center justify-center rounded hover:bg-zinc-100 transition-colors disabled:opacity-50"
             >
               <RefreshCw
                 className={`h-3 w-3 text-zinc-400 ${agentLoading ? "animate-spin" : ""}`}
+                aria-hidden="true"
               />
             </button>
           </div>


### PR DESCRIPTION
## Summary
- add accessible names and native tooltips to System Health section refresh icon buttons
- mark section refresh icons as decorative so assistive tech uses the action labels
- add focused SystemHealth render coverage for the refresh controls

## Testing
- npm run test:run -- src/components/features/admin/health/SystemHealth.test.tsx
- npm run type-check
- npm run lint
- git diff --cached --check

## Risks
- visual UI is unchanged except browser-native title tooltips on the section refresh controls

## Follow-ups
- Continue admin-only route/client contract review from latest main.