### PR TITLE
[codex] fix admin error text sanitization

### DIFF
--- a/frontend/src/components/features/admin/logs/LogViewer.test.tsx
+++ b/frontend/src/components/features/admin/logs/LogViewer.test.tsx
@@ -163,6 +163,33 @@ describe("LogViewer stream controller", () => {
     expect(setConnectionError).toHaveBeenCalledWith(null);
   });
 
+  it("normalizes failed stream connection errors before exposing them", async () => {
+    mockGetValidAccessToken.mockResolvedValue("test-token");
+    mockFetch.mockRejectedValue(
+      new Error("\u001b]0;ignored title\u0007Fetch\u001b[31m failed\u001b[0m"),
+    );
+
+    const state = createLogState();
+    const setConnected = vi.fn();
+    const setConnectionError = vi.fn();
+    const reconnect = vi.fn();
+
+    await connectLogStream({
+      abortRef: { current: null },
+      fetchStream: mockFetch,
+      getValidAccessToken: mockGetValidAccessToken,
+      pausedRef: { current: false },
+      reconnect,
+      setConnected,
+      setConnectionError,
+      setLogs: state.setLogs,
+    });
+
+    expect(setConnected).toHaveBeenCalledWith(false);
+    expect(setConnectionError).toHaveBeenCalledWith("Fetch failed");
+    expect(reconnect).toHaveBeenCalled();
+  });
+
   it("retries on non-ok responses without entering the stream parser", async () => {
     vi.useFakeTimers();
     mockGetValidAccessToken.mockResolvedValue("retry-token");
@@ -284,8 +311,8 @@ describe("LogViewer stream controller", () => {
         sseFrame({
           timestamp: "2026-03-19T00:00:01.000Z",
           level: "info",
-          service: " api\u0000worker\r\nInjected ",
-          message: " Started\u0000\r\nnow ",
+          service: " \u001b]2;ignored title\u0007api\u0000worker\r\nInjected\u001b[0m ",
+          message: " \u001b]0;ignored title\u0007Started\u001b[31m\u0000\r\nnow\u001b[0m ",
         }),
         sseFrame({
           timestamp: "2026-03-19T00:00:02.000Z",

--- a/frontend/src/components/features/admin/logs/LogViewer.tsx
+++ b/frontend/src/components/features/admin/logs/LogViewer.tsx
@@ -41,6 +41,9 @@ const LEVEL_BADGE: Record<string, string> = {
 const LOG_LEVELS = new Set<LogEntry["level"]>(["error", "warn", "info", "debug"]);
 const LOG_STREAM_RECONNECT_MS = 3000;
 const LOG_BUFFER_CAP = 1000;
+const LOG_ANSI_ESCAPE_PATTERN =
+  /\u001b(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001b\\)|[@-Z\\-_])/g;
+const LOG_TEXT_CONTROL_PATTERN = /[\u0000-\u001F\u007F]+/g;
 
 type LogStateSetter = Dispatch<SetStateAction<LogEntry[]>>;
 type BooleanRef = { current: boolean };
@@ -53,7 +56,8 @@ function appendLogEntry(setLogs: LogStateSetter, entry: LogEntry) {
 function normalizeLogText(value: unknown, maxLength: number): string | null {
   if (typeof value !== "string") return null;
   const normalized = value
-    .replace(/[\u0000-\u001F\u007F]+/g, " ")
+    .replace(LOG_ANSI_ESCAPE_PATTERN, " ")
+    .replace(LOG_TEXT_CONTROL_PATTERN, " ")
     .replace(/\s+/g, " ")
     .trim();
   return normalized && normalized.length <= maxLength ? normalized : null;
@@ -211,7 +215,8 @@ export async function connectLogStream({
     }
     setConnected(false);
     setConnectionError?.(
-      err instanceof Error ? err.message : "Failed to connect to log stream",
+      normalizeLogText(err instanceof Error ? err.message : null, 500) ??
+        "Failed to connect to log stream",
     );
     reconnect();
   }

--- a/frontend/src/pages/admin/AdminAuthCallback.test.tsx
+++ b/frontend/src/pages/admin/AdminAuthCallback.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockConsumeAdminReturnPath,
+  mockConsumeOAuthHandoff,
+  mockSetTokens,
+  mockSetTokensFromOAuth,
+} = vi.hoisted(() => ({
+  mockConsumeAdminReturnPath: vi.fn(() => '/admin/config/health'),
+  mockConsumeOAuthHandoff: vi.fn(),
+  mockSetTokens: vi.fn(),
+  mockSetTokensFromOAuth: vi.fn(),
+}));
+
+vi.mock('@/stores/session/useAuthStore', () => ({
+  useAuthStore: () => ({
+    setTokens: mockSetTokens,
+    setTokensFromOAuth: mockSetTokensFromOAuth,
+  }),
+}));
+
+vi.mock('@/services/session/adminReturnTo', () => ({
+  consumeAdminReturnPath: mockConsumeAdminReturnPath,
+}));
+
+vi.mock('@/services/session/auth', () => ({
+  consumeOAuthHandoff: mockConsumeOAuthHandoff,
+}));
+
+import AdminAuthCallback from './AdminAuthCallback';
+
+function renderCallback(hash: string) {
+  window.history.replaceState(null, '', `/admin/auth/callback${hash}`);
+
+  return render(
+    <MemoryRouter initialEntries={['/admin/auth/callback']}>
+      <AdminAuthCallback />
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminAuthCallback', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('normalizes OAuth error hash values before displaying them', async () => {
+    const rawError = '\u001b]0;ignored title\u0007Denied\u001b[31m now\u001b[0m';
+
+    renderCallback(`#error=${encodeURIComponent(rawError)}`);
+
+    expect(
+      await screen.findByText('Authentication failed: Denied now'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/ignored title/)).not.toBeInTheDocument();
+  });
+
+  it('normalizes handoff exchange errors before displaying them', async () => {
+    mockConsumeOAuthHandoff.mockRejectedValueOnce(
+      new Error('\u001b]2;ignored title\u0007Exchange\u001b[31m failed\u001b[0m'),
+    );
+
+    renderCallback('#handoff=oauth-handoff-test');
+
+    await waitFor(() => {
+      expect(mockConsumeOAuthHandoff).toHaveBeenCalledWith('oauth-handoff-test');
+    });
+    expect(
+      await screen.findByText('Authentication failed: Exchange failed'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/ignored title/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin/AdminAuthCallback.tsx
+++ b/frontend/src/pages/admin/AdminAuthCallback.tsx
@@ -11,13 +11,21 @@ function normalizeCallbackCredential(value: string | null): string | null {
   return normalized;
 }
 
-function normalizeCallbackError(value: string | null): string {
-  return (
-    value
-      ?.replace(/[\u0000-\u001F\u007F]+/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim() || 'unknown error'
-  );
+const MAX_CALLBACK_ERROR_LENGTH = 240;
+const CALLBACK_ERROR_ANSI_ESCAPE_PATTERN =
+  /\u001b(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001b\\)|[@-Z\\-_])/g;
+const CALLBACK_UNTERMINATED_OSC_PATTERN = /\u001b\][^\u0007]*$/g;
+const CALLBACK_TEXT_CONTROL_PATTERN = /[\u0000-\u001F\u007F]+/g;
+
+function normalizeCallbackError(value: unknown, fallback = 'unknown error'): string {
+  if (typeof value !== 'string') return fallback;
+  const normalized = value
+    .replace(CALLBACK_ERROR_ANSI_ESCAPE_PATTERN, ' ')
+    .replace(CALLBACK_UNTERMINATED_OSC_PATTERN, ' ')
+    .replace(CALLBACK_TEXT_CONTROL_PATTERN, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return normalized ? normalized.slice(0, MAX_CALLBACK_ERROR_LENGTH) : fallback;
 }
 
 export default function AdminAuthCallback() {
@@ -65,8 +73,10 @@ export default function AdminAuthCallback() {
           navigate(consumeAdminReturnPath(), { replace: true });
         } catch (exchangeError) {
           if (!cancelled) {
-            const message =
-              exchangeError instanceof Error ? exchangeError.message : 'OAuth handoff failed';
+            const message = normalizeCallbackError(
+              exchangeError instanceof Error ? exchangeError.message : null,
+              'OAuth handoff failed',
+            );
             setError(`Authentication failed: ${message}`);
           }
         }

--- a/frontend/src/services/admin/apiClient.ts
+++ b/frontend/src/services/admin/apiClient.ts
@@ -194,7 +194,7 @@ export async function adminApiFetch<T>(
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : 'Network error',
+      error: err instanceof Error ? normalizeAdminErrorMessage(err.message) ?? 'Network error' : 'Network error',
     };
   }
 }

--- a/frontend/src/test/adminApiClient.test.ts
+++ b/frontend/src/test/adminApiClient.test.ts
@@ -235,6 +235,20 @@ describe('admin API client auth retry', () => {
     expect(result).toEqual({ ok: false, error: 'Request failed (429)' });
   });
 
+  it('falls back when a local network Error message is unsafe', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error(`Network failed\u0000${'x'.repeat(10_000)}`)),
+    );
+
+    const result = await adminApiFetch('/api/admin/example');
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Network error',
+    });
+  });
+
   it('does not force refresh after a 401 when no access token was available', async () => {
     mockState.getValidAccessToken.mockResolvedValue(null);
     const fetchMock = vi.fn().mockResolvedValue(


### PR DESCRIPTION
## Summary
- Normalize ANSI, OSC, and control characters from admin-facing error text.
- Add coverage for log stream errors, OAuth callback errors, and unsafe local network errors.

## Testing
- Not run locally by request scope.

## Risks
- Low; display sanitization changes are scoped to admin error rendering and tests.
