### PR TITLE
fix(admin): label usage refresh control

### DIFF
--- a/frontend/src/components/features/admin/ai/UsageMonitor.test.tsx
+++ b/frontend/src/components/features/admin/ai/UsageMonitor.test.tsx
@@ -80,4 +80,14 @@ describe('UsageMonitor', () => {
       expect(mockFetchUsage).toHaveBeenCalled();
     });
   });
+
+  it('labels the usage refresh control', async () => {
+    render(<UsageMonitor />);
+
+    expect(screen.getByRole('button', { name: 'Refresh usage' }))
+      .toHaveAttribute('title', 'Refresh usage');
+    await waitFor(() => {
+      expect(mockFetchUsage).toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/components/features/admin/ai/UsageMonitor.tsx
+++ b/frontend/src/components/features/admin/ai/UsageMonitor.tsx
@@ -184,8 +184,14 @@ export function UsageMonitor() {
                   <SelectItem value="model">By Model</SelectItem>
                 </SelectContent>
               </Select>
-              <Button variant="outline" size="icon" onClick={() => fetchUsage()}>
-                <RefreshCw className="h-4 w-4" />
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => fetchUsage()}
+                aria-label="Refresh usage"
+                title="Refresh usage"
+              >
+                <RefreshCw className="h-4 w-4" aria-hidden="true" />
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add an accessible name and native tooltip to the AI usage refresh icon button
- mark the refresh icon as decorative for screen readers
- add focused UsageMonitor coverage for the refresh control label

## Testing
- npm run test:run -- src/components/features/admin/ai/UsageMonitor.test.tsx
- npm run type-check
- npm run lint
- git diff --cached --check

## Risks
- visual UI is unchanged except a browser-native title tooltip on the refresh control

## Follow-ups
- Continue admin-only route/client contract review from latest main.