### PR TITLE
fix(admin): label secrets list refresh

### DIFF
--- a/frontend/src/components/features/admin/secrets/SecretsListManager.test.tsx
+++ b/frontend/src/components/features/admin/secrets/SecretsListManager.test.tsx
@@ -77,4 +77,14 @@ describe('SecretsListManager', () => {
       expect(mockFetchSecrets).toHaveBeenCalled();
     });
   });
+
+  it('labels the secrets list refresh control', async () => {
+    render(<SecretsListManager categories={[]} />);
+
+    expect(screen.getByRole('button', { name: 'Refresh secrets list' }))
+      .toHaveAttribute('title', 'Refresh secrets list');
+    await waitFor(() => {
+      expect(mockFetchSecrets).toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/components/features/admin/secrets/SecretsListManager.tsx
+++ b/frontend/src/components/features/admin/secrets/SecretsListManager.tsx
@@ -384,8 +384,14 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
             ))}
           </SelectContent>
         </Select>
-        <Button onClick={() => fetchSecrets()} variant="outline" size="icon">
-          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+        <Button
+          onClick={() => fetchSecrets()}
+          variant="outline"
+          size="icon"
+          aria-label="Refresh secrets list"
+          title="Refresh secrets list"
+        >
+          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />
         </Button>
         <Button onClick={() => setIsCreateOpen(true)}>
           <Plus className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## Summary
- add an accessible name and native title tooltip to the SecretsListManager refresh icon button
- hide the decorative refresh icon from assistive technology
- add focused coverage for the secrets list refresh control label

## Verification
- npm run test:run -- src/components/features/admin/secrets/SecretsListManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check