### PR TITLE
fix(admin): label audit log refresh

### DIFF
--- a/frontend/src/components/features/admin/secrets/AuditLogViewer.test.tsx
+++ b/frontend/src/components/features/admin/secrets/AuditLogViewer.test.tsx
@@ -52,4 +52,18 @@ describe('AuditLogViewer', () => {
       });
     });
   });
+
+  it('labels the audit log refresh control', async () => {
+    render(<AuditLogViewer />);
+
+    expect(screen.getByRole('button', { name: 'Refresh audit log' }))
+      .toHaveAttribute('title', 'Refresh audit log');
+    await waitFor(() => {
+      expect(mockFetchLogs).toHaveBeenCalledWith({
+        action: undefined,
+        limit: 20,
+        offset: 0,
+      });
+    });
+  });
 });

--- a/frontend/src/components/features/admin/secrets/AuditLogViewer.tsx
+++ b/frontend/src/components/features/admin/secrets/AuditLogViewer.tsx
@@ -75,6 +75,8 @@ export function AuditLogViewer() {
             <Button
               variant="outline"
               size="icon"
+              aria-label="Refresh audit log"
+              title="Refresh audit log"
               onClick={() =>
                 fetchLogs({
                   action: actionFilter === 'all' ? undefined : actionFilter,
@@ -83,7 +85,7 @@ export function AuditLogViewer() {
                 })
               }
             >
-              <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+              <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add an accessible name and native title tooltip to the audit-log refresh icon button
- hide the decorative refresh icon from assistive technology
- add focused AuditLogViewer coverage for the refresh-control label

## Verification
- npm run test:run -- src/components/features/admin/secrets/AuditLogViewer.test.tsx
- npm run type-check
- npm run lint
- git diff --check