### PR TITLE
fix(admin): label trace view controls

### DIFF
--- a/frontend/src/components/features/admin/ai/TraceViewer.test.tsx
+++ b/frontend/src/components/features/admin/ai/TraceViewer.test.tsx
@@ -71,7 +71,11 @@ describe('TraceViewer', () => {
 
     render(<TraceViewer />);
 
-    fireEvent.click(await screen.findByRole('button', { name: /View trace trace-1/i }));
+    const viewButton = await screen.findByRole('button', { name: /View trace trace-1/i });
+
+    expect(viewButton).toHaveAttribute('title', 'View trace trace-1');
+
+    fireEvent.click(viewButton);
 
     await waitFor(() => {
       expect(mockFetchTraceDetail).toHaveBeenCalledWith('trace-1');

--- a/frontend/src/components/features/admin/ai/TraceViewer.tsx
+++ b/frontend/src/components/features/admin/ai/TraceViewer.tsx
@@ -448,9 +448,10 @@ export function TraceViewer() {
                       variant="ghost"
                       size="sm"
                       aria-label={`View trace ${trace.trace_id}`}
+                      title={`View trace ${trace.trace_id}`}
                       onClick={() => handleViewDetail(trace.trace_id)}
                     >
-                      <ChevronRight className="h-4 w-4" />
+                      <ChevronRight className="h-4 w-4" aria-hidden="true" />
                     </Button>
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
## Summary
- add native title tooltips to trace view icon buttons
- hide the decorative chevron icon from assistive technology
- extend TraceViewer coverage for the trace view-control title

## Verification
- npm run test:run -- src/components/features/admin/ai/TraceViewer.test.tsx
- npm run type-check
- npm run lint
- git diff --check