### PR TITLE
fix(admin): label config icon controls

### DIFF
--- a/frontend/src/components/features/admin/ConfigManager.tsx
+++ b/frontend/src/components/features/admin/ConfigManager.tsx
@@ -268,7 +268,8 @@ export function ConfigManager() {
             <button
               type='button'
               onClick={() => toggleSecretVisibility(variable.key)}
-              aria-label={isVisible ? 'Hide value' : 'Show value'}
+              aria-label={`${isVisible ? 'Hide' : 'Show'} ${variable.key} value`}
+              title={`${isVisible ? 'Hide' : 'Show'} ${variable.key} value`}
               className={iconBtnClass}
               disabled={!mutationsEnabled}
             >
@@ -308,7 +309,8 @@ export function ConfigManager() {
               <button
                 type='button'
                 onClick={() => copyToClipboard(value)}
-                aria-label='Copy URL'
+                aria-label={`Copy ${variable.key} URL`}
+                title={`Copy ${variable.key} URL`}
                 className={iconBtnClass}
               >
                 <Copy className='h-3.5 w-3.5' aria-hidden='true' />

--- a/frontend/src/test/ConfigManager.test.tsx
+++ b/frontend/src/test/ConfigManager.test.tsx
@@ -180,4 +180,98 @@ describe("ConfigManager protected-environment mode", () => {
     expect(screen.getByRole("button", { name: /Retry/i })).toBeInTheDocument();
     expect(screen.queryByText(/Environment config/i)).not.toBeInTheDocument();
   });
+
+  it("labels icon controls with their config keys", async () => {
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.endsWith("/api/v1/admin/config/categories")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: {
+              categories: [
+                {
+                  id: "app",
+                  name: "Application",
+                  description: "server settings",
+                  variables: [
+                    {
+                      key: "SECRET_TOKEN",
+                      type: "password",
+                      description: "Secret token",
+                    },
+                    {
+                      key: "SITE_BASE_URL",
+                      type: "url",
+                      description: "Site URL",
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (url.endsWith("/api/v1/admin/config/current")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: {
+              mutationsEnabled: true,
+              config: {
+                SECRET_TOKEN: {
+                  value: "secret-value",
+                  isSecret: true,
+                  isSet: true,
+                  default: "",
+                },
+                SITE_BASE_URL: {
+                  value: "https://noblog.nodove.com",
+                  isSecret: false,
+                  isSet: true,
+                  default: "",
+                },
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as typeof fetch;
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ConfigManager />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByRole("button", { name: "Show SECRET_TOKEN value" }))
+      .toHaveAttribute("title", "Show SECRET_TOKEN value");
+    expect(screen.getByRole("button", { name: "Copy SITE_BASE_URL URL" }))
+      .toHaveAttribute("title", "Copy SITE_BASE_URL URL");
+  });
 });


### PR DESCRIPTION
## Summary
- include config keys in password visibility and URL copy icon-control accessible names
- add matching native title tooltips for those config icon controls
- extend ConfigManager coverage for keyed icon-control labels

## Verification
- npm run test:run -- src/test/ConfigManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check