### PR TITLE
fix(admin): label secrets refresh control

### DIFF
--- a/frontend/src/components/features/admin/secrets/SecretsManager.test.tsx
+++ b/frontend/src/components/features/admin/secrets/SecretsManager.test.tsx
@@ -45,4 +45,15 @@ describe('SecretsManager', () => {
       expect(mockFetchOverview).toHaveBeenCalled();
     });
   });
+
+  it('labels the secrets overview refresh control', async () => {
+    render(<SecretsManager />);
+
+    expect(
+      screen.getByRole('button', { name: 'Refresh secrets overview' }),
+    ).toHaveAttribute('title', 'Refresh secrets overview');
+    await waitFor(() => {
+      expect(mockFetchOverview).toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/components/features/admin/secrets/SecretsManager.tsx
+++ b/frontend/src/components/features/admin/secrets/SecretsManager.tsx
@@ -52,9 +52,14 @@ export function SecretsManager({ subtab, onSubtabChange }: SecretsManagerProps) 
           type="button"
           onClick={fetchOverview}
           disabled={loading}
+          aria-label="Refresh secrets overview"
+          title="Refresh secrets overview"
           className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors disabled:opacity-50"
         >
-          <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
+          <RefreshCw
+            className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`}
+            aria-hidden="true"
+          />
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- add an accessible name and native tooltip to the Secrets overview refresh icon button
- mark the refresh icon as decorative for screen readers
- add focused SecretsManager coverage for the refresh control label

## Testing
- npm run test:run -- src/components/features/admin/secrets/SecretsManager.test.tsx
- npm run type-check
- npm run lint
- git diff --cached --check

## Risks
- visual UI is unchanged except a browser-native title tooltip on the refresh control

## Follow-ups
- Continue admin-only route/client contract review from latest main.