### PR TITLE
fix(admin): label content refresh tooltip

### DIFF
--- a/frontend/src/components/features/admin/content/ContentManager.tsx
+++ b/frontend/src/components/features/admin/content/ContentManager.tsx
@@ -136,9 +136,11 @@ export function ContentManager({
             disabled={query.isFetching}
             className='flex h-8 w-8 items-center justify-center rounded-md border border-zinc-200 text-zinc-500 transition-colors hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:hover:bg-zinc-800'
             aria-label='Refresh content'
+            title='Refresh content'
           >
             <RefreshCw
               className={`h-3.5 w-3.5 ${query.isFetching ? 'animate-spin' : ''}`}
+              aria-hidden='true'
             />
           </button>
         </div>

--- a/frontend/src/test/ContentManager.test.tsx
+++ b/frontend/src/test/ContentManager.test.tsx
@@ -81,6 +81,8 @@ describe('ContentManager', () => {
 
     expect(screen.getByText('Home CTA store unavailable')).toBeInTheDocument();
     expect(mocks.getAdminSiteContentBlock).toHaveBeenCalledWith('home_ai_cta');
+    expect(screen.getByRole('button', { name: 'Refresh content' }))
+      .toHaveAttribute('title', 'Refresh content');
 
     expect(screen.getByLabelText('Markdown')).toBeDisabled();
     expect(screen.getByLabelText('CTA label')).toBeDisabled();


### PR DESCRIPTION
## Summary
- add a native tooltip to the ContentManager refresh icon button
- mark the refresh icon as decorative for assistive technology
- extend ContentManager coverage for the refresh control title

## Testing
- npm run test:run -- src/test/ContentManager.test.tsx
- npm run type-check
- npm run lint
- git diff --cached --check

## Risks
- visual UI is unchanged except the browser-native title tooltip on the refresh control

## Follow-ups
- Continue admin-only route/client contract review from latest main.