### PR TITLE
fix(admin): label analytics refresh controls

### DIFF
--- a/frontend/src/components/features/admin/analytics/AnalyticsManager.test.tsx
+++ b/frontend/src/components/features/admin/analytics/AnalyticsManager.test.tsx
@@ -196,6 +196,73 @@ describe("getAllPostStats", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("labels analytics refresh icon controls", async () => {
+    mockGetRealtimeVisitorsSnapshot.mockResolvedValue({
+      data: { activeVisitors: 2, timestamp: 1_777_777_777_000 },
+      degraded: false,
+    });
+    mockAdminApiFetch.mockResolvedValue({
+      ok: true,
+      data: { stats: [] },
+    });
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("/api/v1/analytics/trending")) {
+        return new Response(
+          JSON.stringify({ data: { trending: [], total: 0 } }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (url.includes("/api/v1/analytics/editor-picks")) {
+        return new Response(JSON.stringify({ data: { picks: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as typeof fetch;
+
+    render(
+      <>
+        <RealtimeVisitorsSection />
+        <EditorPicksSection />
+        <TrendingPostsSection />
+        <AllPostsSection />
+      </>,
+    );
+
+    expect(screen.getByRole("button", { name: "Refresh realtime visitors" }))
+      .toHaveAttribute("title", "Refresh realtime visitors");
+    expect(screen.getByRole("button", { name: "Refresh editor picks" }))
+      .toHaveAttribute("title", "Refresh editor picks");
+    expect(screen.getByRole("button", { name: "Refresh trending posts" }))
+      .toHaveAttribute("title", "Refresh trending posts");
+    expect(screen.getByRole("button", { name: "Refresh post stats" }))
+      .toHaveAttribute("title", "Refresh post stats");
+
+    expect(await screen.findByText(/active within 60s/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/No editor picks configured/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/No trending data for this period/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/No post stats recorded yet/i),
+    ).toBeInTheDocument();
+  });
+
   it("shows the backend message when removing an editor pick fails", async () => {
     global.fetch = vi.fn(async () => {
       return new Response(

--- a/frontend/src/components/features/admin/analytics/AnalyticsManager.tsx
+++ b/frontend/src/components/features/admin/analytics/AnalyticsManager.tsx
@@ -243,11 +243,13 @@ export function RealtimeVisitorsSection() {
           disabled={loading || refreshing}
           className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors disabled:opacity-50"
           aria-label="Refresh realtime visitors"
+          title="Refresh realtime visitors"
         >
           <RefreshCw
             className={`h-3 w-3 ${
               loading || refreshing ? "animate-spin" : ""
             }`}
+            aria-hidden="true"
           />
         </button>
       </div>
@@ -410,9 +412,14 @@ export function EditorPicksSection() {
             type="button"
             onClick={fetchPicks}
             disabled={loading}
+            aria-label="Refresh editor picks"
+            title="Refresh editor picks"
             className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors disabled:opacity-50"
           >
-            <RefreshCw className={`h-3 w-3 ${loading ? "animate-spin" : ""}`} />
+            <RefreshCw
+              className={`h-3 w-3 ${loading ? "animate-spin" : ""}`}
+              aria-hidden="true"
+            />
           </button>
         </div>
       </div>
@@ -627,9 +634,14 @@ export function TrendingPostsSection() {
             type="button"
             onClick={fetchTrending}
             disabled={loading}
+            aria-label="Refresh trending posts"
+            title="Refresh trending posts"
             className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors disabled:opacity-50"
           >
-            <RefreshCw className={`h-3 w-3 ${loading ? "animate-spin" : ""}`} />
+            <RefreshCw
+              className={`h-3 w-3 ${loading ? "animate-spin" : ""}`}
+              aria-hidden="true"
+            />
           </button>
         </div>
       </div>
@@ -874,9 +886,14 @@ export function AllPostsSection() {
           type="button"
           onClick={fetchStats}
           disabled={loading}
+          aria-label="Refresh post stats"
+          title="Refresh post stats"
           className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors disabled:opacity-50"
         >
-          <RefreshCw className={`h-3 w-3 ${loading ? "animate-spin" : ""}`} />
+          <RefreshCw
+            className={`h-3 w-3 ${loading ? "animate-spin" : ""}`}
+            aria-hidden="true"
+          />
         </button>
       </div>
       {loading ? (


### PR DESCRIPTION
## Summary
- add accessible names and native tooltips to analytics refresh icon buttons
- mark refresh icons as decorative for screen readers
- add focused AnalyticsManager coverage for realtime, editor picks, trending, and post stats refresh labels

## Testing
- npm run test:run -- src/components/features/admin/analytics/AnalyticsManager.test.tsx
- npm run type-check
- npm run lint
- git diff --cached --check

## Risks
- visual UI is unchanged except browser-native title tooltips on the refresh controls

## Follow-ups
- Continue admin-only route/client contract review from latest main.