### PR TITLE
fix(admin): label secret row action titles

### DIFF
--- a/frontend/src/components/features/admin/secrets/SecretsListManager.test.tsx
+++ b/frontend/src/components/features/admin/secrets/SecretsListManager.test.tsx
@@ -87,4 +87,48 @@ describe('SecretsListManager', () => {
       expect(mockFetchSecrets).toHaveBeenCalled();
     });
   });
+
+  it('uses specific titles for secret row action controls', async () => {
+    mockUseSecrets.mockReturnValue(
+      createUseSecretsValue({
+        secrets: [
+          {
+            id: 'secret-1',
+            category_id: 'general',
+            key_name: 'API_KEY',
+            display_name: 'API key',
+            description: null,
+            is_required: 1,
+            is_sensitive: 1,
+            value_type: 'string',
+            validation_pattern: null,
+            default_value: null,
+            env_fallback: null,
+            last_rotated_at: null,
+            expires_at: null,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+            created_by: null,
+            updated_by: null,
+            has_value: true,
+            category_name: 'General',
+          },
+        ],
+      }),
+    );
+
+    render(<SecretsListManager categories={[]} />);
+
+    expect(screen.getByRole('button', { name: 'Reveal API_KEY' }))
+      .toHaveAttribute('title', 'Reveal API_KEY');
+    expect(screen.getByRole('button', { name: 'Copy API_KEY' }))
+      .toHaveAttribute('title', 'Copy API_KEY');
+    expect(screen.getByRole('button', { name: 'Edit API_KEY' }))
+      .toHaveAttribute('title', 'Edit API_KEY');
+    expect(screen.getByRole('button', { name: 'Delete API_KEY' }))
+      .toHaveAttribute('title', 'Delete API_KEY');
+    await waitFor(() => {
+      expect(mockFetchSecrets).toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/components/features/admin/secrets/SecretsListManager.tsx
+++ b/frontend/src/components/features/admin/secrets/SecretsListManager.tsx
@@ -458,26 +458,26 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
                             variant="ghost"
                             size="icon"
                             onClick={() => handleReveal(secret)}
-                            title={revealedValues[secret.id] ? 'Hide' : 'Reveal'}
+                            title={`${revealedValues[secret.id] ? 'Hide' : 'Reveal'} ${secret.key_name}`}
                             aria-label={`${revealedValues[secret.id] ? 'Hide' : 'Reveal'} ${secret.key_name}`}
                           >
                             {revealedValues[secret.id] ? (
-                              <EyeOff className="h-4 w-4" />
+                              <EyeOff className="h-4 w-4" aria-hidden="true" />
                             ) : (
-                              <Eye className="h-4 w-4" />
+                              <Eye className="h-4 w-4" aria-hidden="true" />
                             )}
                           </Button>
                           <Button
                             variant="ghost"
                             size="icon"
                             onClick={() => handleCopy(secret)}
-                            title="Copy"
+                            title={`Copy ${secret.key_name}`}
                             aria-label={`Copy ${secret.key_name}`}
                           >
                             {copiedId === secret.id ? (
-                              <CheckCircle className="h-4 w-4 text-green-500" />
+                              <CheckCircle className="h-4 w-4 text-green-500" aria-hidden="true" />
                             ) : (
-                              <Copy className="h-4 w-4" />
+                              <Copy className="h-4 w-4" aria-hidden="true" />
                             )}
                           </Button>
                         </>
@@ -486,10 +486,10 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
                         variant="ghost"
                         size="icon"
                         onClick={() => openEdit(secret)}
-                        title="Edit"
+                        title={`Edit ${secret.key_name}`}
                         aria-label={`Edit ${secret.key_name}`}
                       >
-                        <Edit className="h-4 w-4" />
+                        <Edit className="h-4 w-4" aria-hidden="true" />
                       </Button>
                       <Button
                         variant="ghost"
@@ -498,10 +498,10 @@ export function SecretsListManager({ categories: initialCategories, initialCateg
                           setSelectedSecret(secret);
                           setIsDeleteOpen(true);
                         }}
-                        title="Delete"
+                        title={`Delete ${secret.key_name}`}
                         aria-label={`Delete ${secret.key_name}`}
                       >
-                        <Trash2 className="h-4 w-4 text-destructive" />
+                        <Trash2 className="h-4 w-4 text-destructive" aria-hidden="true" />
                       </Button>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- make secret row action native titles match their specific accessible names
- hide decorative row action icons from assistive technology
- add focused SecretsListManager coverage for row action titles

## Verification
- npm run test:run -- src/components/features/admin/secrets/SecretsListManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check