### PR TITLE
fix(admin): label worker copy controls

### DIFF
--- a/frontend/src/components/features/admin/WorkersManager.tsx
+++ b/frontend/src/components/features/admin/WorkersManager.tsx
@@ -602,6 +602,7 @@ export function WorkersManager({
                                   copyToClipboard(copyValue);
                                 }}
                                 aria-label={`Copy ${label}`}
+                                title={`Copy ${label}`}
                                 className="h-5 w-5 flex items-center justify-center rounded hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors focus-visible:ring-1 focus-visible:ring-zinc-900 dark:focus-visible:ring-zinc-400 outline-none"
                               >
                                 <Copy

--- a/frontend/src/test/WorkersManager.test.tsx
+++ b/frontend/src/test/WorkersManager.test.tsx
@@ -151,6 +151,8 @@ describe("WorkersManager read-only production mode", () => {
     expect(
       screen.getByText(".github/workflows/deploy-blog-workflow.yml"),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy Account" }))
+      .toHaveAttribute("title", "Copy Account");
   });
 
   it("shows manifest variable keys without exposing their values", async () => {


### PR DESCRIPTION
## Summary
- add native title tooltips to worker metadata copy icon controls
- extend WorkersManager coverage for the worker copy-control title

## Verification
- npm run test:run -- src/test/WorkersManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check