### PR TITLE
fix(admin): label visitor log refresh

### DIFF
--- a/frontend/src/components/features/admin/analytics/PostMetricsDetail.test.tsx
+++ b/frontend/src/components/features/admin/analytics/PostMetricsDetail.test.tsx
@@ -53,6 +53,8 @@ describe('PostMetricsDetail', () => {
     expect(await screen.findByText('127.0.0.1')).toBeInTheDocument();
     expect(screen.getByText('Chrome')).toBeInTheDocument();
     expect(screen.getByText('example.com')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Refresh visitor log' }))
+      .toHaveAttribute('title', 'Refresh visitor log');
     expect(mockAdminApiFetch).toHaveBeenCalledWith(
       '/posts/2026/hello-world/visits?limit=50&offset=0',
       { pathPrefix: '/api/v1/admin/analytics' },

--- a/frontend/src/components/features/admin/analytics/PostMetricsDetail.tsx
+++ b/frontend/src/components/features/admin/analytics/PostMetricsDetail.tsx
@@ -170,9 +170,14 @@ export function PostMetricsDetail({ slug, year, onBack }: PostMetricsDetailProps
             type="button"
             onClick={() => fetchData(page)}
             disabled={loading}
+            aria-label="Refresh visitor log"
+            title="Refresh visitor log"
             className="h-7 w-7 flex items-center justify-center rounded-md border border-zinc-200 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-50 transition-colors disabled:opacity-50"
           >
-            <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
+            <RefreshCw
+              className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`}
+              aria-hidden="true"
+            />
           </button>
         </div>
 


### PR DESCRIPTION
## Summary
- add an accessible name and native tooltip to the PostMetricsDetail visitor-log refresh button
- mark the refresh icon as decorative for screen readers
- extend PostMetricsDetail coverage for the visitor-log refresh control label

## Testing
- npm run test:run -- src/components/features/admin/analytics/PostMetricsDetail.test.tsx
- npm run type-check
- npm run lint
- git diff --cached --check

## Risks
- visual UI is unchanged except a browser-native title tooltip on the visitor-log refresh control

## Follow-ups
- Continue admin-only route/client contract review from latest main.