### PR TITLE
fix(admin): label generated image actions

### DIFF
--- a/frontend/src/components/features/admin/AiImageGeneratorPanel.test.tsx
+++ b/frontend/src/components/features/admin/AiImageGeneratorPanel.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGeneratePostImages = vi.hoisted(() => vi.fn());
+const mockToast = vi.hoisted(() => vi.fn());
+
+vi.mock('@/services/session/adminImages', () => ({
+  generatePostImages: mockGeneratePostImages,
+}));
+
+vi.mock('@/hooks/ui/use-toast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}));
+
+import AiImageGeneratorPanel from './AiImageGeneratorPanel';
+
+describe('AiImageGeneratorPanel', () => {
+  it('labels generated image actions by alt text', async () => {
+    const user = userEvent.setup();
+
+    mockGeneratePostImages.mockResolvedValue({
+      items: [
+        {
+          filename: 'sample.png',
+          path: '2026/sample/sample.png',
+          url: '/images/2026/sample/sample.png',
+          variantWebp: null,
+          alt: 'Sample diagram',
+          markdown: '![Sample diagram](/images/2026/sample/sample.png)',
+          source: 'ai-generated',
+        },
+      ],
+    });
+
+    render(
+      <AiImageGeneratorPanel
+        title="Sample diagram"
+        category="dev"
+        tags="ai"
+        content="content"
+        year="2026"
+        slug="sample"
+        onInsertMarkdown={vi.fn()}
+        onSetCoverImage={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: '이미지 생성' }));
+
+    expect(await screen.findByRole('button', { name: '본문에 Sample diagram 삽입' }))
+      .toHaveAttribute('title', '본문에 Sample diagram 삽입');
+    expect(screen.getByRole('button', { name: 'Sample diagram URL 복사' }))
+      .toHaveAttribute('title', 'Sample diagram URL 복사');
+    await waitFor(() => {
+      expect(mockGeneratePostImages).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/features/admin/AiImageGeneratorPanel.tsx
+++ b/frontend/src/components/features/admin/AiImageGeneratorPanel.tsx
@@ -284,7 +284,8 @@ export default function AiImageGeneratorPanel({
                       'transition-transform duration-200 ease-spring hover:scale-[1.01] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 active:scale-[0.99] motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:active:scale-100',
                     )}
                     onClick={() => onInsertMarkdown(item.markdown)}
-                    title="본문에 삽입"
+                    aria-label={`본문에 ${item.alt} 삽입`}
+                    title={`본문에 ${item.alt} 삽입`}
                   >
                     <img
                       src={imageUrl}
@@ -321,7 +322,8 @@ export default function AiImageGeneratorPanel({
                       variant="ghost"
                       className="min-h-9 px-2 text-xs"
                       onClick={() => void copyUrl(imageUrl)}
-                      aria-label="이미지 URL 복사"
+                      aria-label={`${item.alt} URL 복사`}
+                      title={`${item.alt} URL 복사`}
                     >
                       {copied ? (
                         <Check className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- make generated-image insert controls expose action-oriented labels and titles
- make generated-image URL copy controls include the image alt text and native titles
- add focused AiImageGeneratorPanel coverage for generated-image action labels

## Verification
- npm run test:run -- src/components/features/admin/AiImageGeneratorPanel.test.tsx
- npm run type-check
- npm run lint
- git diff --check