### PR TITLE
fix(admin): label route action menus

### DIFF
--- a/frontend/src/components/features/admin/ai/RoutesManager.test.tsx
+++ b/frontend/src/components/features/admin/ai/RoutesManager.test.tsx
@@ -46,4 +46,41 @@ describe("RoutesManager", () => {
       screen.queryByText(/No routes configured/i),
     ).not.toBeInTheDocument();
   });
+
+  it("labels route action menu controls", () => {
+    mockUseRoutes.mockReturnValue({
+      routes: [
+        {
+          id: "route-1",
+          name: "default-chat",
+          description: "Default chat route",
+          routingStrategy: "simple",
+          primaryModel: {
+            id: "model-1",
+            modelName: "gpt-test",
+            displayName: "GPT Test",
+          },
+          fallbackModelIds: [],
+          contextWindowFallbackIds: [],
+          numRetries: 2,
+          timeoutSeconds: 30,
+          isDefault: true,
+          isEnabled: true,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      loading: false,
+      error: null,
+      fetchRoutes: vi.fn(),
+      createRoute: vi.fn(),
+      updateRoute: vi.fn(),
+      deleteRoute: vi.fn(),
+    });
+
+    render(<RoutesManager />);
+
+    expect(screen.getByRole("button", { name: "Open route actions for default-chat" }))
+      .toHaveAttribute("title", "Open route actions for default-chat");
+  });
 });

--- a/frontend/src/components/features/admin/ai/RoutesManager.tsx
+++ b/frontend/src/components/features/admin/ai/RoutesManager.tsx
@@ -440,8 +440,13 @@ export function RoutesManager() {
                   </div>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon">
-                        <MoreHorizontal className="h-4 w-4" />
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`Open route actions for ${route.name}`}
+                        title={`Open route actions for ${route.name}`}
+                      >
+                        <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">


### PR DESCRIPTION
## Summary
- add accessible names and native title tooltips to route action-menu icon buttons
- hide the decorative MoreHorizontal icon from assistive technology
- add focused RoutesManager coverage for route action-menu labels

## Verification
- npm run test:run -- src/components/features/admin/ai/RoutesManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check