### PR TITLE
fix(admin): label worker secret visibility

### DIFF
--- a/frontend/src/components/features/admin/WorkersManager.tsx
+++ b/frontend/src/components/features/admin/WorkersManager.tsx
@@ -949,8 +949,13 @@ export function WorkersManager({
                     onClick={() => toggleSecretVisibility(secret.key)}
                     aria-label={
                       visibleSecrets.has(secret.key)
-                        ? "Hide secret"
-                        : "Show secret"
+                        ? `Hide ${secret.key} secret`
+                        : `Show ${secret.key} secret`
+                    }
+                    title={
+                      visibleSecrets.has(secret.key)
+                        ? `Hide ${secret.key} secret`
+                        : `Show ${secret.key} secret`
                     }
                     className="h-9 w-9 flex items-center justify-center rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:text-zinc-800 dark:hover:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 dark:focus-visible:ring-zinc-400 shrink-0"
                   >

--- a/frontend/src/test/WorkersManager.test.tsx
+++ b/frontend/src/test/WorkersManager.test.tsx
@@ -388,6 +388,81 @@ describe("WorkersManager read-only production mode", () => {
     expect(screen.queryByText(/No secrets defined/i)).not.toBeInTheDocument();
   });
 
+  it("labels worker secret visibility controls with their keys", async () => {
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.endsWith("/api/v1/admin/workers/list")) {
+        return new Response(JSON.stringify(createWorkerListResponse(true)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      if (url.endsWith("/api/v1/admin/workers/secrets")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: {
+              secrets: [
+                {
+                  key: "JWT_SECRET",
+                  description: "JWT signing key",
+                  workers: ["api-gateway"],
+                },
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (
+        url.endsWith("/api/v1/admin/workers/d1/databases") ||
+        url.endsWith("/api/v1/admin/workers/kv/namespaces") ||
+        url.endsWith("/api/v1/admin/workers/r2/buckets")
+      ) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: { databases: [], namespaces: [], buckets: [] },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as typeof fetch;
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkersManager subtab="secrets" />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByRole("button", { name: "Show JWT_SECRET secret" }))
+      .toHaveAttribute("title", "Show JWT_SECRET secret");
+  });
+
   it("shows a load error instead of an empty resource section when worker resources fail", async () => {
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url =


### PR DESCRIPTION
## Summary
- include worker secret keys in visibility icon-control accessible names
- add matching native title tooltips for worker secret visibility controls
- extend WorkersManager coverage for keyed secret visibility labels

## Verification
- npm run test:run -- src/test/WorkersManager.test.tsx
- npm run type-check
- npm run lint
- git diff --check