### PR TITLE
fix(admin): label assistant send control

### DIFF
--- a/frontend/src/components/features/admin/BotChatPanel.test.tsx
+++ b/frontend/src/components/features/admin/BotChatPanel.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import BotChatPanel from './BotChatPanel';
+
+function renderBotChatPanel() {
+  const noop = vi.fn();
+
+  render(
+    <BotChatPanel
+      title="Draft"
+      slug="draft"
+      year="2026"
+      category="dev"
+      tags="ai"
+      coverImage=""
+      content="Draft content"
+      setTitle={noop}
+      setSlug={noop}
+      setContent={noop}
+      setTags={noop}
+      setCategory={noop}
+      setCoverImage={noop}
+      onInsertMarkdown={noop}
+    />,
+  );
+}
+
+describe('BotChatPanel', () => {
+  it('labels the assistant send control', () => {
+    renderBotChatPanel();
+
+    expect(screen.getByRole('button', { name: 'Send assistant message' }))
+      .toHaveAttribute('title', 'Send assistant message');
+  });
+});

--- a/frontend/src/components/features/admin/BotChatPanel.tsx
+++ b/frontend/src/components/features/admin/BotChatPanel.tsx
@@ -255,8 +255,14 @@ export default function BotChatPanel({
                             }
                         }}
                     />
-                    <Button size="icon" onClick={handleSend} disabled={isTyping || !input.trim()}>
-                        <Send className="w-4 h-4" />
+                    <Button
+                        size="icon"
+                        onClick={handleSend}
+                        disabled={isTyping || !input.trim()}
+                        aria-label="Send assistant message"
+                        title="Send assistant message"
+                    >
+                        <Send className="w-4 h-4" aria-hidden="true" />
                     </Button>
                 </div>
             </CardFooter>


### PR DESCRIPTION
## Summary
- add an accessible name and native title tooltip to the admin assistant send icon button
- hide the decorative send icon from assistive technology
- add focused BotChatPanel coverage for the send-control label

## Verification
- npm run test:run -- src/components/features/admin/BotChatPanel.test.tsx
- npm run type-check
- npm run lint
- git diff --check