### PR TITLE
fix(admin): label provider action menus

### DIFF
--- a/frontend/src/components/features/admin/ai/ProvidersManager.test.tsx
+++ b/frontend/src/components/features/admin/ai/ProvidersManager.test.tsx
@@ -37,4 +37,39 @@ describe("ProvidersManager", () => {
       screen.queryByText(/No providers configured/i),
     ).not.toBeInTheDocument();
   });
+
+  it("labels provider action menu controls", () => {
+    mockUseProviders.mockReturnValue({
+      providers: [
+        {
+          id: "provider-1",
+          name: "openai",
+          displayName: "OpenAI",
+          apiBaseUrl: "https://api.openai.com/v1",
+          apiKeyEnv: "OPENAI_API_KEY",
+          isEnabled: true,
+          healthStatus: "healthy",
+          lastHealthCheck: null,
+          modelCount: 1,
+          enabledModelCount: 1,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      loading: false,
+      error: null,
+      fetchProviders: vi.fn(),
+      createProvider: vi.fn(),
+      updateProvider: vi.fn(),
+      deleteProvider: vi.fn(),
+      checkHealth: vi.fn(),
+      killSwitchProvider: vi.fn(),
+      enableProvider: vi.fn(),
+    });
+
+    render(<ProvidersManager />);
+
+    expect(screen.getByRole("button", { name: "Open provider actions for OpenAI" }))
+      .toHaveAttribute("title", "Open provider actions for OpenAI");
+  });
 });

--- a/frontend/src/components/features/admin/ai/ProvidersManager.tsx
+++ b/frontend/src/components/features/admin/ai/ProvidersManager.tsx
@@ -401,8 +401,13 @@ export function ProvidersManager() {
                     )}
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon">
-                          <MoreHorizontal className="h-4 w-4" />
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Open provider actions for ${provider.displayName}`}
+                          title={`Open provider actions for ${provider.displayName}`}
+                        >
+                          <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">


### PR DESCRIPTION
## Summary
- add accessible names and native title tooltips to provider action-menu icon buttons
- hide the decorative MoreHorizontal icon from assistive technology
- add focused ProvidersManager coverage for provider action-menu labels

## Verification
- npm run test:run -- src/components/features/admin/ai/ProvidersManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check